### PR TITLE
fix: Invoke server.Disconnected before identity is removed for its conn

### DIFF
--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -414,9 +414,9 @@ namespace Mirror
 
             RemoveConnection(connection);
 
-            DestroyPlayerForConnection(connection);
-
             Disconnected.Invoke(connection);
+
+            DestroyPlayerForConnection(connection);
 
             if (connection == localConnection)
                 localConnection = null;


### PR DESCRIPTION
Identity may be needed eg. if we need to save player data on database when disconnecting