### PR TITLE
feat: NetworkConnection manages messages handlers

### DIFF
--- a/Assets/Mirror/Authenticators/BasicAuthenticator.cs
+++ b/Assets/Mirror/Authenticators/BasicAuthenticator.cs
@@ -27,25 +27,16 @@ namespace Mirror.Authenticators
             public string Message;
         }
 
-        public override void OnStartServer()
-        {
-            // register a handler for the authentication request we expect from client
-            manager.server.RegisterHandler<AuthRequestMessage>(OnAuthRequestMessage, false);
-        }
-
-        public override void OnStartClient()
-        {
-            // register a handler for the authentication response we expect from server
-            manager.client.RegisterHandler<AuthResponseMessage>(OnAuthResponseMessage, false);
-        }
-
         public override void OnServerAuthenticate(NetworkConnectionToClient conn)
         {
-            // do nothing...wait for AuthRequestMessage from client
+            // wait for AuthRequestMessage from client
+            conn.RegisterHandler<NetworkConnectionToClient, AuthRequestMessage>(OnAuthRequestMessage, false);
         }
 
         public override void OnClientAuthenticate(NetworkConnectionToServer conn)
         {
+            conn.RegisterHandler<NetworkConnectionToServer, AuthResponseMessage>(OnAuthResponseMessage, false);
+
             var authRequestMessage = new AuthRequestMessage
             {
                 AuthUsername = Username,

--- a/Assets/Mirror/Examples/Chat/Scripts/ChatNetworkManager.cs
+++ b/Assets/Mirror/Examples/Chat/Scripts/ChatNetworkManager.cs
@@ -14,10 +14,9 @@ namespace Mirror.Examples.Chat
             public string name;
         }
 
-        public override void OnStartServer()
+        public override void OnServerConnect(NetworkConnection conn)
         {
-            base.OnStartServer();
-            server.RegisterHandler<CreatePlayerMessage>(OnCreatePlayer);
+            conn.RegisterHandler<NetworkConnectionToClient, CreatePlayerMessage>(OnCreatePlayer);
         }
 
         public override void OnClientConnect(NetworkConnection conn)

--- a/Assets/Mirror/Runtime/MessagePacker.cs
+++ b/Assets/Mirror/Runtime/MessagePacker.cs
@@ -1,6 +1,5 @@
 using System;
 using System.ComponentModel;
-using UnityEngine;
 
 namespace Mirror
 {

--- a/Assets/Mirror/Runtime/NetworkAuthenticator.cs
+++ b/Assets/Mirror/Runtime/NetworkAuthenticator.cs
@@ -21,12 +21,6 @@ namespace Mirror
 
         #region server
 
-        /// <summary>
-        /// Called on server from StartServer to initialize the Authenticator
-        /// <para>Server message handlers should be registered in this method.</para>
-        /// </summary>
-        public virtual void OnStartServer() { }
-
         // This will get more code in the near future
         internal void OnServerAuthenticateInternal(NetworkConnectionToClient conn)
         {
@@ -45,12 +39,6 @@ namespace Mirror
         #endregion
 
         #region client
-
-        /// <summary>
-        /// Called on client from StartClient to initialize the Authenticator
-        /// <para>Client message handlers should be registered in this method.</para>
-        /// </summary>
-        public virtual void OnStartClient() { }
 
         // This will get more code in the near future
         internal void OnClientAuthenticateInternal(NetworkConnectionToServer conn)

--- a/Assets/Mirror/Runtime/NetworkClient.cs
+++ b/Assets/Mirror/Runtime/NetworkClient.cs
@@ -31,11 +31,6 @@ namespace Mirror
         [Tooltip("Authentication component attached to this object")]
         public NetworkAuthenticator authenticator;
 
-        /// <summary>
-        /// The registered network message handlers.
-        /// </summary>
-        readonly Dictionary<int, NetworkMessageDelegate> handlers = new Dictionary<int, NetworkMessageDelegate>();
-
         // spawn handlers
         readonly Dictionary<Guid, SpawnHandlerDelegate> spawnHandlers = new Dictionary<Guid, SpawnHandlerDelegate>();
         readonly Dictionary<Guid, UnSpawnDelegate> unspawnHandlers = new Dictionary<Guid, UnSpawnDelegate>();
@@ -138,7 +133,6 @@ namespace Mirror
         {
             if (LogFilter.Debug) Debug.Log("Client Connect: " + serverIp);
 
-            RegisterSystemHandlers(false);
             Transport.activeTransport.enabled = true;
             InitializeTransportHandlers();
             RegisterSpawnPrefabs();
@@ -148,7 +142,7 @@ namespace Mirror
 
             // setup all the handlers
             connection = new NetworkConnectionToServer();
-            connection.SetHandlers(handlers);
+            RegisterMessageHandlers(connection);
             OnConnected();
         }
 
@@ -160,7 +154,6 @@ namespace Mirror
         {
             if (LogFilter.Debug) Debug.Log("Client Connect: " + uri);
 
-            RegisterSystemHandlers(false);
             Transport.activeTransport.enabled = true;
             InitializeTransportHandlers();
             RegisterSpawnPrefabs();
@@ -170,16 +163,13 @@ namespace Mirror
 
             // setup all the handlers
             connection = new NetworkConnectionToServer();
-            connection.SetHandlers(handlers);
+            RegisterMessageHandlers(connection);
             OnConnected();
         }
 
         internal void ConnectHost(NetworkServer server)
         {
             if (LogFilter.Debug) Debug.Log("Client Connect Host to Server");
-
-            RegisterSystemHandlers(true);
-
             connectState = ConnectState.Connected;
 
             // create local connection objects and connect them
@@ -187,7 +177,7 @@ namespace Mirror
                 = ULocalConnectionToClient.CreateLocalConnections();
 
             connection = connectionToServer;
-            connection.SetHandlers(handlers);
+            RegisterHostHandlers(connection);
 
             // create server connection to local client
             server.SetLocalConnection(this, connectionToClient);
@@ -354,75 +344,32 @@ namespace Mirror
             }
         }
 
-        internal void RegisterSystemHandlers(bool hostMode)
+        internal void RegisterHostHandlers(NetworkConnection connection)
         {
-            // host mode client / regular client react to some messages differently.
-            // but we still need to add handlers for all of them to avoid
-            // 'message id not found' errors.
-            if (hostMode)
-            {
-                RegisterHandler<ObjectDestroyMessage>(OnHostClientObjectDestroy);
-                RegisterHandler<ObjectHideMessage>(OnHostClientObjectHide);
-                RegisterHandler<NetworkPongMessage>((conn, msg) => { }, false);
-                RegisterHandler<SpawnMessage>(OnHostClientSpawn);
-                // host mode doesn't need spawning
-                RegisterHandler<ObjectSpawnStartedMessage>((conn, msg) => { });
-                // host mode doesn't need spawning
-                RegisterHandler<ObjectSpawnFinishedMessage>((conn, msg) => { });
-                RegisterHandler<UpdateVarsMessage>((conn, msg) => { });
-            }
-            else
-            {
-                RegisterHandler<ObjectDestroyMessage>(OnObjectDestroy);
-                RegisterHandler<ObjectHideMessage>(OnObjectHide);
-                RegisterHandler<NetworkPongMessage>(Time.OnClientPong, false);
-                RegisterHandler<SpawnMessage>(OnSpawn);
-                RegisterHandler<ObjectSpawnStartedMessage>(OnObjectSpawnStarted);
-                RegisterHandler<ObjectSpawnFinishedMessage>(OnObjectSpawnFinished);
-                RegisterHandler<UpdateVarsMessage>(OnUpdateVarsMessage);
-            }
-            RegisterHandler<RpcMessage>(OnRPCMessage);
-            RegisterHandler<SyncEventMessage>(OnSyncEventMessage);
+            connection.RegisterHandler<ObjectDestroyMessage>(OnHostClientObjectDestroy);
+            connection.RegisterHandler<ObjectHideMessage>(OnHostClientObjectHide);
+            connection.RegisterHandler<NetworkPongMessage>(msg => { }, false);
+            connection.RegisterHandler<SpawnMessage>(OnHostClientSpawn);
+            // host mode reuses objects in the server
+            // so we don't need to spawn them
+            connection.RegisterHandler<ObjectSpawnStartedMessage>(msg => { });
+            connection.RegisterHandler<ObjectSpawnFinishedMessage>(msg => { });
+            connection.RegisterHandler<UpdateVarsMessage>(msg => { });            
+            connection.RegisterHandler<RpcMessage>(OnRPCMessage);
+            connection.RegisterHandler<SyncEventMessage>(OnSyncEventMessage);
         }
 
-        /// <summary>
-        /// Register a handler for a particular message type.
-        /// <para>There are several system message types which you can add handlers for. You can also add your own message types.</para>
-        /// </summary>
-        /// <typeparam name="T">The message type to unregister.</typeparam>
-        /// <param name="handler"></param>
-        /// <param name="requireAuthentication">true if the message requires an authenticated connection</param>
-        public void RegisterHandler<T>(Action<NetworkConnectionToServer, T> handler, bool requireAuthentication = true) where T : IMessageBase, new()
+        internal void RegisterMessageHandlers(NetworkConnection connection)
         {
-            int msgType = MessagePacker.GetId<T>();
-            if (handlers.ContainsKey(msgType))
-            {
-                if (LogFilter.Debug) Debug.Log("NetworkClient.RegisterHandler replacing " + handler + " - " + msgType);
-            }
-            handlers[msgType] = NetworkConnection.MessageHandler(handler, requireAuthentication);
-        }
-
-        /// <summary>
-        /// Register a handler for a particular message type.
-        /// <para>There are several system message types which you can add handlers for. You can also add your own message types.</para>
-        /// </summary>
-        /// <typeparam name="T">The message type to unregister.</typeparam>
-        /// <param name="handler"></param>
-        /// <param name="requireAuthentication">true if the message requires an authenticated connection</param>
-        public void RegisterHandler<T>(Action<T> handler, bool requireAuthentication = true) where T : IMessageBase, new()
-        {
-            RegisterHandler((NetworkConnectionToServer _, T value) => { handler(value); }, requireAuthentication);
-        }
-
-        /// <summary>
-        /// Unregisters a network message handler.
-        /// </summary>
-        /// <typeparam name="T">The message type to unregister.</typeparam>
-        public void UnregisterHandler<T>() where T : IMessageBase
-        {
-            // use int to minimize collisions
-            int msgType = MessagePacker.GetId<T>();
-            handlers.Remove(msgType);
+            connection.RegisterHandler<ObjectDestroyMessage>(OnObjectDestroy);
+            connection.RegisterHandler<ObjectHideMessage>(OnObjectHide);
+            connection.RegisterHandler<NetworkPongMessage>(Time.OnClientPong, false);
+            connection.RegisterHandler<SpawnMessage>(OnSpawn);
+            connection.RegisterHandler<ObjectSpawnStartedMessage>(OnObjectSpawnStarted);
+            connection.RegisterHandler<ObjectSpawnFinishedMessage>(OnObjectSpawnFinished);
+            connection.RegisterHandler<UpdateVarsMessage>(OnUpdateVarsMessage);
+            connection.RegisterHandler<RpcMessage>(OnRPCMessage);
+            connection.RegisterHandler<SyncEventMessage>(OnSyncEventMessage);
         }
 
         /// <summary>
@@ -441,7 +388,6 @@ namespace Mirror
             isSpawnFinished = false;
 
             connectState = ConnectState.None;
-            handlers.Clear();
 
             if (authenticator != null)
                 authenticator.OnClientAuthenticated -= OnAuthenticated;

--- a/Assets/Mirror/Runtime/NetworkClient.cs
+++ b/Assets/Mirror/Runtime/NetworkClient.cs
@@ -205,7 +205,6 @@ namespace Mirror
         {
             if (authenticator != null)
             {
-                authenticator.OnStartClient();
                 authenticator.OnClientAuthenticated += OnAuthenticated;
 
                 Connected.AddListener(authenticator.OnClientAuthenticateInternal);

--- a/Assets/Mirror/Runtime/NetworkConnection.cs
+++ b/Assets/Mirror/Runtime/NetworkConnection.cs
@@ -174,7 +174,6 @@ namespace Mirror
                 }
                 finally
                 {
-                    // TODO: Figure out the correct channel
                     NetworkDiagnostics.OnReceive(message, channelId, reader.Length);
                 }
 

--- a/Assets/Mirror/Runtime/NetworkConnection.cs
+++ b/Assets/Mirror/Runtime/NetworkConnection.cs
@@ -17,6 +17,10 @@ namespace Mirror
     /// </remarks>
     public abstract class NetworkConnection : IDisposable
     {
+        // Handles network messages on client and server
+        private delegate void NetworkMessageDelegate(NetworkConnection conn, NetworkReader reader, int channelId);
+
+
         // internal so it can be tested
         internal readonly HashSet<NetworkIdentity> visList = new HashSet<NetworkIdentity>();
 
@@ -130,7 +134,7 @@ namespace Mirror
         /// </summary>
         public abstract void Disconnect();
 
-        internal static NetworkMessageDelegate MessageHandler<T, C>(Action<C, T> handler, bool requireAuthenication)
+        private static NetworkMessageDelegate MessageHandler<T, C>(Action<C, T> handler, bool requireAuthenication)
             where T : IMessageBase, new()
             where C : NetworkConnection
         {
@@ -175,7 +179,7 @@ namespace Mirror
                 }
 
                 handler((C)conn, message);
-            };
+            }
             return AdapterFunction;
         }
 

--- a/Assets/Mirror/Runtime/NetworkConnection.cs
+++ b/Assets/Mirror/Runtime/NetworkConnection.cs
@@ -194,9 +194,9 @@ namespace Mirror
             where C : NetworkConnection
         {
             int msgType = MessagePacker.GetId<T>();
-            if (messageHandlers.ContainsKey(msgType))
+            if (LogFilter.Debug && messageHandlers.ContainsKey(msgType))
             {
-                if (LogFilter.Debug) Debug.Log("NetworkServer.RegisterHandler replacing " + msgType);
+                Debug.Log("NetworkServer.RegisterHandler replacing " + msgType);
             }
             messageHandlers[msgType] = MessageHandler(handler, requireAuthentication);
         }

--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;
 using Mirror.Tcp;
 using UnityEngine;
 using UnityEngine.Rendering;

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -60,14 +60,8 @@ namespace Mirror
         public readonly Dictionary<int, NetworkConnectionToClient> connections = new Dictionary<int, NetworkConnectionToClient>();
 
         /// <summary>
-        /// <para>Dictionary of the message handlers registered with the server.</para>
-        /// <para>The key to the dictionary is the message Id.</para>
-        /// </summary>
-        readonly Dictionary<int, NetworkMessageDelegate> handlers = new Dictionary<int, NetworkMessageDelegate>();
-
-        /// <summary>
-        /// <para>If you enable this, the server will listen for incoming connections on the regular network port.</para>
-        /// <para>This can be used if set as false and the game is running in host mode and does not want external players to be able to connect - making it like a single-player game. Also this can be useful when using AddExternalConnection().</para>
+        /// <para>If you enable this, the server will not listen for incoming connections on the regular network port.</para>
+        /// <para>This can be used if the game is running in host mode and does not want external players to be able to connect - making it like a single-player game. Also this can be useful when using AddExternalConnection().</para>
         /// </summary>
         public bool Listening = true;
 

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -131,7 +131,6 @@ namespace Mirror
 
             if (authenticator != null)
             {
-                authenticator.OnStartServer();
                 authenticator.OnServerAuthenticated += OnAuthenticated;
 
                 Connected.AddListener(authenticator.OnServerAuthenticateInternal);

--- a/Assets/Mirror/Runtime/UNetwork.cs
+++ b/Assets/Mirror/Runtime/UNetwork.cs
@@ -4,9 +4,6 @@ using UnityEngine;
 
 namespace Mirror
 {
-    // Handles network messages on client and server
-    internal delegate void NetworkMessageDelegate(NetworkConnection conn, NetworkReader reader, int channelId);
-
     // Handles requests to spawn objects on the client
     public delegate GameObject SpawnDelegate(Vector3 position, Guid assetId);
 

--- a/Assets/Mirror/Tests/Editor/NetworkIdentityTests.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkIdentityTests.cs
@@ -873,11 +873,9 @@ namespace Mirror.Tests
                 = ULocalConnectionToClient.CreateLocalConnections();
             owner.isReady = true;
             owner.isAuthenticated = true;
+            owner.connectionToServer.isAuthenticated = true;
             int ownerCalled = 0;
-            owner.connectionToServer.SetHandlers(new Dictionary<int, NetworkMessageDelegate>
-            {
-                { MessagePacker.GetId<UpdateVarsMessage>(), ((conn, reader, channelId) => ++ownerCalled) }
-            });
+            owner.connectionToServer.RegisterHandler<UpdateVarsMessage>(msg => ++ownerCalled);
             identity.connectionToClient = owner;
 
             // add an observer connection that will receive the updates
@@ -885,11 +883,9 @@ namespace Mirror.Tests
                 = ULocalConnectionToClient.CreateLocalConnections();
             observer.isReady = true;
             observer.isAuthenticated = true;
+            observer.connectionToServer.isAuthenticated = true;
             int observerCalled = 0;
-            observer.connectionToServer.SetHandlers(new Dictionary<int, NetworkMessageDelegate>
-            {
-                { MessagePacker.GetId<UpdateVarsMessage>(), ((conn, reader, channelId) => ++observerCalled) }
-            });
+            observer.connectionToServer.RegisterHandler<UpdateVarsMessage>(msg => ++observerCalled);
             identity.observers.Add(observer);
 
             // set components dirty again

--- a/Assets/Mirror/Tests/Play/NetworkManagerTest.cs
+++ b/Assets/Mirror/Tests/Play/NetworkManagerTest.cs
@@ -22,6 +22,7 @@ namespace Mirror.Tests
             gameObject = new GameObject();
             manager = gameObject.AddComponent<NetworkManager>();
             manager.startOnHeadless = false;
+            manager.autoCreatePlayer = false;
             manager.client = gameObject.GetComponent<NetworkClient>();
             manager.server = gameObject.GetComponent<NetworkServer>();
         }
@@ -41,7 +42,7 @@ namespace Mirror.Tests
             Assert.That(manager.serverTickRate, Is.EqualTo(30));
             Assert.That(manager.offlineScene, Is.Empty);
             Assert.That(manager.server.MaxConnections, Is.EqualTo(4));
-            Assert.That(manager.autoCreatePlayer, Is.True);
+            Assert.That(manager.autoCreatePlayer, Is.False);
             Assert.That(manager.numPlayers, Is.Zero);
             Assert.That(manager.isNetworkActive, Is.False);
 

--- a/Assets/Mirror/Tests/Play/NetworkServerTest.cs
+++ b/Assets/Mirror/Tests/Play/NetworkServerTest.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using NSubstitute;
 using NUnit.Framework;
 using UnityEngine;
@@ -119,10 +118,6 @@ namespace Mirror.Tests
         [Test]
         public void ConnectionEventTest()
         {
-            // message handlers
-            server.RegisterHandler<DisconnectMessage>((conn, msg) => { }, false);
-            server.RegisterHandler<ErrorMessage>((conn, msg) => { }, false);
-
             // listen with maxconnections=1
             server.MaxConnections = 1;
 
@@ -143,10 +138,6 @@ namespace Mirror.Tests
         [Test]
         public void MaxConnectionsTest()
         {
-            // message handlers
-            server.RegisterHandler<DisconnectMessage>((conn, msg) => {}, false);
-            server.RegisterHandler<ErrorMessage>((conn, msg) => {}, false);
-
             // listen with maxconnections=1
             server.MaxConnections = 1;
             server.Listen();
@@ -161,6 +152,7 @@ namespace Mirror.Tests
             Assert.That(server.connections.Count, Is.EqualTo(1));
         }
 
+        /*
         [Test]
         public void DisconnectMessageHandlerTest()
         {
@@ -180,15 +172,11 @@ namespace Mirror.Tests
             // disconnect
             Transport.activeTransport.OnServerDisconnected.Invoke(42);
             Assert.That(disconnectCalled, Is.True);
-        }
+        }*/
 
         [Test]
         public void ConnectionsDictTest()
         {
-            // message handlers
-            server.RegisterHandler<DisconnectMessage>((conn, msg) => {}, false);
-            server.RegisterHandler<ErrorMessage>((conn, msg) => {}, false);
-
             // listen
             server.Listen();
             Assert.That(server.connections.Count, Is.EqualTo(0));
@@ -220,10 +208,6 @@ namespace Mirror.Tests
             // 0 is for local player
             // <0 is never used
 
-            // message handlers
-            server.RegisterHandler<DisconnectMessage>((conn, msg) => {}, false);
-            server.RegisterHandler<ErrorMessage>((conn, msg) => {}, false);
-
             // listen
             server.Listen();
             Assert.That(server.connections.Count, Is.EqualTo(0));
@@ -243,10 +227,6 @@ namespace Mirror.Tests
         [Test]
         public void ConnectDuplicateConnectionIdsTest()
         {
-            // message handlers
-            server.RegisterHandler<DisconnectMessage>((conn, msg) => {}, false);
-            server.RegisterHandler<ErrorMessage>((conn, msg) => {}, false);
-
             // listen
             server.Listen();
             Assert.That(server.connections.Count, Is.EqualTo(0));
@@ -279,10 +259,6 @@ namespace Mirror.Tests
         [Test]
         public void AddConnectionTest()
         {
-            // message handlers
-            server.RegisterHandler<DisconnectMessage>((conn, msg) => {}, false);
-            server.RegisterHandler<ErrorMessage>((conn, msg) => {}, false);
-
             // listen
             server.Listen();
             Assert.That(server.connections.Count, Is.EqualTo(0));
@@ -319,10 +295,6 @@ namespace Mirror.Tests
         [Test]
         public void RemoveConnectionTest()
         {
-            // message handlers
-            server.RegisterHandler<DisconnectMessage>((conn, msg) => {}, false);
-            server.RegisterHandler<ErrorMessage>((conn, msg) => {}, false);
-
             // listen
             server.Listen();
             Assert.That(server.connections.Count, Is.EqualTo(0));
@@ -344,10 +316,6 @@ namespace Mirror.Tests
         [Test]
         public void DisconnectAllConnectionsTest()
         {
-            // message handlers
-            server.RegisterHandler<DisconnectMessage>((conn, msg) => {}, false);
-            server.RegisterHandler<ErrorMessage>((conn, msg) => {}, false);
-
             // listen
             server.Listen();
             Assert.That(server.connections.Count, Is.EqualTo(0));
@@ -365,10 +333,6 @@ namespace Mirror.Tests
         [Test]
         public void DisconnectAllTest()
         {
-            // message handlers
-            server.RegisterHandler<DisconnectMessage>((conn, msg) => {}, false);
-            server.RegisterHandler<ErrorMessage>((conn, msg) => {}, false);
-
             // listen
             server.Listen();
             Assert.That(server.connections.Count, Is.EqualTo(0));
@@ -390,19 +354,10 @@ namespace Mirror.Tests
         [Test]
         public void OnDataReceivedTest()
         {
-            // message handlers
-            server.RegisterHandler<DisconnectMessage>((conn, msg) => {}, false);
-            server.RegisterHandler<ErrorMessage>((conn, msg) => {}, false);
-
             // add one custom message handler
             bool wasReceived = false;
             NetworkConnection connectionReceived = null;
             var messageReceived = new TestMessage();
-            server.RegisterHandler<TestMessage>((conn, msg) => {
-                wasReceived = true;
-                connectionReceived = conn;
-                messageReceived = msg;
-            }, false);
 
             // listen
             server.Listen();
@@ -410,6 +365,13 @@ namespace Mirror.Tests
 
             // add a connection
             var connection = new NetworkConnectionToClient(42);
+
+            connection.RegisterHandler<NetworkConnectionToClient, TestMessage>((conn, msg) => {
+                wasReceived = true;
+                connectionReceived = conn;
+                messageReceived = msg;
+            }, false);
+
             server.AddConnection(connection);
             Assert.That(server.connections.Count, Is.EqualTo(1));
 
@@ -434,19 +396,9 @@ namespace Mirror.Tests
         [Test]
         public void OnDataReceivedInvalidConnectionIdTest()
         {
-            // message handlers
-            server.RegisterHandler<DisconnectMessage>((conn, msg) => {}, false);
-            server.RegisterHandler<ErrorMessage>((conn, msg) => {}, false);
-
             // add one custom message handler
             bool wasReceived = false;
             NetworkConnection connectionReceived = null;
-            var messageReceived = new TestMessage();
-            server.RegisterHandler<TestMessage>((conn, msg) => {
-                wasReceived = true;
-                connectionReceived = conn;
-                messageReceived = msg;
-            }, false);
 
             // listen
             server.Listen();
@@ -563,10 +515,6 @@ namespace Mirror.Tests
         [Test]
         public void SendToAllTest()
         {
-            // message handlers
-            server.RegisterHandler<DisconnectMessage>((conn, msg) => {}, false);
-            server.RegisterHandler<ErrorMessage>((conn, msg) => {}, false);
-
             // listen
             server.Listen();
             Assert.That(server.connections.Count, Is.EqualTo(0));
@@ -575,10 +523,8 @@ namespace Mirror.Tests
             (_, ULocalConnectionToClient connection) = ULocalConnectionToClient.CreateLocalConnections();
             // set a client handler
             int called = 0;
-            connection.connectionToServer.SetHandlers(new Dictionary<int,NetworkMessageDelegate>()
-            {
-                { MessagePacker.GetId<TestMessage>(), (conn, reader, channel) => ++called }
-            });
+            connection.connectionToServer.RegisterHandler<TestMessage>(msg => ++called);
+
             server.AddConnection(connection);
 
             // create a message
@@ -598,27 +544,20 @@ namespace Mirror.Tests
         [Test]
         public void RegisterUnregisterClearHandlerTest()
         {
-            // message handlers that are needed for the test
-            server.RegisterHandler<DisconnectMessage>((conn, msg) => {}, false);
-            server.RegisterHandler<ErrorMessage>((conn, msg) => {}, false);
-
-
-            // RegisterHandler(conn, msg) variant
-            int variant1Called = 0;
-            server.RegisterHandler<TestMessage>((conn, msg) => { ++variant1Called; }, false);
-
-            // RegisterHandler(msg) variant
-            int variant2Called = 0;
-            server.RegisterHandler<WovenTestMessage>(msg => { ++variant2Called; }, false);
 
             // listen
             server.Listen();
-            Assert.That(server.connections.Count, Is.EqualTo(0));
-
             // add a connection
             var connection = new NetworkConnectionToClient(42);
             server.AddConnection(connection);
-            Assert.That(server.connections.Count, Is.EqualTo(1));
+
+            // RegisterHandler(conn, msg) variant
+            int variant1Called = 0;
+            connection.RegisterHandler<NetworkConnectionToClient, TestMessage>((conn, msg) => { ++variant1Called; }, false);
+
+            // RegisterHandler(msg) variant
+            int variant2Called = 0;
+            connection.RegisterHandler<WovenTestMessage>(msg => { ++variant2Called; }, false);
 
             // serialize first message, send it to server, check if it was handled
             var writer = new NetworkWriter();
@@ -640,7 +579,7 @@ namespace Mirror.Tests
             Assert.That(variant2Called, Is.EqualTo(1));
 
             // unregister first handler, send, should fail
-            server.UnregisterHandler<TestMessage>();
+            connection.UnregisterHandler<TestMessage>();
             writer = new NetworkWriter();
             MessagePacker.Pack(new TestMessage(), writer);
             // log error messages are expected
@@ -651,9 +590,9 @@ namespace Mirror.Tests
             Assert.That(variant1Called, Is.EqualTo(1));
 
             // unregister second handler via ClearHandlers to test that one too. send, should fail
-            server.ClearHandlers();
+            connection.ClearHandlers();
             // (only add this one to avoid disconnect error)
-            server.RegisterHandler<DisconnectMessage>((conn, msg) => {}, false);
+            connection.RegisterHandler<DisconnectMessage>(msg => {}, false);
             writer = new NetworkWriter();
             MessagePacker.Pack(new TestMessage(), writer);
             // log error messages are expected
@@ -667,10 +606,6 @@ namespace Mirror.Tests
         [Test]
         public void SendToClientOfPlayer()
         {
-            // message handlers
-            server.RegisterHandler<DisconnectMessage>((conn, msg) => {}, false);
-            server.RegisterHandler<ErrorMessage>((conn, msg) => {}, false);
-
             // listen
             server.Listen();
             Assert.That(server.connections.Count, Is.EqualTo(0));
@@ -679,10 +614,7 @@ namespace Mirror.Tests
             (_, ULocalConnectionToClient connection) = ULocalConnectionToClient.CreateLocalConnections();
             // set a client handler
             int called = 0;
-            connection.connectionToServer.SetHandlers(new Dictionary<int,NetworkMessageDelegate>()
-            {
-                { MessagePacker.GetId<TestMessage>(), (conn, reader, channel) => ++called }
-            });
+            connection.connectionToServer.RegisterHandler<TestMessage>(msg => ++called);
             server.AddConnection(connection);
 
             // create a message
@@ -736,10 +668,6 @@ namespace Mirror.Tests
         [Test]
         public void ShowForConnection()
         {
-            // message handlers
-            server.RegisterHandler<DisconnectMessage>((conn, msg) => {}, false);
-            server.RegisterHandler<ErrorMessage>((conn, msg) => {}, false);
-
             // listen
             server.Listen();
             Assert.That(server.connections.Count, Is.EqualTo(0));
@@ -749,10 +677,7 @@ namespace Mirror.Tests
             connection.isReady = true;
             // set a client handler
             int called = 0;
-            connection.connectionToServer.SetHandlers(new Dictionary<int,NetworkMessageDelegate>()
-            {
-                { MessagePacker.GetId<SpawnMessage>(), (conn, reader, channel) => ++called }
-            });
+            connection.connectionToServer.RegisterHandler<SpawnMessage>(msg => ++called);
             server.AddConnection(connection);
 
             // create a gameobject and networkidentity and some unique values
@@ -782,10 +707,6 @@ namespace Mirror.Tests
         [Test]
         public void HideForConnection()
         {
-            // message handlers
-            server.RegisterHandler<DisconnectMessage>((conn, msg) => {}, false);
-            server.RegisterHandler<ErrorMessage>((conn, msg) => {}, false);
-
             // listen
             server.Listen();
             Assert.That(server.connections.Count, Is.EqualTo(0));
@@ -795,10 +716,7 @@ namespace Mirror.Tests
             connection.isReady = true;
             // set a client handler
             int called = 0;
-            connection.connectionToServer.SetHandlers(new Dictionary<int,NetworkMessageDelegate>()
-            {
-                { MessagePacker.GetId<ObjectHideMessage>(), (conn, reader, channel) => ++called }
-            });
+            connection.connectionToServer.RegisterHandler<ObjectHideMessage>(msg => ++called);
             server.AddConnection(connection);
 
             // create a gameobject and networkidentity
@@ -969,10 +887,6 @@ namespace Mirror.Tests
         [Test]
         public void ShutdownCleanupTest()
         {
-            // message handlers
-            server.RegisterHandler<DisconnectMessage>((conn, msg) => {}, false);
-            server.RegisterHandler<ErrorMessage>((conn, msg) => {}, false);
-
             // listen
             server.Listen();
             Assert.That(server.active, Is.True);

--- a/Assets/Mirror/Tests/Play/NetworkServerTest.cs
+++ b/Assets/Mirror/Tests/Play/NetworkServerTest.cs
@@ -521,6 +521,8 @@ namespace Mirror.Tests
 
             // add connection
             (_, ULocalConnectionToClient connection) = ULocalConnectionToClient.CreateLocalConnections();
+            connection.isAuthenticated = true;
+            connection.connectionToServer.isAuthenticated = true;
             // set a client handler
             int called = 0;
             connection.connectionToServer.RegisterHandler<TestMessage>(msg => ++called);
@@ -612,6 +614,9 @@ namespace Mirror.Tests
 
             // add connection
             (_, ULocalConnectionToClient connection) = ULocalConnectionToClient.CreateLocalConnections();
+            connection.isAuthenticated = true;
+            connection.connectionToServer.isAuthenticated = true;
+
             // set a client handler
             int called = 0;
             connection.connectionToServer.RegisterHandler<TestMessage>(msg => ++called);
@@ -675,6 +680,8 @@ namespace Mirror.Tests
             // add connection
             (_, ULocalConnectionToClient connection) = ULocalConnectionToClient.CreateLocalConnections();
             connection.isReady = true;
+            connection.isAuthenticated = true;
+            connection.connectionToServer.isAuthenticated = true;
             // set a client handler
             int called = 0;
             connection.connectionToServer.RegisterHandler<SpawnMessage>(msg => ++called);
@@ -714,6 +721,8 @@ namespace Mirror.Tests
             // add connection
             (_, ULocalConnectionToClient connection) = ULocalConnectionToClient.CreateLocalConnections();
             connection.isReady = true;
+            connection.isAuthenticated = true;
+            connection.connectionToServer.isAuthenticated = true;
             // set a client handler
             int called = 0;
             connection.connectionToServer.RegisterHandler<ObjectHideMessage>(msg => ++called);


### PR DESCRIPTION
Now you register handles with NetworkConnection instead of NetworkClient/NetworkServer

This resolves the broken abstraction at NetworkConnection level.  Now NetworkConnection deals with sending and receiving messages,  it knows how to encode and decode them with no help from the caller.