### PR TITLE
fix: interrupted server

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,8 +6,6 @@ name: CI
 on: 
   pull_request: {}
   push:
-    branches: 
-      - master
     paths-ignore:
       - 'doc/**'
       - '*.md'

--- a/Assets/Mirror/Runtime/Transport/Tcp/Server.cs
+++ b/Assets/Mirror/Runtime/Transport/Tcp/Server.cs
@@ -154,6 +154,15 @@ namespace Mirror.Tcp
                 // this is thrown when the socket is closed
                 // can be ignored
             }
+            catch (IOException ex)
+            {
+                if (ex.InnerException is SocketException se && se.SocketErrorCode == SocketError.Interrupted)
+                {
+                    // nothing to do,  socket was interupted
+                }
+                else
+                    throw;
+            }
             catch (Exception exception)
             {
                 ReceivedError?.Invoke(connectionId, exception);


### PR DESCRIPTION
When the server is stopped,  the sockets throw a IOException, not SocketException,  so catch that and check if we got interrupted instead of reporting an errorr