### PR TITLE
Update NetworkAnimator.cs

### DIFF
--- a/Assets/Mirror/Components/NetworkAnimator.cs
+++ b/Assets/Mirror/Components/NetworkAnimator.cs
@@ -37,7 +37,7 @@ namespace Mirror
         [Tooltip("Set to true if animations come from owner client,  set to false if animations always come from server")]
         public bool ClientAuthority;
 
-        bool sendMessagesAllowed
+        bool SendMessagesAllowed
         {
             get
             {


### PR DESCRIPTION
Rename property 'sendMessagesAllowed' to match pascal case naming rules, consider using 'SendMessagesAllowed'.

https://sonarcloud.io/project/issues?id=MirrorNG_MirrorNG&issues=AW9mqzsBAdFZhwiq1uOr&open=AW9mqzsBAdFZhwiq1uOr