### PR TITLE
refactor:  Client and server keep their own spawned list

### DIFF
--- a/Assets/Mirror/Examples/Room/Scripts/PlayerScore.cs
+++ b/Assets/Mirror/Examples/Room/Scripts/PlayerScore.cs
@@ -29,13 +29,15 @@ namespace Mirror.Examples.NetworkRoom
                 // OnControllerColliderHit will fire many times as the player slides against the object.
                 controllerColliderHitObject.SetActive(false);
 
-                CmdClaimPrize(controllerColliderHitObject);
+                CmdClaimPrize(controllerColliderHitObject.GetComponent<NetworkIdentity>().netId);
             }
         }
 
         [Command]
-        void CmdClaimPrize(GameObject hitObject)
+        void CmdClaimPrize(uint hitId)
         {
+            NetworkIdentity hitObject = server.spawned[hitId];
+
             // Null check is required, otherwise close timing of multiple claims could throw a null ref.
             if (hitObject != null)
             {

--- a/Assets/Mirror/Runtime/ClientScene.cs
+++ b/Assets/Mirror/Runtime/ClientScene.cs
@@ -430,7 +430,7 @@ namespace Mirror
         /// </summary>
         public static void DestroyAllClientObjects()
         {
-            foreach (NetworkIdentity identity in NetworkIdentity.spawned.Values)
+            foreach (NetworkIdentity identity in client.Spawned.Values)
             {
                 if (identity != null && identity.gameObject != null)
                 {
@@ -448,7 +448,7 @@ namespace Mirror
                     }
                 }
             }
-            NetworkIdentity.spawned.Clear();
+            client.Spawned.Clear();
         }
 
         static void ApplySpawnPayload(NetworkIdentity identity, SpawnMessage msg)
@@ -485,7 +485,7 @@ namespace Mirror
                 }
             }
 
-            NetworkIdentity.spawned[msg.netId] = identity;
+            client.Spawned[msg.netId] = identity;
 
             // objects spawned as part of initial state are started on a second pass
             if (isSpawnFinished)
@@ -524,7 +524,7 @@ namespace Mirror
 
         static NetworkIdentity GetExistingObject(uint netid)
         {
-            NetworkIdentity.spawned.TryGetValue(netid, out NetworkIdentity localObject);
+            client.Spawned.TryGetValue(netid, out NetworkIdentity localObject);
             return localObject;
         }
 
@@ -588,7 +588,7 @@ namespace Mirror
             // paul: Initialize the objects in the same order as they were initialized
             // in the server.   This is important if spawned objects
             // use data from scene objects
-            foreach (NetworkIdentity identity in NetworkIdentity.spawned.Values.OrderBy(uv => uv.netId))
+            foreach (NetworkIdentity identity in client.Spawned.Values.OrderBy(uv => uv.netId))
             {
                 identity.NotifyAuthority();
                 identity.OnStartClient();
@@ -611,7 +611,7 @@ namespace Mirror
         {
             if (LogFilter.Debug) Debug.Log("ClientScene.OnObjDestroy netId:" + netId);
 
-            if (NetworkIdentity.spawned.TryGetValue(netId, out NetworkIdentity localObject) && localObject != null)
+            if (client.Spawned.TryGetValue(netId, out NetworkIdentity localObject) && localObject != null)
             {
                 localObject.OnNetworkDestroy();
 
@@ -629,7 +629,7 @@ namespace Mirror
                         spawnableObjects[localObject.sceneId] = localObject;
                     }
                 }
-                NetworkIdentity.spawned.Remove(netId);
+                client.Spawned.Remove(netId);
                 localObject.MarkForReset();
             }
             else
@@ -642,14 +642,14 @@ namespace Mirror
         {
             if (LogFilter.Debug) Debug.Log("ClientScene.OnLocalObjectObjDestroy netId:" + msg.netId);
 
-            NetworkIdentity.spawned.Remove(msg.netId);
+            client.Spawned.Remove(msg.netId);
         }
 
         internal static void OnHostClientObjectHide(ObjectHideMessage msg)
         {
             if (LogFilter.Debug) Debug.Log("ClientScene::OnLocalObjectObjHide netId:" + msg.netId);
 
-            if (NetworkIdentity.spawned.TryGetValue(msg.netId, out NetworkIdentity localObject) && localObject != null)
+            if (client.Spawned.TryGetValue(msg.netId, out NetworkIdentity localObject) && localObject != null)
             {
                 localObject.OnSetHostVisibility(false);
             }
@@ -657,7 +657,7 @@ namespace Mirror
 
         internal static void OnHostClientSpawn(SpawnMessage msg)
         {
-            if (NetworkIdentity.spawned.TryGetValue(msg.netId, out NetworkIdentity localObject) && localObject != null)
+            if (client.Spawned.TryGetValue(msg.netId, out NetworkIdentity localObject) && localObject != null)
             {
                 if (msg.isLocalPlayer)
                     InternalAddPlayer(localObject);
@@ -674,7 +674,7 @@ namespace Mirror
         {
             if (LogFilter.Debug) Debug.Log("ClientScene.OnUpdateVarsMessage " + msg.netId);
 
-            if (NetworkIdentity.spawned.TryGetValue(msg.netId, out NetworkIdentity localObject) && localObject != null)
+            if (client.Spawned.TryGetValue(msg.netId, out NetworkIdentity localObject) && localObject != null)
             {
                 using (PooledNetworkReader networkReader = NetworkReaderPool.GetReader(msg.payload))
                     localObject.OnDeserializeAllSafely(networkReader, false);
@@ -689,7 +689,7 @@ namespace Mirror
         {
             if (LogFilter.Debug) Debug.Log("ClientScene.OnRPCMessage hash:" + msg.functionHash + " netId:" + msg.netId);
 
-            if (NetworkIdentity.spawned.TryGetValue(msg.netId, out NetworkIdentity identity))
+            if (client.Spawned.TryGetValue(msg.netId, out NetworkIdentity identity))
             {
                 using (PooledNetworkReader networkReader = NetworkReaderPool.GetReader(msg.payload))
                     identity.HandleRPC(msg.componentIndex, msg.functionHash, networkReader);
@@ -700,7 +700,7 @@ namespace Mirror
         {
             if (LogFilter.Debug) Debug.Log("ClientScene.OnSyncEventMessage " + msg.netId);
 
-            if (NetworkIdentity.spawned.TryGetValue(msg.netId, out NetworkIdentity identity))
+            if (client.Spawned.TryGetValue(msg.netId, out NetworkIdentity identity))
             {
                 using (PooledNetworkReader networkReader = NetworkReaderPool.GetReader(msg.payload))
                     identity.HandleSyncEvent(msg.componentIndex, msg.functionHash, networkReader);

--- a/Assets/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirror/Runtime/NetworkBehaviour.cs
@@ -537,7 +537,7 @@ namespace Mirror
 
             // client always looks up based on netId because objects might get in and out of range
             // over and over again, which shouldn't null them forever
-            if (NetworkIdentity.spawned.TryGetValue(netId, out NetworkIdentity identity) && identity != null)
+            if (client.Spawned.TryGetValue(netId, out NetworkIdentity identity) && identity != null)
                 return gameObjectField = identity.gameObject;
             return null;
         }
@@ -598,7 +598,7 @@ namespace Mirror
 
             // client always looks up based on netId because objects might get in and out of range
             // over and over again, which shouldn't null them forever
-            NetworkIdentity.spawned.TryGetValue(netId, out identityField);
+            client.Spawned.TryGetValue(netId, out identityField);
             return identityField;
         }
 

--- a/Assets/Mirror/Runtime/NetworkClient.cs
+++ b/Assets/Mirror/Runtime/NetworkClient.cs
@@ -46,6 +46,23 @@ namespace Mirror
         /// </summary>
         public bool isConnected => connectState == ConnectState.Connected;
 
+        private readonly Dictionary<uint, NetworkIdentity> spawned = new Dictionary<uint, NetworkIdentity>();
+
+        /// <summary>
+        /// List of all objects spawned in this client
+        /// </summary>
+        public Dictionary<uint, NetworkIdentity> Spawned
+        {
+            get
+            {
+                // if we are in host mode,  the list of spawned object is the same as the server list
+                if (hostServer != null)
+                    return hostServer.spawned;
+                else
+                    return spawned;
+            }
+        }
+
         /// <summary>
         /// The host server
         /// </summary>

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -138,11 +138,6 @@ namespace Mirror
             }
         }
 
-        /// <summary>
-        /// All spawned NetworkIdentities by netId. Available on server and client.
-        /// </summary>
-        public static readonly Dictionary<uint, NetworkIdentity> spawned = new Dictionary<uint, NetworkIdentity>();
-
         public NetworkBehaviour[] NetworkBehaviours => networkBehavioursCache = networkBehavioursCache ?? GetComponents<NetworkBehaviour>();
 
         [SerializeField, HideInInspector] string m_AssetId;
@@ -516,7 +511,7 @@ namespace Mirror
 
             // add to spawned (note: the original EnableIsServer isn't needed
             // because we already set m_isServer=true above)
-            spawned[netId] = this;
+            server.spawned[netId] = this;
 
             foreach (NetworkBehaviour comp in NetworkBehaviours)
             {

--- a/Assets/Mirror/Runtime/NetworkReader.cs
+++ b/Assets/Mirror/Runtime/NetworkReader.cs
@@ -339,6 +339,7 @@ namespace Mirror
         }
 
         public static Guid ReadGuid(this NetworkReader reader) => new Guid(reader.ReadBytes(16));
+/*
         public static Transform ReadTransform(this NetworkReader reader) => reader.ReadNetworkIdentity()?.transform;
         public static GameObject ReadGameObject(this NetworkReader reader) => reader.ReadNetworkIdentity()?.gameObject;
 
@@ -356,6 +357,7 @@ namespace Mirror
             if (LogFilter.Debug) Debug.Log("ReadNetworkIdentity netId:" + netId + " not found in spawned");
             return null;
         }
+        */
 
         public static Uri ReadUri(this NetworkReader reader)
         {

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -62,6 +62,9 @@ namespace Mirror
         // cache the Send(connectionIds) list to avoid allocating each time
         readonly List<int> connectionIdsCache = new List<int>();
 
+
+        public readonly Dictionary<uint, NetworkIdentity> spawned = new Dictionary<uint, NetworkIdentity>();
+
         /// <summary>
         /// This shuts down the server and disconnects all clients.
         /// </summary>
@@ -201,7 +204,7 @@ namespace Mirror
 
         internal void ActivateHostScene()
         {
-            foreach (NetworkIdentity identity in NetworkIdentity.spawned.Values)
+            foreach (NetworkIdentity identity in spawned.Values)
             {
                 if (!identity.isClient)
                 {
@@ -409,7 +412,7 @@ namespace Mirror
                 return;
 
             // update all server objects
-            foreach (KeyValuePair<uint, NetworkIdentity> kvp in NetworkIdentity.spawned)
+            foreach (KeyValuePair<uint, NetworkIdentity> kvp in spawned)
             {
                 if (kvp.Value != null && kvp.Value.gameObject != null)
                 {
@@ -631,7 +634,7 @@ namespace Mirror
 
         void SpawnObserversForConnection(NetworkConnection conn)
         {
-            if (LogFilter.Debug) Debug.Log("Spawning " + NetworkIdentity.spawned.Count + " objects for conn " + conn);
+            if (LogFilter.Debug) Debug.Log("Spawning " + spawned.Count + " objects for conn " + conn);
 
             if (!conn.isReady)
             {
@@ -645,7 +648,7 @@ namespace Mirror
 
             // add connection to each nearby NetworkIdentity's observers, which
             // internally sends a spawn message for each one to the connection.
-            foreach (NetworkIdentity identity in NetworkIdentity.spawned.Values)
+            foreach (NetworkIdentity identity in spawned.Values)
             {
                 if (identity.gameObject.activeSelf) //TODO this is different // try with far away ones in ummorpg!
                 {
@@ -880,7 +883,7 @@ namespace Mirror
         // Handle command from specific player, this could be one of multiple players on a single client
         void OnCommandMessage(NetworkConnection conn, CommandMessage msg)
         {
-            if (!NetworkIdentity.spawned.TryGetValue(msg.netId, out NetworkIdentity identity))
+            if (!spawned.TryGetValue(msg.netId, out NetworkIdentity identity))
             {
                 Debug.LogWarning("Spawned object not found when handling Command message [netId=" + msg.netId + "]");
                 return;
@@ -1077,7 +1080,7 @@ namespace Mirror
         void DestroyObject(NetworkIdentity identity, bool destroyServerObject)
         {
             if (LogFilter.Debug) Debug.Log("DestroyObject instance:" + identity.netId);
-            NetworkIdentity.spawned.Remove(identity.netId);
+            spawned.Remove(identity.netId);
 
             identity.connectionToClient?.RemoveOwnedObject(identity);
 

--- a/Assets/Mirror/Tests/Editor/NetworkIdentityTests.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkIdentityTests.cs
@@ -370,44 +370,6 @@ namespace Mirror.Tests
 
             // stop the server
             server.Shutdown();
-            NetworkIdentity.spawned.Clear();
-        }
-
-        // check isClient/isServer/isLocalPlayer in host mode
-        [Test]
-        public void HostMode_IsFlags_Test()
-        {
-            // start the server
-            var networkManagerGameObject = new GameObject();
-            NetworkServer server = networkManagerGameObject.AddComponent<NetworkServer>();
-            NetworkClient client = networkManagerGameObject.AddComponent<NetworkClient>();
-            server.Listen(1000);
-
-            // start the client
-            client.ConnectHost(server);
-
-            // add component
-            IsClientServerCheckComponent component = gameObject.AddComponent<IsClientServerCheckComponent>();
-
-            // set is as local player
-            ClientScene.InternalAddPlayer(identity);
-
-            // spawn it
-            server.Spawn(gameObject);
-
-            // OnStartServer should have been called. check the flags.
-            Assert.That(component.OnStartServer_isClient, Is.EqualTo(true));
-            Assert.That(component.OnStartServer_isLocalPlayer, Is.EqualTo(true));
-            Assert.That(component.OnStartServer_isServer, Is.EqualTo(true));
-
-            // stop the client
-            client.Shutdown();
-            server.RemoveLocalConnection();
-            ClientScene.Shutdown();
-
-            // stop the server
-            server.Shutdown();
-            NetworkIdentity.spawned.Clear();
         }
 
         [Test]

--- a/Assets/Mirror/Tests/Play/NetworkServerTest.cs
+++ b/Assets/Mirror/Tests/Play/NetworkServerTest.cs
@@ -542,7 +542,7 @@ namespace Mirror.Tests
             OnStartClientTestNetworkBehaviour comp = go.AddComponent<OnStartClientTestNetworkBehaviour>();
             Assert.That(comp.called, Is.EqualTo(0));
             //connection.identity = identity;
-            NetworkIdentity.spawned[identity.netId] = identity;
+            server.spawned[identity.netId] = identity;
 
             // ActivateHostScene
             server.ActivateHostScene();
@@ -551,7 +551,7 @@ namespace Mirror.Tests
             Assert.That(comp.called, Is.EqualTo(1));
 
             // clean up
-            NetworkIdentity.spawned.Clear();
+            server.spawned.Clear();
             // destroy the test gameobject AFTER server was stopped.
             // otherwise isServer is true in OnDestroy, which means it would try
             // to call Destroy(go). but we need to use DestroyImmediate in


### PR DESCRIPTION
BREAKING CHANGE: cannot pass GameObjects and NetworkIdentities anymore.
Will be restored in the future.