### PR TITLE
Make it so that observers can't be null

### DIFF
--- a/Assets/Mirror/Editor/NetworkInformationPreview.cs
+++ b/Assets/Mirror/Editor/NetworkInformationPreview.cs
@@ -172,7 +172,7 @@ namespace Mirror
 
         private float DrawObservers(NetworkIdentity identity, float initialX, float Y)
         {
-            if (identity.observers != null && identity.observers.Count > 0)
+            if (identity.observers.Count > 0)
             {
                 var observerRect = new Rect(initialX, Y + 10, 200, 20);
 

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -286,7 +286,7 @@ namespace Mirror
         {
             if (LogFilter.Debug) Debug.Log("Server.SendToObservers id:" + typeof(T));
 
-            if (identity.observers != null)
+            if (identity.observers.Count > 0)
                 NetworkConnection.Send(identity.observers, msg, channelId);
         }
 

--- a/Assets/Mirror/Tests/Editor/NetworkIdentityTests.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkIdentityTests.cs
@@ -714,15 +714,6 @@ namespace Mirror.Tests
             var connection1 = new NetworkConnection(null);
             var connection2 = new NetworkConnection(null);
 
-            // AddObserver should return early if called before .observers was
-            // created
-            Assert.That(identity.observers, Is.Null);
-            // error log is expected
-            LogAssert.ignoreFailingMessages = true;
-            identity.AddObserver(connection1);
-            LogAssert.ignoreFailingMessages = false;
-            Assert.That(identity.observers, Is.Null);
-
             // call OnStartServer so that observers dict is created
             identity.StartServer();
 


### PR DESCRIPTION
Null should not be used if possible.  This eliminates potential NRE accessing observers