### PR TITLE
remove runInBackground

### DIFF
--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -35,14 +35,6 @@ namespace Mirror
         public bool dontDestroyOnLoad = true;
 
         /// <summary>
-        /// Controls whether the program runs when it is in the background.
-        /// <para>This is required when multiple instances of a program using networking are running on the same machine, such as when testing using localhost. But this is not recommended when deploying to mobile platforms.</para>
-        /// </summary>
-        [FormerlySerializedAs("m_RunInBackground")]
-        [Tooltip("Should the server or client keep running in the background?")]
-        public bool runInBackground = true;
-
-        /// <summary>
         /// Automatically invoke StartServer()
         /// <para>If the application is a Server Build or run with the -batchMode command line arguement, StartServer is automatically invoked.</para>
         /// </summary>
@@ -267,9 +259,6 @@ namespace Mirror
             if (LogFilter.Debug) Debug.Log("NetworkManager SetupServer");
             Initialize();
 
-            if (runInBackground)
-                Application.runInBackground = true;
-
             if (authenticator != null)
             {
                 authenticator.OnStartServer();
@@ -352,9 +341,6 @@ namespace Mirror
                 authenticator.OnClientAuthenticated += OnClientAuthenticated;
             }
 
-            if (runInBackground)
-                Application.runInBackground = true;
-
             isNetworkActive = true;
 
             RegisterClientMessages();
@@ -386,11 +372,6 @@ namespace Mirror
             {
                 authenticator.OnStartClient();
                 authenticator.OnClientAuthenticated += OnClientAuthenticated;
-            }
-
-            if (runInBackground)
-            {
-                Application.runInBackground = true;
             }
 
             isNetworkActive = true;

--- a/Assets/Mirror/Tests/Play/NetworkManagerTest.cs
+++ b/Assets/Mirror/Tests/Play/NetworkManagerTest.cs
@@ -29,7 +29,6 @@ namespace Mirror.Tests
         public void VariableTest()
         {
             Assert.That(manager.dontDestroyOnLoad, Is.True);
-            Assert.That(manager.runInBackground, Is.True);
             Assert.That(manager.startOnHeadless, Is.True);
             Assert.That(manager.showDebugMessages, Is.False);
             Assert.That(manager.serverTickRate, Is.EqualTo(30));


### PR DESCRIPTION
This flag has nothing to do with networking,  so why is this here?
It is also on by default in the player settings.
If people want to turn this off,  let them do it in player settings or
their own scripts.

BREAKING CHANGE: NetworkManager no longer has runInBackground option