### PR TITLE
refactor: NetworkConnection no longer accepts bytes

### DIFF
--- a/Assets/Mirror/Runtime/LocalConnections.cs
+++ b/Assets/Mirror/Runtime/LocalConnections.cs
@@ -16,7 +16,7 @@ namespace Mirror
 
         public override string address => "localhost";
 
-        internal override bool Send(ArraySegment<byte> segment, int channelId = Channels.DefaultReliable)
+        protected override bool Send(ArraySegment<byte> segment, int channelId = Channels.DefaultReliable)
         {
             // LocalConnection doesn't support allocation-free sends yet.
             // previously we allocated in Mirror. now we do it here.
@@ -57,7 +57,7 @@ namespace Mirror
 
         public override string address => "localhost";
 
-        internal override bool Send(ArraySegment<byte> segment, int channelId = Channels.DefaultReliable)
+        protected override bool Send(ArraySegment<byte> segment, int channelId = Channels.DefaultReliable)
         {
             if (segment.Count == 0)
             {

--- a/Assets/Mirror/Runtime/NetworkConnectionToClient.cs
+++ b/Assets/Mirror/Runtime/NetworkConnectionToClient.cs
@@ -16,7 +16,7 @@ namespace Mirror
         // the client. they would be detected as a message. send messages instead.
         readonly List<int> singleConnectionId = new List<int> { -1 };
 
-        internal override bool Send(ArraySegment<byte> segment, int channelId = Channels.DefaultReliable)
+        protected override bool Send(ArraySegment<byte> segment, int channelId = Channels.DefaultReliable)
         {
             if (logNetworkMessages) Debug.Log("ConnectionSend " + this + " bytes:" + BitConverter.ToString(segment.Array, segment.Offset, segment.Count));
 

--- a/Assets/Mirror/Runtime/NetworkConnectionToServer.cs
+++ b/Assets/Mirror/Runtime/NetworkConnectionToServer.cs
@@ -7,7 +7,7 @@ namespace Mirror
     {
         public override string address => "";
 
-        internal override bool Send(ArraySegment<byte> segment, int channelId = Channels.DefaultReliable)
+        protected override bool Send(ArraySegment<byte> segment, int channelId = Channels.DefaultReliable)
         {
             if (logNetworkMessages) Debug.Log("ConnectionSend " + this + " bytes:" + BitConverter.ToString(segment.Array, segment.Offset, segment.Count));
 

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -59,11 +59,11 @@ namespace Mirror
         /// </summary>
         public bool active { get; private set; }
 
-        // cache the Send(connectionIds) list to avoid allocating each time
-        readonly List<int> connectionIdsCache = new List<int>();
-
-
         public readonly Dictionary<uint, NetworkIdentity> spawned = new Dictionary<uint, NetworkIdentity>();
+
+        // just a cached memory area where we can collect connections
+        // for broadcasting messages
+        private static readonly List<NetworkConnection> connectionsCache = new List<NetworkConnection>();
 
         /// <summary>
         /// This shuts down the server and disconnects all clients.
@@ -254,8 +254,7 @@ namespace Mirror
         {
             if (LogFilter.Debug) Debug.Log("Server.SendToReady msgType:" + typeof(T));
 
-            // TODO: cache this
-            var connections = new List<NetworkConnection>();
+            connectionsCache.Clear();
            
             foreach (NetworkConnection connection in identity.observers)
             {
@@ -263,11 +262,11 @@ namespace Mirror
                 bool isOwner = connection == identity.connectionToClient;
                 if ((!isOwner || includeOwner) && connection.isReady)
                 {
-                    connections.Add(connection);
+                    connectionsCache.Add(connection);
                 }
             }
 
-            return NetworkConnection.Send(connections, msg, channelId);
+            return NetworkConnection.Send(connectionsCache, msg, channelId);
         }
 
         /// <summary>

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -221,38 +221,8 @@ namespace Mirror
         {
             if (LogFilter.Debug) Debug.Log("Server.SendToObservers id:" + typeof(T));
 
-            if (identity != null && identity.observers != null)
-            {
-                // get writer from pool
-                using (PooledNetworkWriter writer = NetworkWriterPool.GetWriter())
-                {
-                    // pack message into byte[] once
-                    MessagePacker.Pack(msg, writer);
-                    var segment = writer.ToArraySegment();
-
-                    // filter and then send to all internet connections at once
-                    // -> makes code more complicated, but is HIGHLY worth it to
-                    //    avoid allocations, allow for multicast, etc.
-                    connectionIdsCache.Clear();
-                    foreach ( NetworkConnection connection in identity.observers)
-                    {
-                        // use local connection directly because it doesn't send via transport
-                        if (connection is ULocalConnectionToClient)
-                            connection.Send(segment);
-                        // gather all internet connections
-                        else
-                            connectionIdsCache.Add(connection.connectionId);
-                    }
-
-                    // send to all internet connections at once
-                    if (connectionIdsCache.Count > 0)
-                    {
-                        NetworkConnectionToClient.Send(connectionIdsCache, segment, channelId);
-                    }
-
-                    NetworkDiagnostics.OnSend(msg, channelId, segment.Count, identity.observers.Count);
-                }
-            }
+            if (identity.observers != null)
+                NetworkConnection.Send(identity.observers, msg, channelId);
         }
 
         // Deprecated 03/03/2019
@@ -267,39 +237,7 @@ namespace Mirror
         public bool SendToAll<T>(T msg, int channelId = Channels.DefaultReliable) where T : IMessageBase
         {
             if (LogFilter.Debug) Debug.Log("Server.SendToAll id:" + typeof(T));
-
-            // get writer from pool
-            using (PooledNetworkWriter writer = NetworkWriterPool.GetWriter())
-            {
-                // pack message only once
-                MessagePacker.Pack(msg, writer);
-                var segment = writer.ToArraySegment();
-
-                // filter and then send to all internet connections at once
-                // -> makes code more complicated, but is HIGHLY worth it to
-                //    avoid allocations, allow for multicast, etc.
-                connectionIdsCache.Clear();
-                bool result = true;
-                foreach (KeyValuePair<int, NetworkConnectionToClient> kvp in connections)
-                {
-                    // use local connection directly because it doesn't send via transport
-                    if (kvp.Value is ULocalConnectionToClient)
-                        result &= kvp.Value.Send(segment);
-                    // gather all internet connections
-                    else
-                        connectionIdsCache.Add(kvp.Key);
-                }
-
-                // send to all internet connections at once
-                if (connectionIdsCache.Count > 0)
-                {
-                    result &= NetworkConnectionToClient.Send(connectionIdsCache, segment, channelId);
-                }
-
-                NetworkDiagnostics.OnSend(msg, channelId, segment.Count, connections.Count);
-
-                return result;
-            }
+            return NetworkConnection.Send(connections.Values, msg, channelId);
         }
 
         /// <summary>
@@ -316,49 +254,20 @@ namespace Mirror
         {
             if (LogFilter.Debug) Debug.Log("Server.SendToReady msgType:" + typeof(T));
 
-            if (identity != null && identity.observers != null)
+            // TODO: cache this
+            var connections = new List<NetworkConnection>();
+           
+            foreach (NetworkConnection connection in identity.observers)
             {
-                // get writer from pool
-                using (PooledNetworkWriter writer = NetworkWriterPool.GetWriter())
+                
+                bool isOwner = connection == identity.connectionToClient;
+                if ((!isOwner || includeOwner) && connection.isReady)
                 {
-                    // pack message only once
-                    MessagePacker.Pack(msg, writer);
-                    var segment = writer.ToArraySegment();
-
-                    // filter and then send to all internet connections at once
-                    // -> makes code more complicated, but is HIGHLY worth it to
-                    //    avoid allocations, allow for multicast, etc.
-                    connectionIdsCache.Clear();
-                    bool result = true;
-                    int count = 0;
-                    foreach ( NetworkConnection connection in identity.observers)
-                    {
-                        bool isOwner = connection == identity.connectionToClient;
-                        if ((!isOwner || includeOwner) && connection.isReady)
-                        {
-                            count++;
-
-                            // use local connection directly because it doesn't send via transport
-                            if (connection is ULocalConnectionToClient)
-                                result &= connection.Send(segment);
-                            // gather all internet connections
-                            else
-                                connectionIdsCache.Add(connection.connectionId);
-                        }
-                    }
-
-                    // send to all internet connections at once
-                    if (connectionIdsCache.Count > 0)
-                    {
-                        result &= NetworkConnectionToClient.Send(connectionIdsCache, segment, channelId);
-                    }
-
-                    NetworkDiagnostics.OnSend(msg, channelId, segment.Count, count);
-
-                    return result;
+                    connections.Add(connection);
                 }
             }
-            return false;
+
+            return NetworkConnection.Send(connections, msg, channelId);
         }
 
         /// <summary>

--- a/Assets/Mirror/Tests/Editor/LocalConnectionTest.cs
+++ b/Assets/Mirror/Tests/Editor/LocalConnectionTest.cs
@@ -104,14 +104,5 @@ namespace Mirror.Tests
             Assert.True(invoked, "handler should have been invoked");
         }
 
-        [Test]
-        public void ClientToServerFailTest()
-        {
-            LogAssert.ignoreFailingMessages = true; // error log is expected
-            bool result = connectionToServer.Send(new ArraySegment<byte>(new byte[0]));
-            LogAssert.ignoreFailingMessages = false;
-
-            Assert.That(result, Is.False);
-        }
     }
 }


### PR DESCRIPTION
Previously you could call networkConnection.Send(ArraySegment<byte> bytes, channelId)
This totally breaks abstraction,  NetworkConnection should _only_ deal with messages.

The problem is that if we want to send the same message to multiple connections,
we don't want to serialilize the message multiple times (very expensive).

The solution is that NetworkConnection now has a static method:

```cs
public static bool Send(IEnumerable<NetworkConnection> connections, T msg, int channelId)
```

which proceeds to send the message to all the supplied connections.

This code was previouly done in NetworkServer.