### PR TITLE
remove redundant Update call

### DIFF
--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -241,11 +241,6 @@ namespace Mirror
         /// </summary>
         public virtual void LateUpdate()
         {
-            // call it while the NetworkManager exists.
-            // -> we don't only call while Client/Server.Connected, because then we would stop if disconnected and the
-            //    NetworkClient wouldn't receive the last Disconnect event, result in all kinds of issues
-            server.Update();
-            client.Update();
             UpdateScene();
         }
 


### PR DESCRIPTION
NetworkClient and NetworkServer's update is already called by unity
no need to call it again in LateUpdate.
Besides,  calling Update in LateUpdate is a recipe for bugs.