### PR TITLE
Simplify unpacking messages

### DIFF
--- a/Assets/Mirror/Runtime/MessagePacker.cs
+++ b/Assets/Mirror/Runtime/MessagePacker.cs
@@ -82,19 +82,9 @@ namespace Mirror
         // -> pass NetworkReader so it's less strange if we create it in here
         //    and pass it upwards.
         // -> NetworkReader will point at content afterwards!
-        public static bool UnpackMessage(NetworkReader messageReader, out int msgType)
+        public static int UnpackId(NetworkReader messageReader)
         {
-            // read message type (varint)
-            try
-            {
-                msgType = messageReader.ReadUInt16();
-                return true;
-            }
-            catch (System.IO.EndOfStreamException)
-            {
-                msgType = 0;
-                return false;
-            }
+            return messageReader.ReadUInt16();
         }
 
         internal static NetworkMessageDelegate MessageHandler<T, C>(Action<C, T> handler, bool requireAuthenication)

--- a/Assets/Mirror/Runtime/NetworkConnection.cs
+++ b/Assets/Mirror/Runtime/NetworkConnection.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using UnityEngine;
 
 namespace Mirror
@@ -265,8 +266,9 @@ namespace Mirror
             // unpack message
             using (PooledNetworkReader networkReader = NetworkReaderPool.GetReader(buffer))
             {
-                if (MessagePacker.UnpackMessage(networkReader, out int msgType))
+                try
                 {
+                    int msgType = MessagePacker.UnpackId(networkReader);
                     // logging
                     if (logNetworkMessages) Debug.Log("ConnectionRecv " + this + " msgType:" + msgType + " content:" + BitConverter.ToString(buffer.Array, buffer.Offset, buffer.Count));
 
@@ -276,9 +278,9 @@ namespace Mirror
                         lastMessageTime = Time.time;
                     }
                 }
-                else
+                catch (IOException ex)
                 {
-                    Debug.LogError("Closed connection: " + this + ". Invalid message header.");
+                    Debug.LogError("Closed connection: " + this + ". Invalid message " + ex);
                     Disconnect();
                 }
             }

--- a/Assets/Mirror/Tests/Editor/MessagePackerTest.cs
+++ b/Assets/Mirror/Tests/Editor/MessagePackerTest.cs
@@ -65,14 +65,12 @@ namespace Mirror.Tests
             byte[] data = MessagePacker.Pack(message);
             NetworkReader reader = new NetworkReader(data);
 
-            bool result = MessagePacker.UnpackMessage(reader, out int msgType);
-            Assert.That(result, Is.EqualTo(true));
+            int msgType = MessagePacker.UnpackId(reader);
             Assert.That(msgType, Is.EqualTo(BitConverter.ToUInt16(data, 0)));
 
             // try an invalid message
             NetworkReader reader2 = new NetworkReader(new byte[0]);
-            bool result2 = MessagePacker.UnpackMessage(reader2, out int msgType2);
-            Assert.That(result2, Is.EqualTo(false));
+            int msgType2 = MessagePacker.UnpackId(reader2);
             Assert.That(msgType2, Is.EqualTo(0));
         }
     }


### PR DESCRIPTION
Use exceptions instead of returning false for failure.

BREAKING CHANGE: MessagePacker.UnpackMessage replaced by UnpackId