### PR TITLE
refactor: Simplify message size validation

### DIFF
--- a/Assets/Mirror/Runtime/NetworkConnection.cs
+++ b/Assets/Mirror/Runtime/NetworkConnection.cs
@@ -153,24 +153,6 @@ namespace Mirror
             }
         }
 
-        // validate packet size before sending. show errors if too big/small.
-        // => it's best to check this here, we can't assume that all transports
-        //    would check max size and show errors internally. best to do it
-        //    in one place in hlapi.
-        // => it's important to log errors, so the user knows what went wrong.
-        protected internal static void ValidatePacketSize(ArraySegment<byte> segment, int channelId)
-        {
-            if (segment.Count > Transport.activeTransport.GetMaxPacketSize(channelId))
-            {
-                throw new InvalidOperationException("NetworkConnection.ValidatePacketSize: cannot send packet larger than " + Transport.activeTransport.GetMaxPacketSize(channelId) + " bytes");
-            }
-
-            if (segment.Count == 0)
-            {
-                throw new InvalidOperationException("NetworkConnection.ValidatePacketSize: cannot send zero bytes");
-            }
-        }
-
         // internal because no one except Mirror should send bytes directly to
         // the client. they would be detected as a message. send messages instead.
         internal abstract bool Send(ArraySegment<byte> segment, int channelId = Channels.DefaultReliable);

--- a/Assets/Mirror/Runtime/NetworkConnectionToClient.cs
+++ b/Assets/Mirror/Runtime/NetworkConnectionToClient.cs
@@ -20,19 +20,13 @@ namespace Mirror
         {
             if (logNetworkMessages) Debug.Log("ConnectionSend " + this + " bytes:" + BitConverter.ToString(segment.Array, segment.Offset, segment.Count));
 
-            // validate packet size first.
-            ValidatePacketSize(segment, channelId);
-
             singleConnectionId[0] = connectionId;
             return Transport.activeTransport.ServerSend(singleConnectionId, channelId, segment);
         }
 
         // Send to many. basically Transport.Send(connections) + checks.
         internal static bool Send(List<int> connectionIds, ArraySegment<byte> segment, int channelId = Channels.DefaultReliable)
-        {
-            // validate packet size first.
-            ValidatePacketSize(segment, channelId);
-            
+        {            
             // only the server sends to many, we don't have that function on
             // a client.
             if (Transport.activeTransport.ServerActive())

--- a/Assets/Mirror/Runtime/NetworkConnectionToServer.cs
+++ b/Assets/Mirror/Runtime/NetworkConnectionToServer.cs
@@ -11,9 +11,6 @@ namespace Mirror
         {
             if (logNetworkMessages) Debug.Log("ConnectionSend " + this + " bytes:" + BitConverter.ToString(segment.Array, segment.Offset, segment.Count));
 
-            // validate packet size first.
-            ValidatePacketSize(segment, channelId);
-
             return Transport.activeTransport.ClientSend(channelId, segment);
         }
 


### PR DESCRIPTION
It is not possible for message to have size 0, so that check is redundant
Also, let each transport validate that the message is not to large
no need to validate it for them.  Reduces transport coupling