### PR TITLE
fix: remove tests from npm package

### DIFF
--- a/publish_upm.sh
+++ b/publish_upm.sh
@@ -2,4 +2,4 @@
 git subtree split --prefix=Assets/Mirror -b upm 
 git filter-branch --prune-empty --tree-filter 'rm -rf Tests' upm
 git tag $1 upm
-#git push --tags
+git push -u origin upm --tags

--- a/publish_upm.sh
+++ b/publish_upm.sh
@@ -1,4 +1,5 @@
-git subtree push --prefix=Assets/Mirror origin upm 
-git fetch
-git tag $1 origin/upm
-git push --tags
+#!/bin/sh
+git subtree split --prefix=Assets/Mirror -b upm 
+git filter-branch --prune-empty --tree-filter 'rm -rf Tests' upm
+git tag $1 upm
+#git push --tags


### PR DESCRIPTION
Remove tests from npm package.  These were causing problems with other packages that also want nsubstitute