### PR TITLE
Improve LocalConnection coverage

### DIFF
--- a/Assets/Mirror/Runtime/LocalConnections.cs
+++ b/Assets/Mirror/Runtime/LocalConnections.cs
@@ -79,8 +79,7 @@ namespace Mirror
         {
             if (segment.Count == 0)
             {
-                Debug.LogError("LocalConnection.SendBytes cannot send zero bytes");
-                return false;
+                throw new InvalidMessageException("LocalConnection.Send cannot send zero bytes");
             }
 
             // handle the server's message directly

--- a/Assets/Mirror/Runtime/LocalConnections.cs
+++ b/Assets/Mirror/Runtime/LocalConnections.cs
@@ -16,7 +16,7 @@ namespace Mirror
 
         public override string address => "localhost";
 
-        protected override bool Send(ArraySegment<byte> segment, int channelId = Channels.DefaultReliable)
+        internal override bool Send(ArraySegment<byte> segment, int channelId = Channels.DefaultReliable)
         {
             // LocalConnection doesn't support allocation-free sends yet.
             // previously we allocated in Mirror. now we do it here.
@@ -75,7 +75,7 @@ namespace Mirror
 
         public override string address => "localhost";
 
-        protected override bool Send(ArraySegment<byte> segment, int channelId = Channels.DefaultReliable)
+        internal override bool Send(ArraySegment<byte> segment, int channelId = Channels.DefaultReliable)
         {
             if (segment.Count == 0)
             {

--- a/Assets/Mirror/Runtime/NetworkConnection.cs
+++ b/Assets/Mirror/Runtime/NetworkConnection.cs
@@ -252,7 +252,7 @@ namespace Mirror
 
         // internal because no one except Mirror should send bytes directly to
         // the client. they would be detected as a message. send messages instead.
-        protected abstract bool Send(ArraySegment<byte> segment, int channelId = Channels.DefaultReliable);
+        internal abstract bool Send(ArraySegment<byte> segment, int channelId = Channels.DefaultReliable);
 
         // cache the Send(connectionIds) list to avoid allocating each time
         static readonly List<int> connectionIdsCache = new List<int>();

--- a/Assets/Mirror/Runtime/NetworkConnectionToClient.cs
+++ b/Assets/Mirror/Runtime/NetworkConnectionToClient.cs
@@ -16,7 +16,7 @@ namespace Mirror
         // the client. they would be detected as a message. send messages instead.
         readonly List<int> singleConnectionId = new List<int> { -1 };
 
-        protected override bool Send(ArraySegment<byte> segment, int channelId = Channels.DefaultReliable)
+        internal override bool Send(ArraySegment<byte> segment, int channelId = Channels.DefaultReliable)
         {
             if (logNetworkMessages) Debug.Log("ConnectionSend " + this + " bytes:" + BitConverter.ToString(segment.Array, segment.Offset, segment.Count));
 

--- a/Assets/Mirror/Runtime/NetworkConnectionToServer.cs
+++ b/Assets/Mirror/Runtime/NetworkConnectionToServer.cs
@@ -7,7 +7,7 @@ namespace Mirror
     {
         public override string address => "";
 
-        protected override bool Send(ArraySegment<byte> segment, int channelId = Channels.DefaultReliable)
+        internal override bool Send(ArraySegment<byte> segment, int channelId = Channels.DefaultReliable)
         {
             if (logNetworkMessages) Debug.Log("ConnectionSend " + this + " bytes:" + BitConverter.ToString(segment.Array, segment.Offset, segment.Count));
 

--- a/Assets/Mirror/Tests/Editor/LocalConnectionTest.cs
+++ b/Assets/Mirror/Tests/Editor/LocalConnectionTest.cs
@@ -1,10 +1,10 @@
 using System;
-using System.Collections.Generic;
 using NUnit.Framework;
-using UnityEngine.TestTools;
+using UnityEngine;
 
 namespace Mirror.Tests
 {
+    [Category("LocalConnection")]
     public class LocalConnectionTest
     {
 
@@ -27,6 +27,24 @@ namespace Mirror.Tests
         public void Disconnect()
         {
             connectionToServer.Disconnect();
+        }
+
+        [Test]
+        public void LocalConnectionToClientAddressTest()
+        {
+            Assert.That(connectionToClient.address, Is.EqualTo("localhost"));
+        }
+
+        [Test]
+        public void LocalConnectionToServerAddressTest()
+        {
+            Assert.That(connectionToServer.address, Is.EqualTo("localhost"));
+        }
+
+        [Test]
+        public void ClientToServerFailTest()
+        {
+            Assert.Throws<InvalidMessageException>( () => connectionToServer.Send(new ArraySegment<byte>(new byte[0])));
         }
 
         /*[Test]


### PR DESCRIPTION
- Make NetworkConnection.Send(ArraySegment<byte>, int channelId) internal to be able to test (the comment above the method says it's supposed to be internal not protected);
- Cover the last few lines in LocalConnection.cs that where not covered by other tests.

Should commented tests in LocalConnectionTest.cs be removed?