### PR TITLE
fix: attributes causing a NRE

### DIFF
--- a/Assets/Mirror/Editor/Weaver/Processors/PropertySiteProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/PropertySiteProcessor.cs
@@ -99,9 +99,7 @@ namespace Mirror.Weaver
             Instruction top = md.Body.Instructions[0];
 
             worker.InsertBefore(top, worker.Create(OpCodes.Ldarg_0));
-            worker.InsertBefore(top, worker.Create(OpCodes.Call, Weaver.NetworkBehaviourGetIdentity));
-            worker.InsertBefore(top, worker.Create(OpCodes.Call, Weaver.NetworkIdentityGetServer));
-            worker.InsertBefore(top, worker.Create(OpCodes.Call, Weaver.NetworkServerGetActive));
+            worker.InsertBefore(top, worker.Create(OpCodes.Call, Weaver.NetworkBehaviourIsServer));
             worker.InsertBefore(top, worker.Create(OpCodes.Brtrue, top));
             if (logWarning)
             {
@@ -124,9 +122,7 @@ namespace Mirror.Weaver
             Instruction top = md.Body.Instructions[0];
 
             worker.InsertBefore(top, worker.Create(OpCodes.Ldarg_0));
-            worker.InsertBefore(top, worker.Create(OpCodes.Call, Weaver.NetworkBehaviourGetIdentity));
-            worker.InsertBefore(top, worker.Create(OpCodes.Call, Weaver.NetworkIdentityGetClient));
-            worker.InsertBefore(top, worker.Create(OpCodes.Call, Weaver.NetworkClientGetActive));
+            worker.InsertBefore(top, worker.Create(OpCodes.Call, Weaver.NetworkBehaviourIsClient));
             worker.InsertBefore(top, worker.Create(OpCodes.Brtrue, top));
             if (logWarning)
             {

--- a/Assets/Mirror/Editor/Weaver/Weaver.cs
+++ b/Assets/Mirror/Editor/Weaver/Weaver.cs
@@ -85,6 +85,9 @@ namespace Mirror.Weaver
         public static MethodReference NetworkIdentityGetServer;
         public static MethodReference NetworkIdentityGetClient;
 
+        public static MethodReference NetworkBehaviourIsServer;
+        public static MethodReference NetworkBehaviourIsClient;
+
         // custom attribute types
         public static TypeReference SyncVarType;
         public static TypeReference CommandType;
@@ -279,6 +282,9 @@ namespace Mirror.Weaver
             NetworkBehaviourGetIdentity = Resolvers.ResolveMethod(NetworkBehaviourType, CurrentAssembly, "get_netIdentity");
             NetworkIdentityGetServer = Resolvers.ResolveMethod(NetworkIdentityType, CurrentAssembly, "get_server");
             NetworkIdentityGetClient = Resolvers.ResolveMethod(NetworkIdentityType, CurrentAssembly, "get_client");
+
+            NetworkBehaviourIsServer = Resolvers.ResolveProperty(NetworkBehaviourType, CurrentAssembly, "isServer");
+            NetworkBehaviourIsClient = Resolvers.ResolveProperty(NetworkBehaviourType, CurrentAssembly, "isClient");
 
             MonoBehaviourType = UnityAssembly.MainModule.GetType("UnityEngine.MonoBehaviour");
             ScriptableObjectType = UnityAssembly.MainModule.GetType("UnityEngine.ScriptableObject");

--- a/Assets/Mirror/Tests/Play/ClientServerTests.cs
+++ b/Assets/Mirror/Tests/Play/ClientServerTests.cs
@@ -1,0 +1,58 @@
+using UnityEngine;
+
+namespace Mirror.Tests
+{
+    public class ClientServerTests
+    {
+        #region Setup
+        protected GameObject networkManagerGo;
+        protected NetworkManager manager;
+        protected NetworkServer server;
+        protected NetworkClient client;
+
+        protected GameObject clientNetworkManagerGo;
+        protected NetworkManager clientManager;
+        protected NetworkServer server2;
+        protected NetworkClient client2;
+
+        public void SetupServer()
+        {
+            networkManagerGo = new GameObject();
+            manager = networkManagerGo.AddComponent<NetworkManager>();
+            manager.client = networkManagerGo.GetComponent<NetworkClient>();
+            manager.server = networkManagerGo.GetComponent<NetworkServer>();
+            server = manager.server;
+            client = manager.client;
+
+            manager.autoCreatePlayer = false;
+            
+            manager.StartServer();
+        }
+
+        public void SetupClient()
+        {
+            clientNetworkManagerGo = new GameObject();
+            clientManager = clientNetworkManagerGo.AddComponent<NetworkManager>();
+            clientManager.client = clientNetworkManagerGo.GetComponent<NetworkClient>();
+            clientManager.server = clientNetworkManagerGo.GetComponent<NetworkServer>();
+            server2 = clientManager.server;
+            client2 = clientManager.client;
+
+            clientManager.StartClient("localhost");
+        }
+
+        public void ShutdownServer()
+        {
+            manager.StopServer();
+            GameObject.DestroyImmediate(networkManagerGo);
+        }
+
+        public void ShutdownClient()
+        {
+            clientManager.StopClient();
+            GameObject.DestroyImmediate(clientNetworkManagerGo);
+        }
+
+        #endregion
+    }
+}

--- a/Assets/Mirror/Tests/Play/ClientServerTests.cs.meta
+++ b/Assets/Mirror/Tests/Play/ClientServerTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7d16e7f0e4594f846a499e9e55a56b81
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Mirror/Tests/Play/FlagsTests.cs
+++ b/Assets/Mirror/Tests/Play/FlagsTests.cs
@@ -1,0 +1,149 @@
+using NUnit.Framework;
+using UnityEngine;
+
+namespace Mirror.Tests
+{
+    public class Flags : NetworkBehaviour
+    {
+        public bool serverFunctionCalled;
+        public bool serverCallbackFunctionCalled;
+        public bool clientFunctionCalled;
+        public bool clientCallbackFunctionCalled;
+
+        [Server]
+        public void CallServerFunction()
+        {
+            serverFunctionCalled = true;
+        }
+
+        [ServerCallback]
+        public void CallServerCallbackFunction()
+        {
+            serverCallbackFunctionCalled = true;
+        }
+
+        [Client]
+        public void CallClientFunction()
+        {
+            clientFunctionCalled = true;
+        }
+
+        [ClientCallback]
+        public void CallClientCallbackFunction()
+        {
+            clientCallbackFunctionCalled = true;
+        }
+    }
+
+    public class FlagsTests : ClientServerTests
+    {
+        #region Setup
+        GameObject playerGO;
+        GameObject playerGO2;
+
+        EmptyBehaviour behavior;
+        EmptyBehaviour behavior2;
+        Flags flags;
+
+        [SetUp]
+        public void SetupNetworkServer()
+        {
+            SetupServer();
+
+            playerGO = new GameObject();
+            playerGO.AddComponent<NetworkIdentity>();
+            behavior = playerGO.AddComponent<EmptyBehaviour>();
+            flags = playerGO.AddComponent<Flags>();
+        }
+
+        public void SetupNetworkClient()
+        {
+            SetupClient();
+
+            playerGO2 = new GameObject();
+            playerGO2.AddComponent<NetworkIdentity>();
+            behavior2 = playerGO2.AddComponent<EmptyBehaviour>();
+            flags = playerGO2.AddComponent<Flags>();
+        }
+
+        [TearDown]
+        public void ShutdownNetworkServer()
+        {
+            GameObject.DestroyImmediate(playerGO);
+
+            ShutdownServer();
+        }
+
+        public void ShutdownNetworkClient()
+        {
+            GameObject.DestroyImmediate(playerGO2);
+
+            ShutdownClient();
+        }
+        #endregion
+
+        [Test]
+        public void CanCallServerFunctionAsServer()
+        {
+            manager.server.Spawn(playerGO);
+            Assert.That(behavior.isServer, Is.True);
+            Assert.That(behavior.isClient, Is.False);
+
+            flags.CallServerFunction();
+            flags.CallServerCallbackFunction();
+
+            Assert.That(flags.serverFunctionCalled, Is.True);
+            Assert.That(flags.serverCallbackFunctionCalled, Is.True);
+        }
+
+        [Test]
+        public void CannotCallClientFunctionAsServer()
+        {
+            manager.server.Spawn(playerGO);
+            Assert.That(behavior.isServer, Is.True);
+            Assert.That(behavior.isClient, Is.False);
+
+            flags.CallClientFunction();
+            flags.CallClientCallbackFunction();
+
+            Assert.That(flags.clientFunctionCalled, Is.False);
+            Assert.That(flags.clientCallbackFunctionCalled, Is.False);
+        }
+
+        // TODO: fix #68 in order to make sure these tests are working
+
+        /*[Test]
+        public void CanCallClientFunctionAsClient()
+        {
+            SetupNetworkClient();
+
+            Assert.That(behavior2.isServer, Is.False);
+            Assert.That(behavior2.isClient, Is.True);
+
+            flags.CallClientFunction();
+            flags.CallClientCallbackFunction();
+
+            Assert.That(flags.clientFunctionCalled, Is.True);
+            Assert.That(flags.clientCallbackFunctionCalled, Is.True);
+
+            ShutdownNetworkClient();
+        }
+
+        [Test]
+        public void CannotCallServerFunctionAsClient()
+        {
+            SetupNetworkClient();
+
+            Assert.That(behavior2.isServer, Is.False);
+            Assert.That(behavior2.isClient, Is.True);
+
+            flags.CallServerFunction();
+            flags.CallServerCallbackFunction();
+
+            Assert.That(flags.serverFunctionCalled, Is.False);
+            Assert.That(flags.serverCallbackFunctionCalled, Is.False);
+
+            ShutdownNetworkClient();
+        }*/
+    }
+}

--- a/Assets/Mirror/Tests/Play/FlagsTests.cs.meta
+++ b/Assets/Mirror/Tests/Play/FlagsTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f38a104c882d5ff498fe3b07218b91ca
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
- Fix [Server], [Client], [ServerCallback], [ClientCallback] firing NRE when client.active is null.
- Add code coverage

**NOTE:** Some tests are commented, because unusuable because of #68 
