### PR TITLE
feat: synclists has individual meaningful events

### DIFF
--- a/Assets/Mirror/Tests/Editor/SyncListStructTest.cs
+++ b/Assets/Mirror/Tests/Editor/SyncListStructTest.cs
@@ -1,3 +1,5 @@
+using System;
+using NSubstitute;
 using NUnit.Framework;
 
 namespace Mirror.Tests
@@ -7,8 +9,8 @@ namespace Mirror.Tests
         [Test]
         public void ListIsDirtyWhenModifingAndSettingStruct()
         {
-            SyncListTestPlayer serverList = new SyncListTestPlayer();
-            SyncListTestPlayer clientList = new SyncListTestPlayer();
+            var serverList = new SyncListTestPlayer();
+            var clientList = new SyncListTestPlayer();
             SyncListTest.SerializeAllTo(serverList, clientList);
             serverList.Add(new TestPlayer { item = new TestItem { price = 10 } });
             SyncListTest.SerializeDeltaTo(serverList, clientList);
@@ -19,34 +21,6 @@ namespace Mirror.Tests
             serverList[0] = player;
 
             Assert.That(serverList.IsDirty, Is.True);
-        }
-
-
-        [Test]
-        public void OldValueShouldNotBeNewValue()
-        {
-            SyncListTestPlayer serverList = new SyncListTestPlayer();
-            SyncListTestPlayer clientList = new SyncListTestPlayer();
-            SyncListTest.SerializeAllTo(serverList, clientList);
-            serverList.Add(new TestPlayer { item = new TestItem { price = 10 } });
-            SyncListTest.SerializeDeltaTo(serverList, clientList);
-
-            TestPlayer player = serverList[0];
-            player.item.price = 15;
-            serverList[0] = player;
-
-            bool callbackCalled = false;
-            clientList.Callback += (SyncList<TestPlayer>.Operation op, int itemIndex, TestPlayer oldItem, TestPlayer newItem) =>
-            {
-                Assert.That(op == SyncList<TestPlayer>.Operation.OP_SET, Is.True);
-                Assert.That(itemIndex, Is.EqualTo(0));
-                Assert.That(oldItem.item.price, Is.EqualTo(10));
-                Assert.That(newItem.item.price, Is.EqualTo(15));
-                callbackCalled = true;
-            };
-
-            SyncListTest.SerializeDeltaTo(serverList, clientList);
-            Assert.IsTrue(callbackCalled);
         }
     }
 


### PR DESCRIPTION
fixes #103

BREAKING CHANGE: Sync lists no longer have a Callback event with an operation enum