### PR TITLE
Improve test coverage of NetworkDiagnostics class

### DIFF
--- a/Assets/Mirror/Runtime/NetworkDiagnostics.cs
+++ b/Assets/Mirror/Runtime/NetworkDiagnostics.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 
 namespace Mirror
 {
@@ -53,7 +54,7 @@ namespace Mirror
             if (count > 0 && OutMessageEvent != null)
             {
                 var outMessage = new MessageInfo(message, channel, bytes, count);
-                OutMessageEvent?.Invoke(outMessage);
+                OutMessageEvent.Invoke(outMessage);
             }
         }
         #endregion
@@ -71,7 +72,7 @@ namespace Mirror
             if (InMessageEvent != null)
             {
                 var inMessage = new MessageInfo(message, channel, bytes, 1);
-                InMessageEvent?.Invoke(inMessage);
+                InMessageEvent.Invoke(inMessage);
             }
         }
 

--- a/Assets/Mirror/Runtime/NetworkDiagnostics.cs
+++ b/Assets/Mirror/Runtime/NetworkDiagnostics.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Diagnostics;
 
 namespace Mirror
 {

--- a/Assets/Mirror/Tests/Editor/NetworkDiagnosticsTests.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkDiagnosticsTests.cs
@@ -1,0 +1,51 @@
+using System;
+using NUnit.Framework;
+using NSubstitute;
+
+namespace Mirror.Tests
+{
+    [TestFixture(Category = "NetworkDiagnostics")]
+    public class NetworkDiagnosticsTests
+    {
+        [Test]
+        public void TestOnSendEvent()
+        {
+            Action<NetworkDiagnostics.MessageInfo> outMessageCallback = Substitute.For<Action<NetworkDiagnostics.MessageInfo>>();
+            NetworkDiagnostics.OutMessageEvent += outMessageCallback;
+
+            var message = new TestMessage();
+            NetworkDiagnostics.OnSend(message, Channels.DefaultReliable, 10, 5);
+            var expected = new NetworkDiagnostics.MessageInfo(message, Channels.DefaultReliable, 10, 5);
+            outMessageCallback.Received(1).Invoke(Arg.Is(expected));
+
+            NetworkDiagnostics.OutMessageEvent -= outMessageCallback;
+        }
+
+        [Test]
+        public void TestOnSendZeroCountEvent()
+        {
+            Action<NetworkDiagnostics.MessageInfo> outMessageCallback = Substitute.For<Action<NetworkDiagnostics.MessageInfo>>();
+            NetworkDiagnostics.OutMessageEvent += outMessageCallback;
+
+            var message = new TestMessage();
+            NetworkDiagnostics.OnSend(message, Channels.DefaultReliable, 10, 0);
+            outMessageCallback.DidNotReceive();
+
+            NetworkDiagnostics.OutMessageEvent -= outMessageCallback;
+        }
+
+        [Test]
+        public void TestOnReceiveEvent()
+        {
+            Action<NetworkDiagnostics.MessageInfo> outMessageCallback = Substitute.For<Action<NetworkDiagnostics.MessageInfo>>();
+            NetworkDiagnostics.InMessageEvent += outMessageCallback;
+
+            var message = new TestMessage();
+            NetworkDiagnostics.OnReceive(message, Channels.DefaultReliable, 10);
+            var expected = new NetworkDiagnostics.MessageInfo(message, Channels.DefaultReliable, 10, 1);
+            outMessageCallback.Received(1).Invoke(Arg.Is(expected));
+
+            NetworkDiagnostics.InMessageEvent -= outMessageCallback;
+        }
+    }
+}

--- a/Assets/Mirror/Tests/Editor/NetworkDiagnosticsTests.cs.meta
+++ b/Assets/Mirror/Tests/Editor/NetworkDiagnosticsTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c0838922faec45c588bd7e291691cf28
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This class had a bit of coverage based on the testing of other classes.
With this PR it's fully covered with specific tests for it's functionality.

Additionally, there was an redundant null propagation operator where the events where being called that was removed. The event was called from inside a if block that checked for a null event.