### PR TITLE
refactor: NetworkConnection now receives Transport in constructor

### DIFF
--- a/Assets/Mirror/Runtime/LocalConnections.cs
+++ b/Assets/Mirror/Runtime/LocalConnections.cs
@@ -10,7 +10,7 @@ namespace Mirror
     {
         internal ULocalConnectionToServer connectionToServer { get; private set; }
 
-        private ULocalConnectionToClient() : base(0)
+        private ULocalConnectionToClient() : base(0, null)
         {
         }
 
@@ -63,7 +63,7 @@ namespace Mirror
     {
         internal ULocalConnectionToClient connectionToClient { get; }
 
-        internal ULocalConnectionToServer(ULocalConnectionToClient connectionToClient)
+        internal ULocalConnectionToServer(ULocalConnectionToClient connectionToClient) : base(null)
         {
             this.connectionToClient = connectionToClient;
         }

--- a/Assets/Mirror/Runtime/NetworkClient.cs
+++ b/Assets/Mirror/Runtime/NetworkClient.cs
@@ -141,7 +141,7 @@ namespace Mirror
             await Transport.activeTransport.ClientConnectAsync(serverIp);
 
             // setup all the handlers
-            connection = new NetworkConnectionToServer();
+            connection = new NetworkConnectionToServer(Transport.activeTransport);
             connection.SetHandlers(handlers);
             OnConnected();
         }
@@ -163,7 +163,7 @@ namespace Mirror
             await Transport.activeTransport.ClientConnectAsync(uri);
 
             // setup all the handlers
-            connection = new NetworkConnectionToServer();
+            connection = new NetworkConnectionToServer(Transport.activeTransport);
             connection.SetHandlers(handlers);
             OnConnected();
         }

--- a/Assets/Mirror/Runtime/NetworkConnection.cs
+++ b/Assets/Mirror/Runtime/NetworkConnection.cs
@@ -63,6 +63,11 @@ namespace Mirror
         public float lastMessageTime;
 
         /// <summary>
+        /// The transport used in this connection
+        /// </summary>
+        public Transport transport { get; internal set; }
+
+        /// <summary>
         /// The NetworkIdentity for this connection.
         /// </summary>
         public NetworkIdentity identity { get; internal set; }
@@ -89,15 +94,18 @@ namespace Mirror
         /// <summary>
         /// Creates a new NetworkConnection with the specified address
         /// </summary>
-        internal NetworkConnection()
+        /// <param name="networkTransport">Transport that will be used in this connection</param>
+        internal NetworkConnection(Transport networkTransport)
         {
+            transport = networkTransport;
         }
 
         /// <summary>
         /// Creates a new NetworkConnection with the specified address and connectionId
         /// </summary>
         /// <param name="networkConnectionId"></param>
-        internal NetworkConnection(int networkConnectionId)
+        /// <param name="networkTransport">Transport that will be used in this connection</param>
+        internal NetworkConnection(int networkConnectionId, Transport networkTransport) : this(networkTransport)
         {
             connectionId = networkConnectionId;
         }

--- a/Assets/Mirror/Runtime/NetworkConnectionToClient.cs
+++ b/Assets/Mirror/Runtime/NetworkConnectionToClient.cs
@@ -21,7 +21,7 @@ namespace Mirror
             if (logNetworkMessages) Debug.Log("ConnectionSend " + this + " bytes:" + BitConverter.ToString(segment.Array, segment.Offset, segment.Count));
 
             singleConnectionId[0] = connectionId;
-            return Transport.activeTransport.ServerSend(singleConnectionId, channelId, segment);
+            return transport.ServerSend(singleConnectionId, channelId, segment);
         }
 
         // Send to many. basically Transport.Send(connections) + checks.

--- a/Assets/Mirror/Runtime/NetworkConnectionToClient.cs
+++ b/Assets/Mirror/Runtime/NetworkConnectionToClient.cs
@@ -6,7 +6,7 @@ namespace Mirror
 {
     public class NetworkConnectionToClient : NetworkConnection
     {
-        public NetworkConnectionToClient(int networkConnectionId) : base(networkConnectionId)
+        public NetworkConnectionToClient(int networkConnectionId, Transport networkTransport) : base(networkConnectionId, networkTransport)
         {
         }
 

--- a/Assets/Mirror/Runtime/NetworkConnectionToServer.cs
+++ b/Assets/Mirror/Runtime/NetworkConnectionToServer.cs
@@ -15,7 +15,7 @@ namespace Mirror
         {
             if (logNetworkMessages) Debug.Log("ConnectionSend " + this + " bytes:" + BitConverter.ToString(segment.Array, segment.Offset, segment.Count));
 
-            return Transport.activeTransport.ClientSend(channelId, segment);
+            return transport.ClientSend(channelId, segment);
         }
 
         /// <summary>
@@ -29,7 +29,7 @@ namespace Mirror
             // TODO: This does not work if there is no player yet
             if (identity != null)
                 identity.client.HandleClientDisconnect(this);
-            Transport.activeTransport.ClientDisconnect();
+            transport.ClientDisconnect();
         }
     }
 }

--- a/Assets/Mirror/Runtime/NetworkConnectionToServer.cs
+++ b/Assets/Mirror/Runtime/NetworkConnectionToServer.cs
@@ -7,6 +7,10 @@ namespace Mirror
     {
         public override string address => "";
 
+        public NetworkConnectionToServer(Transport networkTransport) : base(networkTransport)
+        {
+        }
+
         protected override bool Send(ArraySegment<byte> segment, int channelId = Channels.DefaultReliable)
         {
             if (logNetworkMessages) Debug.Log("ConnectionSend " + this + " bytes:" + BitConverter.ToString(segment.Array, segment.Offset, segment.Count));

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -402,7 +402,7 @@ namespace Mirror
             if (connections.Count < MaxConnections)
             {
                 // add connection
-                var conn = new NetworkConnectionToClient(connectionId);
+                var conn = new NetworkConnectionToClient(connectionId, Transport.activeTransport);
                 OnConnected(conn);
             }
             else

--- a/Assets/Mirror/Tests/Editor/NetworkIdentityTests.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkIdentityTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using NSubstitute;
 using NUnit.Framework;
@@ -328,11 +328,11 @@ namespace Mirror.Tests
             identity.OnStartServer();
 
             // add an observer connection
-            var connection = new NetworkConnectionToClient(42);
+            var connection = new NetworkConnectionToClient(42, Transport.activeTransport);
             identity.observers.Add(connection);
 
             // RemoveObserverInternal with invalid connection should do nothing
-            identity.RemoveObserverInternal(new NetworkConnectionToClient(43));
+            identity.RemoveObserverInternal(new NetworkConnectionToClient(43, Transport.activeTransport));
             Assert.That(identity.observers.Count, Is.EqualTo(1));
 
             // RemoveObserverInternal with existing connection should remove it
@@ -549,7 +549,7 @@ namespace Mirror.Tests
             // add component
             CheckObserverExceptionNetworkBehaviour compExc = gameObject.AddComponent<CheckObserverExceptionNetworkBehaviour>();
 
-            NetworkConnection connection = new NetworkConnectionToClient(42);
+            NetworkConnection connection = new NetworkConnectionToClient(42, Transport.activeTransport);
 
             // an exception in OnCheckObserver should be caught, so that one
             // component's exception doesn't stop all other components from
@@ -761,8 +761,8 @@ namespace Mirror.Tests
 
             identity.server = server;
             // create some connections
-            var connection1 = new NetworkConnectionToClient(42);
-            var connection2 = new NetworkConnectionToClient(43);
+            var connection1 = new NetworkConnectionToClient(42, Transport.activeTransport);
+            var connection2 = new NetworkConnectionToClient(43, Transport.activeTransport);
 
             // AddObserver should return early if called before .observers was
             // created
@@ -793,8 +793,8 @@ namespace Mirror.Tests
             identity.OnStartServer();
 
             // add some observers
-            identity.observers.Add(new NetworkConnectionToClient(42));
-            identity.observers.Add(new NetworkConnectionToClient(43));
+            identity.observers.Add(new NetworkConnectionToClient(42, Transport.activeTransport));
+            identity.observers.Add(new NetworkConnectionToClient(43, Transport.activeTransport));
 
             // call ClearObservers
             identity.ClearObservers();
@@ -809,9 +809,9 @@ namespace Mirror.Tests
             // creates .observers and generates a netId
             identity.OnStartServer();
             uint netId = identity.netId;
-            identity.connectionToClient = new NetworkConnectionToClient(1);
-            identity.connectionToServer = new NetworkConnectionToServer();
-            identity.observers.Add( new NetworkConnectionToClient(2));
+            identity.connectionToClient = new NetworkConnectionToClient(1, Transport.activeTransport);
+            identity.connectionToServer = new NetworkConnectionToServer(Transport.activeTransport);
+            identity.observers.Add( new NetworkConnectionToClient(2, Transport.activeTransport));
 
             // calling reset shouldn't do anything unless it was marked for reset
             identity.Reset();
@@ -907,9 +907,9 @@ namespace Mirror.Tests
         {
             // add components
             RebuildObserversNetworkBehaviour compA = gameObject.AddComponent<RebuildObserversNetworkBehaviour>();
-            compA.observer = new NetworkConnectionToClient(12);
+            compA.observer = new NetworkConnectionToClient(12, Transport.activeTransport);
             RebuildObserversNetworkBehaviour compB = gameObject.AddComponent<RebuildObserversNetworkBehaviour>();
-            compB.observer = new NetworkConnectionToClient(13);
+            compB.observer = new NetworkConnectionToClient(13, Transport.activeTransport);
 
             // get new observers
             var observers = new HashSet<NetworkConnection>();
@@ -926,7 +926,7 @@ namespace Mirror.Tests
             // get new observers. no observer components so it should just clear
             // it and not do anything else
             var observers = new HashSet<NetworkConnection>();
-            observers.Add(new NetworkConnectionToClient(42));
+            observers.Add(new NetworkConnectionToClient(42, Transport.activeTransport));
             identity.GetNewObservers(observers, true);
             Assert.That(observers.Count, Is.EqualTo(0));
         }
@@ -943,8 +943,8 @@ namespace Mirror.Tests
         [Test]
         public void AddAllReadyServerConnectionsToObservers()
         {
-            var connection1 = new NetworkConnectionToClient(12) { isReady = true };
-            var connection2 = new NetworkConnectionToClient(13) { isReady = false };
+            var connection1 = new NetworkConnectionToClient(12, Transport.activeTransport) { isReady = true };
+            var connection2 = new NetworkConnectionToClient(13, Transport.activeTransport) { isReady = false };
             // add some server connections
             server.connections[12] = connection1;
             server.connections[13] = connection2;

--- a/Assets/Mirror/Tests/Play/NetworkIdentityTests.cs
+++ b/Assets/Mirror/Tests/Play/NetworkIdentityTests.cs
@@ -1,4 +1,4 @@
-﻿using NSubstitute;
+using NSubstitute;
 using NUnit.Framework;
 using UnityEngine;
 using InvalidOperationException = System.InvalidOperationException;
@@ -152,7 +152,7 @@ namespace Mirror.Tests
             // another connection
             InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() =>
             {
-                identity.AssignClientAuthority(new NetworkConnectionToClient(43));
+                identity.AssignClientAuthority(new NetworkConnectionToClient(43, Transport.activeTransport));
             });
             Assert.That(ex.Message, Is.EqualTo("AssignClientAuthority for " + gameObject + " already has an owner. Use RemoveClientAuthority() first"));
         }

--- a/Assets/Mirror/Tests/Play/NetworkServerTest.cs
+++ b/Assets/Mirror/Tests/Play/NetworkServerTest.cs
@@ -282,7 +282,7 @@ namespace Mirror.Tests
             Assert.That(server.connections.Count, Is.EqualTo(0));
 
             // add first connection
-            var conn42 = new NetworkConnectionToClient(42);
+            var conn42 = new NetworkConnectionToClient(42, Transport.activeTransport);
             bool result42 = server.AddConnection(conn42);
             Assert.That(result42, Is.True);
             Assert.That(server.connections.Count, Is.EqualTo(1));
@@ -290,7 +290,7 @@ namespace Mirror.Tests
             Assert.That(server.connections[42], Is.EqualTo(conn42));
 
             // add second connection
-            var conn43 = new NetworkConnectionToClient(43);
+            var conn43 = new NetworkConnectionToClient(43, Transport.activeTransport);
             bool result43 = server.AddConnection(conn43);
             Assert.That(result43, Is.True);
             Assert.That(server.connections.Count, Is.EqualTo(2));
@@ -300,7 +300,7 @@ namespace Mirror.Tests
             Assert.That(server.connections[43], Is.EqualTo(conn43));
 
             // add duplicate connectionId
-            var connDup = new NetworkConnectionToClient(42);
+            var connDup = new NetworkConnectionToClient(42, Transport.activeTransport);
             bool resultDup = server.AddConnection(connDup);
             Assert.That(resultDup, Is.False);
             Assert.That(server.connections.Count, Is.EqualTo(2));
@@ -322,7 +322,7 @@ namespace Mirror.Tests
             Assert.That(server.connections.Count, Is.EqualTo(0));
 
             // add connection
-            var conn42 = new NetworkConnectionToClient(42);
+            var conn42 = new NetworkConnectionToClient(42, Transport.activeTransport);
             bool result42 = server.AddConnection(conn42);
             Assert.That(result42, Is.True);
             Assert.That(server.connections.Count, Is.EqualTo(1));
@@ -347,7 +347,7 @@ namespace Mirror.Tests
             Assert.That(server.connections.Count, Is.EqualTo(0));
 
             // add connection
-            var conn42 = new NetworkConnectionToClient(42);
+            var conn42 = new NetworkConnectionToClient(42, Transport.activeTransport);
             server.AddConnection(conn42);
             Assert.That(server.connections.Count, Is.EqualTo(1));
 
@@ -371,7 +371,7 @@ namespace Mirror.Tests
             Assert.That(server.localConnection, Is.Not.Null);
 
             // add connection
-            var conn42 = new NetworkConnectionToClient(42);
+            var conn42 = new NetworkConnectionToClient(42, Transport.activeTransport);
             server.AddConnection(conn42);
             Assert.That(server.connections.Count, Is.EqualTo(1));
 
@@ -403,7 +403,7 @@ namespace Mirror.Tests
             Assert.That(server.connections.Count, Is.EqualTo(0));
 
             // add a connection
-            var connection = new NetworkConnectionToClient(42);
+            var connection = new NetworkConnectionToClient(42, Transport.activeTransport);
             server.AddConnection(connection);
             Assert.That(server.connections.Count, Is.EqualTo(1));
 
@@ -609,7 +609,7 @@ namespace Mirror.Tests
             Assert.That(server.connections.Count, Is.EqualTo(0));
 
             // add a connection
-            var connection = new NetworkConnectionToClient(42);
+            var connection = new NetworkConnectionToClient(42, Transport.activeTransport);
             server.AddConnection(connection);
             Assert.That(server.connections.Count, Is.EqualTo(1));
 

--- a/ProjectSettings/EditorBuildSettings.asset
+++ b/ProjectSettings/EditorBuildSettings.asset
@@ -4,5 +4,8 @@
 EditorBuildSettings:
   m_ObjectHideFlags: 0
   serializedVersion: 2
-  m_Scenes: []
+  m_Scenes:
+  - enabled: 1
+    path: Assets/Mirror/Examples/Tanks/Scenes/Scene.unity
+    guid: 83f9d2fb76f5742448c6e51f258327a2
   m_configObjects: {}


### PR DESCRIPTION
First step for the removal of Transport.activeTransport (#91).

The class NetworkConnection now requires a Transport to be passed on the constructor. For now it's being passed Transport.activeTransport, or null on the LocalConnections.

**Tested**:
- [x] Editor
- [x] Playmode
- [x] Basic
- [x] Chat
- [x] Pong
- [x] Tanks
- [ ] Aditive
- [ ] Room
- [ ] List
- [ ] Discovery