### PR TITLE
feat: individual events for SyncSet

### DIFF
--- a/Assets/Mirror/Runtime/SyncSet.cs
+++ b/Assets/Mirror/Runtime/SyncSet.cs
@@ -14,7 +14,30 @@ namespace Mirror
 
         public int Count => objects.Count;
         public bool IsReadOnly { get; private set; }
-        public event SyncSetChanged Callback;
+
+        /// <summary>
+        /// Raised when an element is added to the list.
+        /// Receives the new item
+        /// </summary>
+        public event Action<T> OnAdd;
+
+        /// <summary>
+        /// Raised when the set is cleared
+        /// </summary>
+        public event Action OnClear;
+
+        /// <summary>
+        /// Raised when an item is removed from the set
+        /// receives the old item
+        /// </summary>
+        public event Action<T> OnRemove;
+
+        /// <summary>
+        /// Raised after the set has been updated
+        /// Note that if there are multiple changes
+        /// this event is only raised once.
+        /// </summary>
+        public event Action OnChange;
 
         public enum Operation : byte
         {
@@ -65,7 +88,25 @@ namespace Mirror
 
             changes.Add(change);
 
-            Callback?.Invoke(op, item);
+            RaiseEvents(op, item);
+
+            OnChange?.Invoke();
+        }
+
+        private void RaiseEvents(Operation op, T item)
+        {
+            switch (op)
+            {
+                case Operation.OP_ADD:
+                    OnAdd?.Invoke(item);
+                    break;
+                case Operation.OP_CLEAR:
+                    OnClear?.Invoke();
+                    break;
+                case Operation.OP_REMOVE:
+                    OnRemove?.Invoke(item);
+                    break;
+            }
         }
 
         void AddOperation(Operation op) => AddOperation(op, default);
@@ -140,6 +181,7 @@ namespace Mirror
         {
             // This list can now only be modified by synchronization
             IsReadOnly = true;
+            bool raiseOnChange = false;
 
             int changesCount = (int)reader.ReadPackedUInt32();
 
@@ -180,13 +222,19 @@ namespace Mirror
 
                 if (apply)
                 {
-                    Callback?.Invoke(operation, item);
+                    RaiseEvents(operation, item);
+                    raiseOnChange = true;
                 }
                 // we just skipped this change
                 else
                 {
                     changesAhead--;
                 }
+            }
+
+            if (raiseOnChange)
+            {
+                OnChange?.Invoke();
             }
         }
 

--- a/Assets/Mirror/Runtime/SyncSet.cs
+++ b/Assets/Mirror/Runtime/SyncSet.cs
@@ -8,8 +8,6 @@ namespace Mirror
     [EditorBrowsable(EditorBrowsableState.Never)]
     public abstract class SyncSet<T> : ISet<T>, ISyncObject
     {
-        public delegate void SyncSetChanged(Operation op, T item);
-
         protected readonly ISet<T> objects;
 
         public int Count => objects.Count;

--- a/Assets/Mirror/Runtime/SyncSet.cs
+++ b/Assets/Mirror/Runtime/SyncSet.cs
@@ -37,7 +37,7 @@ namespace Mirror
         /// </summary>
         public event Action OnChange;
 
-        public enum Operation : byte
+        private enum Operation : byte
         {
             OP_ADD,
             OP_CLEAR,

--- a/Assets/Mirror/Tests/Editor/SyncSetTest.cs
+++ b/Assets/Mirror/Tests/Editor/SyncSetTest.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using NSubstitute;
 using NUnit.Framework;
 
 namespace Mirror.Tests
@@ -91,40 +92,44 @@ namespace Mirror.Tests
         }
 
         [Test]
-        public void CallbackTest()
+        public void AddClientCallbackTest()
         {
-            bool called = false;
-
-            clientSyncSet.Callback += (op, item) =>
-            {
-                called = true;
-
-                Assert.That(op, Is.EqualTo(SyncSetString.Operation.OP_ADD));
-                Assert.That(item, Is.EqualTo("yay"));
-            };
-
+            Action<string> callback = Substitute.For<Action<string>>();
+            clientSyncSet.OnAdd += callback;
             serverSyncSet.Add("yay");
             SerializeDeltaTo(serverSyncSet, clientSyncSet);
-
-            Assert.That(called, Is.True);
+            callback.Received().Invoke("yay");
         }
 
         [Test]
-        public void CallbackRemoveTest()
+        public void RemoveClientCallbackTest()
         {
-            bool called = false;
-
-            clientSyncSet.Callback += (op, item) =>
-            {
-                called = true;
-
-                Assert.That(op, Is.EqualTo(SyncSetString.Operation.OP_REMOVE));
-                Assert.That(item, Is.EqualTo("World"));
-            };
+            Action<string> callback = Substitute.For<Action<string>>();
+            clientSyncSet.OnRemove += callback;
             serverSyncSet.Remove("World");
             SerializeDeltaTo(serverSyncSet, clientSyncSet);
+            callback.Received().Invoke("World");
+        }
 
-            Assert.That(called, Is.True);
+        [Test]
+        public void ClearClientCallbackTest()
+        {
+            Action callback = Substitute.For<Action>();
+            clientSyncSet.OnClear += callback;
+            serverSyncSet.Clear();
+            SerializeDeltaTo(serverSyncSet, clientSyncSet);
+            callback.Received().Invoke();
+        }
+
+        [Test]
+        public void ChangeClientCallbackTest()
+        {
+            Action callback = Substitute.For<Action>();
+            clientSyncSet.OnChange += callback;
+            serverSyncSet.Add("1");
+            serverSyncSet.Add("2");
+            SerializeDeltaTo(serverSyncSet, clientSyncSet);
+            callback.Received(1).Invoke();
         }
 
         [Test]


### PR DESCRIPTION
Fixes #104 

BREAKING CHANGE: SyncSet no longer have a Callback event with an operation enum