### PR TITLE
Remove NetworkClient.localplayer

### DIFF
--- a/Assets/Mirror/Runtime/NetworkClient.cs
+++ b/Assets/Mirror/Runtime/NetworkClient.cs
@@ -49,7 +49,7 @@ namespace Mirror
         /// <summary>
         /// NetworkIdentity of the localPlayer
         /// </summary>
-        public NetworkIdentity LocalPlayer { get; private set; }
+        public NetworkIdentity LocalPlayer => Connection?.Identity;
 
         internal ConnectState connectState = ConnectState.None;
 
@@ -357,7 +357,6 @@ namespace Mirror
             Destroy(Connection.Identity.gameObject);
 
             Connection.Identity = null;
-            LocalPlayer = null;
 
             return true;
         }
@@ -399,10 +398,6 @@ namespace Mirror
         internal void InternalAddPlayer(NetworkIdentity identity)
         {
             if (LogFilter.Debug) Debug.LogWarning("ClientScene.InternalAddPlayer");
-
-            // NOTE: It can be "normal" when changing scenes for the player to be destroyed and recreated.
-            // But, the player structures are not cleaned up, we'll just replace the old player
-            LocalPlayer = identity;
 
             if (Connection != null)
             {

--- a/Assets/Mirror/Tests/Runtime/NetworkClientTest.cs
+++ b/Assets/Mirror/Tests/Runtime/NetworkClientTest.cs
@@ -130,12 +130,10 @@ namespace Mirror.Tests
 
             yield return null;
 
-            Assert.That(client.Connection.Identity != null);
             Assert.That(client.LocalPlayer != null);
 
             Assert.That(client.RemovePlayer());
             Assert.That(identity == null);
-            Assert.That(client.Connection.Identity == null);
             Assert.That(client.LocalPlayer == null);
         }
 


### PR DESCRIPTION
This is redundant and possible source of bugs.  You can get the
local player by calling NetworkClient.Connection.Identity