### PR TITLE
apply Interface Segregation Principle to NetworkConnection

### DIFF
--- a/Assets/Mirror/Authenticators/BasicAuthenticator.cs
+++ b/Assets/Mirror/Authenticators/BasicAuthenticator.cs
@@ -27,13 +27,13 @@ namespace Mirror.Authenticators
             public string Message;
         }
 
-        public override void OnServerAuthenticate(NetworkConnection conn)
+        public override void OnServerAuthenticate(INetworkConnection conn)
         {
             // wait for AuthRequestMessage from client
             conn.RegisterHandler<AuthRequestMessage>(OnAuthRequestMessage);
         }
 
-        public override void OnClientAuthenticate(NetworkConnection conn)
+        public override void OnClientAuthenticate(INetworkConnection conn)
         {
             conn.RegisterHandler<AuthResponseMessage>(OnAuthResponseMessage);
 
@@ -46,7 +46,7 @@ namespace Mirror.Authenticators
             conn.Send(authRequestMessage);
         }
 
-        public void OnAuthRequestMessage(NetworkConnection conn, AuthRequestMessage msg)
+        public void OnAuthRequestMessage(INetworkConnection conn, AuthRequestMessage msg)
         {
             Debug.LogFormat("Authentication Request: {0} {1}", msg.AuthUsername, msg.AuthPassword);
 
@@ -81,13 +81,13 @@ namespace Mirror.Authenticators
             }
         }
 
-        public IEnumerator DelayedDisconnect(NetworkConnection conn, float waitTime)
+        public IEnumerator DelayedDisconnect(INetworkConnection conn, float waitTime)
         {
             yield return new WaitForSeconds(waitTime);
             conn.Disconnect();
         }
 
-        public void OnAuthResponseMessage(NetworkConnection conn, AuthResponseMessage msg)
+        public void OnAuthResponseMessage(INetworkConnection conn, AuthResponseMessage msg)
         {
             if (msg.Code == 100)
             {

--- a/Assets/Mirror/Authenticators/TimeoutAuthenticator.cs
+++ b/Assets/Mirror/Authenticators/TimeoutAuthenticator.cs
@@ -22,21 +22,21 @@ namespace Mirror.Authenticators
             Authenticator.OnServerAuthenticated += HandleServerAuthenticated;
         }
 
-        private readonly HashSet<NetworkConnection> pendingAuthentication = new HashSet<NetworkConnection>();
+        private readonly HashSet<INetworkConnection> pendingAuthentication = new HashSet<INetworkConnection>();
 
-        private void HandleServerAuthenticated(NetworkConnection connection)
+        private void HandleServerAuthenticated(INetworkConnection connection)
         {
             pendingAuthentication.Remove(connection);
             base.OnClientAuthenticate(connection);
         }
 
-        private void HandleClientAuthenticated(NetworkConnection connection)
+        private void HandleClientAuthenticated(INetworkConnection connection)
         {
             pendingAuthentication.Remove(connection);
             base.OnServerAuthenticate(connection);
         }
 
-        public override void OnClientAuthenticate(NetworkConnection conn)
+        public override void OnClientAuthenticate(INetworkConnection conn)
         {
             pendingAuthentication.Add(conn);
             Authenticator.OnClientAuthenticate(conn);
@@ -45,7 +45,7 @@ namespace Mirror.Authenticators
                 StartCoroutine(BeginAuthentication(conn));
         }
 
-        public override void OnServerAuthenticate(NetworkConnection conn)
+        public override void OnServerAuthenticate(INetworkConnection conn)
         {
             pendingAuthentication.Add(conn);
             Authenticator.OnServerAuthenticate(conn);
@@ -53,7 +53,7 @@ namespace Mirror.Authenticators
                 StartCoroutine(BeginAuthentication(conn));
         }
 
-        IEnumerator BeginAuthentication(NetworkConnection conn)
+        IEnumerator BeginAuthentication(INetworkConnection conn)
         {
             if (LogFilter.Debug) Debug.Log($"Authentication countdown started {conn} {Timeout}");
 

--- a/Assets/Mirror/Components/NetworkProximityChecker.cs
+++ b/Assets/Mirror/Components/NetworkProximityChecker.cs
@@ -83,7 +83,7 @@ namespace Mirror
         /// </summary>
         /// <param name="conn">NetworkConnection of player object</param>
         /// <returns>True if object is within visible range</returns>
-        public override bool OnCheckObserver(NetworkConnection conn)
+        public override bool OnCheckObserver(INetworkConnection conn)
         {
             if (ForceHidden)
                 return false;
@@ -97,7 +97,7 @@ namespace Mirror
         /// <param name="observers">List of players to be updated.  Modify this set with all the players that can see this object</param>
         /// <param name="initialize">True if this is the first time the method is called for this object</param>
         /// <returns>True if this component calculated the list of observers</returns>
-        public override bool OnRebuildObservers(HashSet<NetworkConnection> observers, bool initialize)
+        public override bool OnRebuildObservers(HashSet<INetworkConnection> observers, bool initialize)
         {
             // if force hidden then return without adding any observers.
             if (ForceHidden)
@@ -122,7 +122,7 @@ namespace Mirror
             return true;
         }
 
-        void Add3DHits(HashSet<NetworkConnection> observers)
+        void Add3DHits(HashSet<INetworkConnection> observers)
         {
             // cast without allocating GC for maximum performance
             int hitCount = Physics.OverlapSphereNonAlloc(transform.position, VisibilityRange, hitsBuffer3D, CastLayers);
@@ -142,7 +142,7 @@ namespace Mirror
             }
         }
 
-        void Add2DHits(HashSet<NetworkConnection> observers)
+        void Add2DHits(HashSet<INetworkConnection> observers)
         {
             // cast without allocating GC for maximum performance
             int hitCount = Physics2D.OverlapCircleNonAlloc(transform.position, VisibilityRange, hitsBuffer2D, CastLayers);

--- a/Assets/Mirror/Components/NetworkSceneChecker.cs
+++ b/Assets/Mirror/Components/NetworkSceneChecker.cs
@@ -84,7 +84,7 @@ namespace Mirror
         /// </summary>
         /// <param name="newObserver">NetworkConnection of player object</param>
         /// <returns>True if object is in the same scene</returns>
-        public override bool OnCheckObserver(NetworkConnection conn)
+        public override bool OnCheckObserver(INetworkConnection conn)
         {
             if (forceHidden)
                 return false;
@@ -94,7 +94,7 @@ namespace Mirror
 
         // Always return true when overriding OnRebuildObservers so that
         // Mirror knows not to use the built in rebuild method.
-        public override bool OnRebuildObservers(HashSet<NetworkConnection> observers, bool initialize)
+        public override bool OnRebuildObservers(HashSet<INetworkConnection> observers, bool initialize)
         {
             // If forceHidden then return true without adding any observers.
             if (forceHidden)

--- a/Assets/Mirror/Editor/NetworkInformationPreview.cs
+++ b/Assets/Mirror/Editor/NetworkInformationPreview.cs
@@ -181,7 +181,7 @@ namespace Mirror
                 observerRect.x += 20;
                 observerRect.y += observerRect.height;
 
-                foreach (NetworkConnection conn in identity.observers)
+                foreach (INetworkConnection conn in identity.observers)
                 {
 
                     GUI.Label(observerRect, conn.Address + ":" + conn, styles.ComponentName);

--- a/Assets/Mirror/Editor/Weaver/Processors/NetworkBehaviourProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/NetworkBehaviourProcessor.cs
@@ -788,7 +788,7 @@ namespace Mirror.Weaver
                     return false;
                 }
                 // TargetRPC is an exception to this rule and can have a NetworkConnection as first parameter
-                if (p.ParameterType.FullName == Weaver.NetworkConnectionType.FullName &&
+                if (p.ParameterType.FullName == Weaver.INetworkConnectionType.FullName &&
                     !(ca.AttributeType.FullName == Weaver.TargetRpcType.FullName && i == 0))
                 {
                     Weaver.Error($"{md} has invalid parameer {p}. Cannot pass NeworkConnections");

--- a/Assets/Mirror/Editor/Weaver/Processors/TargetRpcProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/TargetRpcProcessor.cs
@@ -12,7 +12,7 @@ namespace Mirror.Weaver
         public static bool HasNetworkConnectionParameter(MethodDefinition md)
         {
             return md.Parameters.Count > 0 &&
-                   md.Parameters[0].ParameterType.FullName == Weaver.NetworkConnectionType.FullName;
+                   md.Parameters[0].ParameterType.FullName == Weaver.INetworkConnectionType.FullName;
         }
 
         public static MethodDefinition ProcessTargetRpcInvoke(TypeDefinition td, MethodDefinition md, MethodDefinition rpcCallFunc)

--- a/Assets/Mirror/Editor/Weaver/Weaver.cs
+++ b/Assets/Mirror/Editor/Weaver/Weaver.cs
@@ -42,7 +42,7 @@ namespace Mirror.Weaver
         public static TypeReference NetworkBehaviourType2;
         public static TypeReference MonoBehaviourType;
         public static TypeReference ScriptableObjectType;
-        public static TypeReference NetworkConnectionType;
+        public static TypeReference INetworkConnectionType;
 
         public static TypeReference MessageBaseType;
         public static TypeReference IMessageBaseType;
@@ -271,7 +271,8 @@ namespace Mirror.Weaver
 
             NetworkBehaviourType = NetAssembly.MainModule.GetType("Mirror.NetworkBehaviour");
             NetworkBehaviourType2 = CurrentAssembly.MainModule.ImportReference(NetworkBehaviourType);
-            NetworkConnectionType = NetAssembly.MainModule.GetType("Mirror.NetworkConnection");
+            INetworkConnectionType = NetAssembly.MainModule.GetType("Mirror.INetworkConnection");
+            INetworkConnectionType = CurrentAssembly.MainModule.ImportReference(INetworkConnectionType);
 
             NetworkBehaviourGetIdentity = Resolvers.ResolveMethod(NetworkBehaviourType, CurrentAssembly, "get_NetIdentity");
             NetworkIdentityGetServer = Resolvers.ResolveMethod(NetworkIdentityType, CurrentAssembly, "get_Server");
@@ -288,8 +289,6 @@ namespace Mirror.Weaver
                 ScriptableObjectType, CurrentAssembly,
                 md => md.Name == "CreateInstance" && md.HasGenericParameters);
 
-            NetworkConnectionType = NetAssembly.MainModule.GetType("Mirror.NetworkConnection");
-            NetworkConnectionType = CurrentAssembly.MainModule.ImportReference(NetworkConnectionType);
 
             MessageBaseType = NetAssembly.MainModule.GetType("Mirror.MessageBase");
             IMessageBaseType = NetAssembly.MainModule.GetType("Mirror.IMessageBase");

--- a/Assets/Mirror/Examples/AdditiveScenes/Scripts/ShootingTankBehaviour.cs
+++ b/Assets/Mirror/Examples/AdditiveScenes/Scripts/ShootingTankBehaviour.cs
@@ -36,7 +36,7 @@ namespace Mirror.Examples.Additive
             GameObject target = null;
             float distance = 100f;
 
-            foreach (NetworkConnection networkConnection in NetIdentity.observers)
+            foreach (INetworkConnection networkConnection in NetIdentity.observers)
             {
                 GameObject tempTarget = networkConnection.Identity.gameObject;
                 float tempDistance = Vector3.Distance(tempTarget.transform.position, transform.position);

--- a/Assets/Mirror/Examples/Chat/Scripts/ChatNetworkManager.cs
+++ b/Assets/Mirror/Examples/Chat/Scripts/ChatNetworkManager.cs
@@ -21,18 +21,18 @@ namespace Mirror.Examples.Chat
             public string name;
         }
 
-        public override void OnServerConnect(NetworkConnection conn)
+        public override void OnServerConnect(INetworkConnection conn)
         {
             conn.RegisterHandler<CreatePlayerMessage>(OnCreatePlayer);
         }
 
-        public void OnAuthenticated(NetworkConnection conn)
+        public void OnAuthenticated(INetworkConnection conn)
         {
             // tell the server to create a player with this name
             conn.Send(new CreatePlayerMessage { name = PlayerName });
         }
 
-        private void OnCreatePlayer(NetworkConnection connection, CreatePlayerMessage createPlayerMessage)
+        private void OnCreatePlayer(INetworkConnection connection, CreatePlayerMessage createPlayerMessage)
         {
             // create a gameobject using the name supplied by client
             GameObject playergo = Instantiate(playerPrefab).gameObject;

--- a/Assets/Mirror/Examples/Pong/Scripts/PaddleSpawner.cs
+++ b/Assets/Mirror/Examples/Pong/Scripts/PaddleSpawner.cs
@@ -10,7 +10,7 @@ namespace Mirror.Examples.Pong
 
         GameObject ball;
 
-        public override void OnServerAddPlayer(NetworkConnection conn)
+        public override void OnServerAddPlayer(INetworkConnection conn)
         {
             // add player at correct spawn position
             Transform start = server.NumPlayers == 0 ? leftRacketSpawn : rightRacketSpawn;
@@ -26,7 +26,7 @@ namespace Mirror.Examples.Pong
         }
 
 
-        public void OnServerDisconnect(NetworkConnection conn)
+        public void OnServerDisconnect(INetworkConnection conn)
         {
             // destroy ball
             if (ball != null)

--- a/Assets/Mirror/Runtime/INetworkConnection.cs
+++ b/Assets/Mirror/Runtime/INetworkConnection.cs
@@ -4,14 +4,11 @@ using System.Threading.Tasks;
 
 namespace Mirror
 {
-    public interface INetworkConnection
+    /// <summary>
+    /// An object that can send and receive messages
+    /// </summary>
+    public interface IMessageHandler
     {
-        NetworkIdentity Identity { get; set; }
-        bool IsReady { get; set; }
-        EndPoint Address { get; }
-
-        void Disconnect();
-
         void RegisterHandler<T>(Action<INetworkConnection, T> handler)
                 where T : IMessageBase, new();
 
@@ -25,13 +22,40 @@ namespace Mirror
 
         Task SendAsync<T>(T msg, int channelId = Channels.DefaultReliable) where T : IMessageBase;
 
-        string ToString();
         Task ProcessMessagesAsync();
+
+    }
+
+    /// <summary>
+    /// An object that can observe NetworkIdentities.
+    /// this is useful for interest management
+    /// </summary>
+    public interface IVisibilityTracker
+    {
         void AddToVisList(NetworkIdentity identity);
         void RemoveFromVisList(NetworkIdentity identity);
+        void RemoveObservers();
+    }
+
+    /// <summary>
+    /// An object that can own networked objects
+    /// </summary>
+    public interface IObjectOwner
+    {
+        NetworkIdentity Identity { get; set; }
         void RemoveOwnedObject(NetworkIdentity networkIdentity);
         void AddOwnedObject(NetworkIdentity networkIdentity);
-        void RemoveObservers();
         void DestroyOwnedObjects();
+    }
+
+    /// <summary>
+    /// A connection to a remote endpoint.
+    /// May be from the server to client or from client to server
+    /// </summary>
+    public interface INetworkConnection : IMessageHandler, IVisibilityTracker, IObjectOwner
+    {
+        bool IsReady { get; set; }
+        EndPoint Address { get; }
+        void Disconnect();
     }
 }

--- a/Assets/Mirror/Runtime/INetworkConnection.cs
+++ b/Assets/Mirror/Runtime/INetworkConnection.cs
@@ -1,13 +1,18 @@
 using System;
+using System.Net;
 using System.Threading.Tasks;
 
 namespace Mirror
 {
     public interface INetworkConnection
     {
+        NetworkIdentity Identity { get; set; }
+        bool IsReady { get; set; }
+        EndPoint Address { get; }
+
         void Disconnect();
 
-        void RegisterHandler<T>(Action<NetworkConnection, T> handler)
+        void RegisterHandler<T>(Action<INetworkConnection, T> handler)
                 where T : IMessageBase, new();
 
         void RegisterHandler<T>(Action<T> handler) where T : IMessageBase, new();
@@ -21,5 +26,12 @@ namespace Mirror
         Task SendAsync<T>(T msg, int channelId = Channels.DefaultReliable) where T : IMessageBase;
 
         string ToString();
+        Task ProcessMessagesAsync();
+        void AddToVisList(NetworkIdentity identity);
+        void RemoveFromVisList(NetworkIdentity identity);
+        void RemoveOwnedObject(NetworkIdentity networkIdentity);
+        void AddOwnedObject(NetworkIdentity networkIdentity);
+        void RemoveObservers();
+        void DestroyOwnedObjects();
     }
 }

--- a/Assets/Mirror/Runtime/NetworkAuthenticator.cs
+++ b/Assets/Mirror/Runtime/NetworkAuthenticator.cs
@@ -12,17 +12,17 @@ namespace Mirror
         /// <summary>
         /// Notify subscribers on the server when a client is authenticated
         /// </summary>
-        public event Action<NetworkConnection> OnServerAuthenticated;
+        public event Action<INetworkConnection> OnServerAuthenticated;
 
         /// <summary>
         /// Notify subscribers on the client when the client is authenticated
         /// </summary>
-        public event Action<NetworkConnection> OnClientAuthenticated;
+        public event Action<INetworkConnection> OnClientAuthenticated;
 
         #region server
 
         // This will get more code in the near future
-        internal void OnServerAuthenticateInternal(NetworkConnection conn)
+        internal void OnServerAuthenticateInternal(INetworkConnection conn)
         {
             OnServerAuthenticate(conn);
         }
@@ -31,7 +31,7 @@ namespace Mirror
         /// Called on server from OnServerAuthenticateInternal when a client needs to authenticate
         /// </summary>
         /// <param name="conn">Connection to client.</param>
-        public virtual void OnServerAuthenticate(NetworkConnection conn)
+        public virtual void OnServerAuthenticate(INetworkConnection conn)
         {
             OnServerAuthenticated?.Invoke(conn);
         }
@@ -41,7 +41,7 @@ namespace Mirror
         #region client
 
         // This will get more code in the near future
-        internal void OnClientAuthenticateInternal(NetworkConnection conn)
+        internal void OnClientAuthenticateInternal(INetworkConnection conn)
         {
             OnClientAuthenticate(conn);
         }
@@ -50,7 +50,7 @@ namespace Mirror
         /// Called on client from OnClientAuthenticateInternal when a client needs to authenticate
         /// </summary>
         /// <param name="conn">Connection of the client.</param>
-        public virtual void OnClientAuthenticate(NetworkConnection conn)
+        public virtual void OnClientAuthenticate(INetworkConnection conn)
         {
             OnClientAuthenticated?.Invoke(conn);
         }

--- a/Assets/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirror/Runtime/NetworkBehaviour.cs
@@ -97,12 +97,12 @@ namespace Mirror
         /// <summary>
         /// The <see cref="NetworkConnection">NetworkConnection</see> associated with this <see cref="NetworkIdentity">NetworkIdentity.</see> This is only valid for player objects on the server.
         /// </summary>
-        public NetworkConnection ConnectionToServer => NetIdentity.ConnectionToServer;
+        public INetworkConnection ConnectionToServer => NetIdentity.ConnectionToServer;
 
         /// <summary>
         /// The <see cref="NetworkConnection">NetworkConnection</see> associated with this <see cref="NetworkIdentity">NetworkIdentity.</see> This is only valid for player objects on the server.
         /// </summary>
-        public NetworkConnection ConnectionToClient => NetIdentity.ConnectionToClient;
+        public INetworkConnection ConnectionToClient => NetIdentity.ConnectionToClient;
 
         public NetworkTime NetworkTime => IsClient ? Client.Time : Server.Time;
 
@@ -279,7 +279,7 @@ namespace Mirror
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        protected void SendTargetRpcInternal(NetworkConnection conn, Type invokeClass, string rpcName, NetworkWriter writer, int channelId)
+        protected void SendTargetRpcInternal(INetworkConnection conn, Type invokeClass, string rpcName, NetworkWriter writer, int channelId)
         {
             // this was in Weaver before
             if (!Server.Active)
@@ -820,7 +820,7 @@ namespace Mirror
         /// <param name="observers">The new set of observers for this object.</param>
         /// <param name="initialize">True if the set of observers is being built for the first time.</param>
         /// <returns>true when overwriting so that Mirror knows that we wanted to rebuild observers ourselves. otherwise it uses built in rebuild.</returns>
-        public virtual bool OnRebuildObservers(HashSet<NetworkConnection> observers, bool initialize)
+        public virtual bool OnRebuildObservers(HashSet<INetworkConnection> observers, bool initialize)
         {
             return false;
         }
@@ -838,7 +838,7 @@ namespace Mirror
         /// </summary>
         /// <param name="conn">Network connection of a player.</param>
         /// <returns>True if the player can see this object.</returns>
-        public virtual bool OnCheckObserver(NetworkConnection conn)
+        public virtual bool OnCheckObserver(INetworkConnection conn)
         {
             return true;
         }

--- a/Assets/Mirror/Runtime/NetworkClient.cs
+++ b/Assets/Mirror/Runtime/NetworkClient.cs
@@ -35,7 +35,7 @@ namespace Mirror
         readonly Dictionary<Guid, SpawnHandlerDelegate> spawnHandlers = new Dictionary<Guid, SpawnHandlerDelegate>();
         readonly Dictionary<Guid, UnSpawnDelegate> unspawnHandlers = new Dictionary<Guid, UnSpawnDelegate>();
 
-        [Serializable] public class NetworkConnectionEvent : UnityEvent<NetworkConnection> { }
+        [Serializable] public class NetworkConnectionEvent : UnityEvent<INetworkConnection> { }
 
         public NetworkConnectionEvent Connected = new NetworkConnectionEvent();
         public NetworkConnectionEvent Authenticated = new NetworkConnectionEvent();
@@ -44,7 +44,7 @@ namespace Mirror
         /// <summary>
         /// The NetworkConnection object this client is using.
         /// </summary>
-        public NetworkConnection Connection { get; internal set; }
+        public INetworkConnection Connection { get; internal set; }
 
         /// <summary>
         /// NetworkIdentity of the localPlayer
@@ -229,7 +229,7 @@ namespace Mirror
 
         }
 
-        public void OnAuthenticated(NetworkConnection conn)
+        public void OnAuthenticated(INetworkConnection conn)
         {
             Authenticated?.Invoke(conn);
         }
@@ -272,7 +272,7 @@ namespace Mirror
             }
         }
 
-        internal void RegisterHostHandlers(NetworkConnection connection)
+        internal void RegisterHostHandlers(INetworkConnection connection)
         {
             connection.RegisterHandler<ObjectDestroyMessage>(OnHostClientObjectDestroy);
             connection.RegisterHandler<ObjectHideMessage>(OnHostClientObjectHide);
@@ -287,7 +287,7 @@ namespace Mirror
             connection.RegisterHandler<SyncEventMessage>(OnSyncEventMessage);
         }
 
-        internal void RegisterMessageHandlers(NetworkConnection connection)
+        internal void RegisterMessageHandlers(INetworkConnection connection)
         {
             connection.RegisterHandler<ObjectDestroyMessage>(OnObjectDestroy);
             connection.RegisterHandler<ObjectHideMessage>(OnObjectHide);
@@ -367,7 +367,7 @@ namespace Mirror
         /// </summary>
         /// <param name="conn">The client connection which is ready.</param>
         /// <returns>True if succcessful</returns>
-        public void Ready(NetworkConnection conn)
+        public void Ready(INetworkConnection conn)
         {
             if (ready)
             {

--- a/Assets/Mirror/Runtime/NetworkConnection.cs
+++ b/Assets/Mirror/Runtime/NetworkConnection.cs
@@ -208,10 +208,17 @@ namespace Mirror
                 var segment = writer.ToArraySegment();
                 int count = 0;
 
-                foreach (NetworkConnection conn in connections)
+                foreach (INetworkConnection conn in connections)
                 {
-                    // send to all connections, but don't wait for them
-                    _ = conn.SendAsync(segment);
+                    if (conn is NetworkConnection networkConnection)
+                    {
+                        // send to all connections, but don't wait for them
+                        _ = networkConnection.SendAsync(segment, channelId);
+                    }
+                    else
+                    {
+                        _ = conn.SendAsync(msg, channelId);
+                    }
                     count++;
                 }
 

--- a/Assets/Mirror/Runtime/NetworkConnection.cs
+++ b/Assets/Mirror/Runtime/NetworkConnection.cs
@@ -20,7 +20,7 @@ namespace Mirror
     public class NetworkConnection : INetworkConnection
     {
         // Handles network messages on client and server
-        private delegate void NetworkMessageDelegate(NetworkConnection conn, NetworkReader reader, int channelId);
+        private delegate void NetworkMessageDelegate(INetworkConnection conn, NetworkReader reader, int channelId);
 
 
         // internal so it can be tested
@@ -61,7 +61,7 @@ namespace Mirror
         /// <summary>
         /// The NetworkIdentity for this connection.
         /// </summary>
-        public NetworkIdentity Identity { get; internal set; }
+        public NetworkIdentity Identity { get; set; }
 
         /// <summary>
         /// A list of the NetworkIdentity objects owned by this connection. This list is read-only.
@@ -89,10 +89,10 @@ namespace Mirror
             connection.Disconnect();
         }
 
-        private static NetworkMessageDelegate MessageHandler<T>(Action<NetworkConnection, T> handler)
+        private static NetworkMessageDelegate MessageHandler<T>(Action<INetworkConnection, T> handler)
             where T : IMessageBase, new()
         {
-            void AdapterFunction(NetworkConnection conn, NetworkReader reader, int channelId)
+            void AdapterFunction(INetworkConnection conn, NetworkReader reader, int channelId)
             {
                 // protect against DOS attacks if attackers try to send invalid
                 // data packets to crash the server/client. there are a thousand
@@ -128,7 +128,7 @@ namespace Mirror
         /// <typeparam name="T">Message type</typeparam>
         /// <param name="handler">Function handler which will be invoked for when this message type is received.</param>
         /// <param name="requireAuthentication">True if the message requires an authenticated connection</param>
-        public void RegisterHandler<T>(Action<NetworkConnection, T> handler)
+        public void RegisterHandler<T>(Action<INetworkConnection, T> handler)
             where T : IMessageBase, new()
         {
             int msgType = MessagePacker.GetId<T>();
@@ -199,7 +199,7 @@ namespace Mirror
             }
         }
 
-        public static void Send<T>(IEnumerable<NetworkConnection> connections, T msg, int channelId = Channels.DefaultReliable) where T : IMessageBase
+        public static void Send<T>(IEnumerable<INetworkConnection> connections, T msg, int channelId = Channels.DefaultReliable) where T : IMessageBase
         {
             using (PooledNetworkWriter writer = NetworkWriterPool.GetWriter())
             {
@@ -231,17 +231,17 @@ namespace Mirror
             return $"connection({Address})";
         }
 
-        internal void AddToVisList(NetworkIdentity identity)
+        public void AddToVisList(NetworkIdentity identity)
         {
             visList.Add(identity);
         }
 
-        internal void RemoveFromVisList(NetworkIdentity identity)
+        public void RemoveFromVisList(NetworkIdentity identity)
         {
             visList.Remove(identity);
         }
 
-        internal void RemoveObservers()
+        public void RemoveObservers()
         {
             foreach (NetworkIdentity identity in visList)
             {
@@ -289,17 +289,17 @@ namespace Mirror
             }
         }
 
-        internal void AddOwnedObject(NetworkIdentity obj)
+        public void AddOwnedObject(NetworkIdentity obj)
         {
             clientOwnedObjects.Add(obj);
         }
 
-        internal void RemoveOwnedObject(NetworkIdentity obj)
+        public void RemoveOwnedObject(NetworkIdentity obj)
         {
             clientOwnedObjects.Remove(obj);
         }
 
-        internal void DestroyOwnedObjects()
+        public void DestroyOwnedObjects()
         {
             // create a copy because the list might be modified when destroying
             var tmp = new HashSet<NetworkIdentity>(clientOwnedObjects);
@@ -315,7 +315,7 @@ namespace Mirror
             clientOwnedObjects.Clear();
         }
 
-        internal async Task ProcessMessagesAsync()
+        public async Task ProcessMessagesAsync()
         {
             var buffer = new MemoryStream();
 

--- a/Assets/Mirror/Runtime/NetworkConnection.cs
+++ b/Assets/Mirror/Runtime/NetworkConnection.cs
@@ -296,14 +296,14 @@ namespace Mirror
             }
         }
 
-        public void AddOwnedObject(NetworkIdentity obj)
+        public void AddOwnedObject(NetworkIdentity networkIdentity)
         {
-            clientOwnedObjects.Add(obj);
+            clientOwnedObjects.Add(networkIdentity);
         }
 
-        public void RemoveOwnedObject(NetworkIdentity obj)
+        public void RemoveOwnedObject(NetworkIdentity networkIdentity)
         {
-            clientOwnedObjects.Remove(obj);
+            clientOwnedObjects.Remove(networkIdentity);
         }
 
         public void DestroyOwnedObjects()

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -867,7 +867,7 @@ namespace Mirror
 
         internal void ClearObservers()
         {
-            foreach (NetworkConnection conn in observers)
+            foreach (INetworkConnection conn in observers)
             {
                 conn.RemoveFromVisList(this);
             }
@@ -915,7 +915,7 @@ namespace Mirror
         internal void AddAllReadyServerConnectionsToObservers()
         {
             // add all server connections
-            foreach (NetworkConnection conn in Server.connections)
+            foreach (INetworkConnection conn in Server.connections)
             {
                 if (conn.IsReady)
                     AddObserver(conn);
@@ -964,7 +964,7 @@ namespace Mirror
             }
 
             // add all newObservers that aren't in .observers yet
-            foreach (NetworkConnection conn in newObservers)
+            foreach (INetworkConnection conn in newObservers)
             {
                 // only add ready connections.
                 // otherwise the player might not be in the world yet or anymore

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -87,7 +87,7 @@ namespace Mirror
         /// The set of network connections (players) that can see this object.
         /// <para>null until OnStartServer was called. this is necessary for SendTo* to work properly in server-only mode.</para>
         /// </summary>
-        public readonly HashSet<NetworkConnection> observers = new HashSet<NetworkConnection>();
+        public readonly HashSet<INetworkConnection> observers = new HashSet<INetworkConnection>();
 
         /// <summary>
         /// Unique identifier for this particular object instance, used for tracking objects between networked clients and the server.
@@ -117,20 +117,20 @@ namespace Mirror
         /// <summary>
         /// The NetworkConnection associated with this NetworkIdentity. This is only valid for player objects on a local client.
         /// </summary>
-        public NetworkConnection ConnectionToServer { get; internal set; }
+        public INetworkConnection ConnectionToServer { get; internal set; }
 
         /// <summary>
         /// The NetworkClient associated with this NetworkIdentity.
         /// </summary>
         public NetworkClient Client { get; internal set; }
 
-        NetworkConnection _connectionToClient;
+        INetworkConnection _connectionToClient;
 
         /// <summary>
         /// The NetworkConnection associated with this <see cref="NetworkIdentity">NetworkIdentity.</see> This is valid for player and other owned objects in the server.
         /// <para>Use it to return details such as the connection&apos;s identity, IP address and ready status.</para>
         /// </summary>
-        public NetworkConnection ConnectionToClient
+        public INetworkConnection ConnectionToClient
         {
             get => _connectionToClient;
 
@@ -248,7 +248,7 @@ namespace Mirror
         public static NetworkIdentity GetSceneIdentity(ulong id) => sceneIds[id];
 
         // used when adding players
-        internal void SetClientOwner(NetworkConnection conn)
+        internal void SetClientOwner(INetworkConnection conn)
         {
             // do nothing if it already has an owner
             if (ConnectionToClient != null && conn != ConnectionToClient)
@@ -274,7 +274,7 @@ namespace Mirror
         /// <param name="conn">The network connection that is gaining or losing authority.</param>
         /// <param name="identity">The object whose client authority status is being changed.</param>
         /// <param name="authorityState">The new state of client authority of the object for the connection.</param>
-        public delegate void ClientAuthorityCallback(NetworkConnection conn, NetworkIdentity identity, bool authorityState);
+        public delegate void ClientAuthorityCallback(INetworkConnection conn, NetworkIdentity identity, bool authorityState);
 
         /// <summary>
         /// A callback that can be populated to be notified when the client-authority state of objects changes.
@@ -284,7 +284,7 @@ namespace Mirror
         public static event ClientAuthorityCallback clientAuthorityCallback;
 
         // this is used when a connection is destroyed, since the "observers" property is read-only
-        internal void RemoveObserverInternal(NetworkConnection conn)
+        internal void RemoveObserverInternal(INetworkConnection conn)
         {
             observers.Remove(conn);
         }
@@ -639,7 +639,7 @@ namespace Mirror
             }
         }
 
-        internal bool OnCheckObserver(NetworkConnection conn)
+        internal bool OnCheckObserver(INetworkConnection conn)
         {
             foreach (NetworkBehaviour comp in NetworkBehaviours)
             {
@@ -874,7 +874,7 @@ namespace Mirror
             observers.Clear();
         }
 
-        internal void AddObserver(NetworkConnection conn)
+        internal void AddObserver(INetworkConnection conn)
         {
             if (observers.Contains(conn))
             {
@@ -896,7 +896,7 @@ namespace Mirror
         // -> returns true if any of the components implemented
         //    OnRebuildObservers, false otherwise
         // -> initialize is true on first rebuild, false on consecutive rebuilds
-        internal bool GetNewObservers(HashSet<NetworkConnection> observersSet, bool initialize)
+        internal bool GetNewObservers(HashSet<INetworkConnection> observersSet, bool initialize)
         {
             bool rebuildOverwritten = false;
             observersSet.Clear();
@@ -928,7 +928,7 @@ namespace Mirror
             }
         }
 
-        static readonly HashSet<NetworkConnection> newObservers = new HashSet<NetworkConnection>();
+        static readonly HashSet<INetworkConnection> newObservers = new HashSet<INetworkConnection>();
 
         /// <summary>
         /// This causes the set of players that can see this object to be rebuild. The OnRebuildObservers callback function will be invoked on each NetworkBehaviour.
@@ -983,7 +983,7 @@ namespace Mirror
             }
 
             // remove all old .observers that aren't in newObservers anymore
-            foreach (NetworkConnection conn in observers)
+            foreach (INetworkConnection conn in observers)
             {
                 if (!newObservers.Contains(conn))
                 {
@@ -999,7 +999,7 @@ namespace Mirror
             if (changed)
             {
                 observers.Clear();
-                foreach (NetworkConnection conn in newObservers)
+                foreach (INetworkConnection conn in newObservers)
                 {
                     if (conn != null && conn.IsReady)
                         observers.Add(conn);
@@ -1042,7 +1042,7 @@ namespace Mirror
         /// <para>Authority can be removed with RemoveClientAuthority. Only one client can own an object at any time. This does not need to be called for player objects, as their authority is setup automatically.</para>
         /// </summary>
         /// <param name="conn">	The connection of the client to assign authority to.</param>
-        public void AssignClientAuthority(NetworkConnection conn)
+        public void AssignClientAuthority(INetworkConnection conn)
         {
             if (!IsServer)
             {
@@ -1089,7 +1089,7 @@ namespace Mirror
             {
                 clientAuthorityCallback?.Invoke(ConnectionToClient, this, false);
 
-                NetworkConnection previousOwner = ConnectionToClient;
+                INetworkConnection previousOwner = ConnectionToClient;
 
                 ConnectionToClient = null;
 

--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -628,14 +628,14 @@ namespace Mirror
 
         #region Server Internal Message Handlers
 
-        void RegisterServerMessages(NetworkConnection connection)
+        void RegisterServerMessages(INetworkConnection connection)
         {
             connection.RegisterHandler<ReadyMessage>(OnServerReadyMessageInternal);
             connection.RegisterHandler<RemovePlayerMessage>(OnServerRemovePlayerMessageInternal);
         }
 
         // called after successful authentication
-        void OnServerAuthenticated(NetworkConnection conn)
+        void OnServerAuthenticated(INetworkConnection conn)
         {
             // a connection has been established,  register for our messages
             RegisterServerMessages(conn);
@@ -652,13 +652,13 @@ namespace Mirror
             OnServerConnect(conn);
         }
 
-        void OnServerReadyMessageInternal(NetworkConnection conn, ReadyMessage msg)
+        void OnServerReadyMessageInternal(INetworkConnection conn, ReadyMessage msg)
         {
             if (LogFilter.Debug) Debug.Log("NetworkManager.OnServerReadyMessageInternal");
             OnServerReady(conn);
         }
 
-        void OnServerRemovePlayerMessageInternal(NetworkConnection conn, RemovePlayerMessage msg)
+        void OnServerRemovePlayerMessageInternal(INetworkConnection conn, RemovePlayerMessage msg)
         {
             if (LogFilter.Debug) Debug.Log("NetworkManager.OnServerRemovePlayerMessageInternal");
 
@@ -673,14 +673,14 @@ namespace Mirror
 
         #region Client Internal Message Handlers
 
-        void RegisterClientMessages(NetworkConnection connection)
+        void RegisterClientMessages(INetworkConnection connection)
         {
             connection.RegisterHandler<NotReadyMessage>(OnClientNotReadyMessageInternal);
             connection.RegisterHandler<SceneMessage>(OnClientSceneInternal);
         }
 
         // called after successful authentication
-        void OnClientAuthenticated(NetworkConnection conn)
+        void OnClientAuthenticated(INetworkConnection conn)
         {
             RegisterClientMessages(conn);
 
@@ -691,7 +691,7 @@ namespace Mirror
             client.Connection = conn;
         }
 
-        void OnClientNotReadyMessageInternal(NetworkConnection conn, NotReadyMessage msg)
+        void OnClientNotReadyMessageInternal(INetworkConnection conn, NotReadyMessage msg)
         {
             if (LogFilter.Debug) Debug.Log("NetworkManager.OnClientNotReadyMessageInternal");
 
@@ -701,7 +701,7 @@ namespace Mirror
             // NOTE: clientReadyConnection is not set here! don't want OnClientConnect to be invoked again after scene changes.
         }
 
-        void OnClientSceneInternal(NetworkConnection conn, SceneMessage msg)
+        void OnClientSceneInternal(INetworkConnection conn, SceneMessage msg)
         {
             if (LogFilter.Debug) Debug.Log("NetworkManager.OnClientSceneInternal");
 
@@ -720,7 +720,7 @@ namespace Mirror
         /// <para>Unity calls this on the Server when a Client connects to the Server. Use an override to tell the NetworkManager what to do when a client connects to the server.</para>
         /// </summary>
         /// <param name="conn">Connection from client.</param>
-        public virtual void OnServerConnect(NetworkConnection conn) { }
+        public virtual void OnServerConnect(INetworkConnection conn) { }
 
 
         /// <summary>
@@ -728,7 +728,7 @@ namespace Mirror
         /// <para>The default implementation of this function calls NetworkServer.SetClientReady() to continue the network setup process.</para>
         /// </summary>
         /// <param name="conn">Connection from client.</param>
-        public virtual void OnServerReady(NetworkConnection conn)
+        public virtual void OnServerReady(INetworkConnection conn)
         {
             if (conn.Identity == null)
             {
@@ -745,7 +745,7 @@ namespace Mirror
         /// </summary>
         /// <param name="conn">The connection to remove the player from.</param>
         /// <param name="player">The player identity to remove.</param>
-        public virtual void OnServerRemovePlayer(NetworkConnection conn, NetworkIdentity player)
+        public virtual void OnServerRemovePlayer(INetworkConnection conn, NetworkIdentity player)
         {
             if (player.gameObject != null)
             {
@@ -775,7 +775,7 @@ namespace Mirror
         /// <para>This is commonly used when switching scenes.</para>
         /// </summary>
         /// <param name="conn">Connection to the server.</param>
-        public virtual void OnClientNotReady(NetworkConnection conn) { }
+        public virtual void OnClientNotReady(INetworkConnection conn) { }
 
         /// <summary>
         /// Called from ClientChangeScene immediately before SceneManager.LoadSceneAsync is executed
@@ -791,7 +791,7 @@ namespace Mirror
         /// <para>Scene changes can cause player objects to be destroyed. The default implementation of OnClientSceneChanged in the NetworkManager is to add a player object for the connection if no player object exists.</para>
         /// </summary>
         /// <param name="conn">The network connection that the scene change message arrived on.</param>
-        public virtual void OnClientSceneChanged(NetworkConnection conn)
+        public virtual void OnClientSceneChanged(INetworkConnection conn)
         {
             // always become ready.
             if (!client.ready)

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -23,7 +23,7 @@ namespace Mirror
     {
         bool initialized;
 
-        [Serializable] public class NetworkConnectionEvent : UnityEvent<NetworkConnection> { }
+        [Serializable] public class INetworkConnectionEvent : UnityEvent<INetworkConnection> { }
 
         /// <summary>
         /// The maximum number of concurrent network connections to support.
@@ -38,9 +38,9 @@ namespace Mirror
         /// </summary>
         public UnityEvent Started = new UnityEvent();
 
-        public NetworkConnectionEvent Connected = new NetworkConnectionEvent();
-        public NetworkConnectionEvent Authenticated = new NetworkConnectionEvent();
-        public NetworkConnectionEvent Disconnected = new NetworkConnectionEvent();
+        public INetworkConnectionEvent Connected = new INetworkConnectionEvent();
+        public INetworkConnectionEvent Authenticated = new INetworkConnectionEvent();
+        public INetworkConnectionEvent Disconnected = new INetworkConnectionEvent();
 
         public UnityEvent Stopped = new UnityEvent();
 
@@ -54,7 +54,7 @@ namespace Mirror
         // original HLAPI has .localConnections list with only m_LocalConnection in it
         // (for backwards compatibility because they removed the real localConnections list a while ago)
         // => removed it for easier code. use .localConnection now!
-        public NetworkConnection LocalConnection { get; private set; }
+        public INetworkConnection LocalConnection { get; private set; }
 
         // The host client for this server 
         public NetworkClient LocalClient { get; private set; }
@@ -74,7 +74,7 @@ namespace Mirror
         /// <summary>
         /// A list of local connections on the server.
         /// </summary>
-        public readonly HashSet<NetworkConnection> connections = new HashSet<NetworkConnection>();
+        public readonly HashSet<INetworkConnection> connections = new HashSet<INetworkConnection>();
 
         /// <summary>
         /// <para>If you enable this, the server will not listen for incoming connections on the regular network port.</para>
@@ -92,7 +92,7 @@ namespace Mirror
 
         // just a cached memory area where we can collect connections
         // for broadcasting messages
-        private static readonly List<NetworkConnection> connectionsCache = new List<NetworkConnection>();
+        private static readonly List<INetworkConnection> connectionsCache = new List<INetworkConnection>();
 
         // Time kept in this server
         public readonly NetworkTime Time = new NetworkTime();
@@ -142,7 +142,7 @@ namespace Mirror
         }
 
 
-        internal void RegisterMessageHandlers(NetworkConnection connection)
+        internal void RegisterMessageHandlers(INetworkConnection connection)
         {
             connection.RegisterHandler<ReadyMessage>(OnClientReadyMessage);
             connection.RegisterHandler<CommandMessage>(OnCommandMessage);
@@ -189,7 +189,7 @@ namespace Mirror
 
                 while ((connection = await transport.AcceptAsync()) != null)
                 {
-                    NetworkConnection networkConnectionToClient = new NetworkConnection(connection);
+                    var networkConnectionToClient = new NetworkConnection(connection);
 
                     _ = ConnectionAcceptedAsync(networkConnectionToClient);
                 }
@@ -228,7 +228,7 @@ namespace Mirror
         /// </summary>
         /// <param name="conn">Network connection to add.</param>
         /// <returns>True if added.</returns>
-        public void AddConnection(NetworkConnection conn)
+        public void AddConnection(INetworkConnection conn)
         {
             if (!connections.Contains(conn))
             {
@@ -244,7 +244,7 @@ namespace Mirror
         /// </summary>
         /// <param name="connectionId">The id of the connection to remove.</param>
         /// <returns>True if the removal succeeded</returns>
-        public void RemoveConnection(NetworkConnection conn)
+        public void RemoveConnection(INetworkConnection conn)
         {
             connections.Remove(conn);
         }
@@ -258,7 +258,7 @@ namespace Mirror
                 return;
             }
 
-            NetworkConnection conn = new NetworkConnection(tconn);
+            var conn = new NetworkConnection(tconn);
             LocalConnection = conn;
             LocalClient = client;
 
@@ -319,7 +319,7 @@ namespace Mirror
 
             connectionsCache.Clear();
 
-            foreach (NetworkConnection connection in identity.observers)
+            foreach (INetworkConnection connection in identity.observers)
             {
 
                 bool isOwner = connection == identity.ConnectionToClient;
@@ -368,7 +368,7 @@ namespace Mirror
             }
         }
 
-        async Task ConnectionAcceptedAsync(NetworkConnection conn)
+        async Task ConnectionAcceptedAsync(INetworkConnection conn)
         {
             if (LogFilter.Debug) Debug.Log("Server accepted client:" + conn);
 
@@ -407,7 +407,7 @@ namespace Mirror
         }
 
 
-        void OnDisconnected(NetworkConnection connection)
+        void OnDisconnected(INetworkConnection connection)
         {
             if (LogFilter.Debug) Debug.Log("Server disconnect client:" + connection);
 
@@ -421,7 +421,7 @@ namespace Mirror
                 LocalConnection = null;
         }
 
-        internal void OnAuthenticated(NetworkConnection conn)
+        internal void OnAuthenticated(INetworkConnection conn)
         {
             if (LogFilter.Debug) Debug.Log("Server authenticate client:" + conn);
 
@@ -467,7 +467,7 @@ namespace Mirror
         /// <param name="assetId"></param>
         /// <param name="keepAuthority">Does the previous player remain attached to this connection?</param>
         /// <returns></returns>
-        public bool ReplacePlayerForConnection(NetworkConnection conn, NetworkClient client, GameObject player, Guid assetId, bool keepAuthority = false)
+        public bool ReplacePlayerForConnection(INetworkConnection conn, NetworkClient client, GameObject player, Guid assetId, bool keepAuthority = false)
         {
             NetworkIdentity identity = GetNetworkIdentity(player);
             identity.AssetId = assetId;
@@ -483,7 +483,7 @@ namespace Mirror
         /// <param name="player">Player object spawned for the player.</param>
         /// <param name="keepAuthority">Does the previous player remain attached to this connection?</param>
         /// <returns></returns>
-        public bool ReplacePlayerForConnection(NetworkConnection conn, NetworkClient client, GameObject player, bool keepAuthority = false)
+        public bool ReplacePlayerForConnection(INetworkConnection conn, NetworkClient client, GameObject player, bool keepAuthority = false)
         {
             return InternalReplacePlayerForConnection(conn, client, player, keepAuthority);
         }
@@ -497,14 +497,14 @@ namespace Mirror
         /// <param name="player">Player object spawned for the player.</param>
         /// <param name="assetId"></param>
         /// <returns></returns>
-        public bool AddPlayerForConnection(NetworkConnection conn, GameObject player, Guid assetId)
+        public bool AddPlayerForConnection(INetworkConnection conn, GameObject player, Guid assetId)
         {
             NetworkIdentity identity = GetNetworkIdentity(player);
             identity.AssetId = assetId;
             return AddPlayerForConnection(conn, player);
         }
 
-        void SpawnObserversForConnection(NetworkConnection conn)
+        void SpawnObserversForConnection(INetworkConnection conn)
         {
             if (LogFilter.Debug) Debug.Log("Spawning " + spawned.Count + " objects for conn " + conn);
 
@@ -550,7 +550,7 @@ namespace Mirror
         /// <param name="client">Client associated to the player.</param>
         /// <param name="player">Player object spawned for the player.</param>
         /// <returns></returns>
-        public bool AddPlayerForConnection(NetworkConnection conn, GameObject player)
+        public bool AddPlayerForConnection(INetworkConnection conn, GameObject player)
         {
             NetworkIdentity identity = player.GetComponent<NetworkIdentity>();
             if (identity == null)
@@ -609,7 +609,7 @@ namespace Mirror
             }
         }
 
-        internal bool InternalReplacePlayerForConnection(NetworkConnection conn, NetworkClient client, GameObject player, bool keepAuthority)
+        internal bool InternalReplacePlayerForConnection(INetworkConnection conn, NetworkClient client, GameObject player, bool keepAuthority)
         {
             NetworkIdentity identity = player.GetComponent<NetworkIdentity>();
             if (identity == null)
@@ -676,7 +676,7 @@ namespace Mirror
         /// <para>When a client has signaled that it is ready, this method tells the server that the client is ready to receive spawned objects and state synchronization updates. This is usually called in a handler for the SYSTEM_READY message. If there is not specific action a game needs to take for this message, relying on the default ready handler function is probably fine, so this call wont be needed.</para>
         /// </summary>
         /// <param name="conn">The connection of the client to make ready.</param>
-        public void SetClientReady(NetworkConnection conn)
+        public void SetClientReady(INetworkConnection conn)
         {
             if (LogFilter.Debug) Debug.Log("SetClientReadyInternal for conn:" + conn);
 
@@ -688,13 +688,13 @@ namespace Mirror
                 SpawnObserversForConnection(conn);
         }
 
-        internal void ShowForConnection(NetworkIdentity identity, NetworkConnection conn)
+        internal void ShowForConnection(NetworkIdentity identity, INetworkConnection conn)
         {
             if (conn.IsReady)
                 SendSpawnMessage(identity, conn);
         }
 
-        internal void HideForConnection(NetworkIdentity identity, NetworkConnection conn)
+        internal void HideForConnection(NetworkIdentity identity, INetworkConnection conn)
         {
             var msg = new ObjectHideMessage
             {
@@ -709,7 +709,7 @@ namespace Mirror
         /// </summary>
         public void SetAllClientsNotReady()
         {
-            foreach (NetworkConnection conn in connections)
+            foreach (INetworkConnection conn in connections)
             {
                 SetClientNotReady(conn);
             }
@@ -720,7 +720,7 @@ namespace Mirror
         /// <para>Clients that are not ready do not receive spawned objects or state synchronization updates. They client can be made ready again by calling SetClientReady().</para>
         /// </summary>
         /// <param name="conn">The connection of the client to make not ready.</param>
-        public void SetClientNotReady(NetworkConnection conn)
+        public void SetClientNotReady(INetworkConnection conn)
         {
             if (conn.IsReady)
             {
@@ -733,14 +733,14 @@ namespace Mirror
         }
 
         // default ready handler.
-        void OnClientReadyMessage(NetworkConnection conn, ReadyMessage msg)
+        void OnClientReadyMessage(INetworkConnection conn, ReadyMessage msg)
         {
             if (LogFilter.Debug) Debug.Log("Default handler for ready message from " + conn);
             SetClientReady(conn);
         }
 
         // default remove player handler
-        void OnRemovePlayerMessage(NetworkConnection conn, RemovePlayerMessage msg)
+        void OnRemovePlayerMessage(INetworkConnection conn, RemovePlayerMessage msg)
         {
             if (conn.Identity != null)
             {
@@ -754,7 +754,7 @@ namespace Mirror
         }
 
         // Handle command from specific player, this could be one of multiple players on a single client
-        void OnCommandMessage(NetworkConnection conn, CommandMessage msg)
+        void OnCommandMessage(INetworkConnection conn, CommandMessage msg)
         {
             if (!spawned.TryGetValue(msg.netId, out NetworkIdentity identity))
             {
@@ -777,7 +777,7 @@ namespace Mirror
                 identity.HandleCommand(msg.componentIndex, msg.functionHash, networkReader);
         }
 
-        internal void SpawnObject(GameObject obj, NetworkConnection ownerConnection)
+        internal void SpawnObject(GameObject obj, INetworkConnection ownerConnection)
         {
             if (!Active)
             {
@@ -808,7 +808,7 @@ namespace Mirror
             identity.RebuildObservers(true);
         }
 
-        internal void SendSpawnMessage(NetworkIdentity identity, NetworkConnection conn)
+        internal void SendSpawnMessage(NetworkIdentity identity, INetworkConnection conn)
         {
             if (identity.serverOnly)
                 return;
@@ -850,11 +850,11 @@ namespace Mirror
         }
 
         /// <summary>
-        /// This destroys all the player objects associated with a NetworkConnections on a server.
+        /// This destroys all the player objects associated with a INetworkConnections on a server.
         /// <para>This is used when a client disconnects, to remove the players for that client. This also destroys non-player objects that have client authority set for this connection.</para>
         /// </summary>
         /// <param name="conn">The connections object to clean up for.</param>
-        public void DestroyPlayerForConnection(NetworkConnection conn)
+        public void DestroyPlayerForConnection(INetworkConnection conn)
         {
             // destroy all objects owned by this connection
             conn.DestroyOwnedObjects();
@@ -924,7 +924,7 @@ namespace Mirror
         /// <param name="assetId">The assetId of the object to spawn. Used for custom spawn handlers.</param>
         /// <param name="client">The client associated to the object.</param>
         /// <param name="ownerConnection">The connection that has authority over the object</param>
-        public void Spawn(GameObject obj, Guid assetId, NetworkConnection ownerConnection = null)
+        public void Spawn(GameObject obj, Guid assetId, INetworkConnection ownerConnection = null)
         {
             if (VerifyCanSpawn(obj))
             {
@@ -941,7 +941,7 @@ namespace Mirror
         /// <param name="obj">Game object with NetworkIdentity to spawn.</param>
         /// <param name="client">Client associated to the object.</param>
         /// <param name="ownerConnection">The connection that has authority over the object</param>
-        public void Spawn(GameObject obj, NetworkConnection ownerConnection = null)
+        public void Spawn(GameObject obj, INetworkConnection ownerConnection = null)
         {
             if (VerifyCanSpawn(obj))
             {

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -23,7 +23,7 @@ namespace Mirror
     {
         bool initialized;
 
-        [Serializable] public class INetworkConnectionEvent : UnityEvent<INetworkConnection> { }
+        [Serializable] public class NetworkConnectionEvent : UnityEvent<INetworkConnection> { }
 
         /// <summary>
         /// The maximum number of concurrent network connections to support.
@@ -38,9 +38,9 @@ namespace Mirror
         /// </summary>
         public UnityEvent Started = new UnityEvent();
 
-        public INetworkConnectionEvent Connected = new INetworkConnectionEvent();
-        public INetworkConnectionEvent Authenticated = new INetworkConnectionEvent();
-        public INetworkConnectionEvent Disconnected = new INetworkConnectionEvent();
+        public NetworkConnectionEvent Connected = new NetworkConnectionEvent();
+        public NetworkConnectionEvent Authenticated = new NetworkConnectionEvent();
+        public NetworkConnectionEvent Disconnected = new NetworkConnectionEvent();
 
         public UnityEvent Stopped = new UnityEvent();
 

--- a/Assets/Mirror/Runtime/NetworkTime.cs
+++ b/Assets/Mirror/Runtime/NetworkTime.cs
@@ -63,7 +63,7 @@ namespace Mirror
         // executed at the server when we receive a ping message
         // reply with a pong containing the time from the client
         // and time from the server
-        internal void OnServerPing(NetworkConnection conn, NetworkPingMessage msg)
+        internal void OnServerPing(INetworkConnection conn, NetworkPingMessage msg)
         {
             if (LogFilter.Debug) Debug.Log("OnPingServerMessage  conn=" + conn);
 

--- a/Assets/Mirror/Runtime/PlayerSpawner.cs
+++ b/Assets/Mirror/Runtime/PlayerSpawner.cs
@@ -34,7 +34,7 @@ namespace Mirror
             client.RegisterPrefab(playerPrefab.gameObject);
         }
 
-        private void OnServerAuthenticated(NetworkConnection connection)
+        private void OnServerAuthenticated(INetworkConnection connection)
         {
             // wait for client to send us an AddPlayerMessage
             connection.RegisterHandler<AddPlayerMessage>(OnServerAddPlayerInternal);
@@ -45,7 +45,7 @@ namespace Mirror
         /// <para>The default implementation of this function sets the client as ready and adds a player. Override the function to dictate what happens when the client connects.</para>
         /// </summary>
         /// <param name="conn">Connection to the server.</param>
-        private void OnClientAuthenticated(NetworkConnection connection)
+        private void OnClientAuthenticated(INetworkConnection connection)
         {
             // OnClientConnect by default calls AddPlayer but it should not do
             // that when we have online/offline scenes. so we need the
@@ -57,7 +57,7 @@ namespace Mirror
             client.Send(new AddPlayerMessage());
         }
 
-        void OnServerAddPlayerInternal(NetworkConnection conn, AddPlayerMessage msg)
+        void OnServerAddPlayerInternal(INetworkConnection conn, AddPlayerMessage msg)
         {
             if (LogFilter.Debug) Debug.Log("NetworkManager.OnServerAddPlayer");
 
@@ -77,7 +77,7 @@ namespace Mirror
         /// <para>The default implementation for this function creates a new player object from the playerPrefab.</para>
         /// </summary>
         /// <param name="conn">Connection from client.</param>
-        public virtual void OnServerAddPlayer(NetworkConnection conn)
+        public virtual void OnServerAddPlayer(INetworkConnection conn)
         {
             Transform startPos = GetStartPosition();
             NetworkIdentity player = startPos != null

--- a/Assets/Mirror/Tests/Editor/NetworkIdentityTests.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkIdentityTests.cs
@@ -48,8 +48,8 @@ namespace Mirror.Tests
         class CheckObserverExceptionNetworkBehaviour : NetworkBehaviour
         {
             public int called;
-            public NetworkConnection valuePassed;
-            public override bool OnCheckObserver(NetworkConnection conn)
+            public INetworkConnection valuePassed;
+            public override bool OnCheckObserver(INetworkConnection conn)
             {
                 ++called;
                 valuePassed = conn;
@@ -60,7 +60,7 @@ namespace Mirror.Tests
         class CheckObserverTrueNetworkBehaviour : NetworkBehaviour
         {
             public int called;
-            public override bool OnCheckObserver(NetworkConnection conn)
+            public override bool OnCheckObserver(INetworkConnection conn)
             {
                 ++called;
                 return true;
@@ -70,7 +70,7 @@ namespace Mirror.Tests
         class CheckObserverFalseNetworkBehaviour : NetworkBehaviour
         {
             public int called;
-            public override bool OnCheckObserver(NetworkConnection conn)
+            public override bool OnCheckObserver(INetworkConnection conn)
             {
                 ++called;
                 return false;
@@ -136,7 +136,7 @@ namespace Mirror.Tests
         class RebuildObserversNetworkBehaviour : NetworkBehaviour
         {
             public NetworkConnection observer;
-            public override bool OnRebuildObservers(HashSet<NetworkConnection> observers, bool initialize)
+            public override bool OnRebuildObservers(HashSet<INetworkConnection> observers, bool initialize)
             {
                 observers.Add(observer);
                 return true;
@@ -145,7 +145,7 @@ namespace Mirror.Tests
 
         class RebuildEmptyObserversNetworkBehaviour : NetworkBehaviour
         {
-            public override bool OnRebuildObservers(HashSet<NetworkConnection> observers, bool initialize)
+            public override bool OnRebuildObservers(HashSet<INetworkConnection> observers, bool initialize)
             {
                 // return true so that caller knows we implemented
                 // OnRebuildObservers, but return no observers
@@ -771,7 +771,7 @@ namespace Mirror.Tests
             compB.observer = new NetworkConnection(null);
 
             // get new observers
-            var observers = new HashSet<NetworkConnection>();
+            var observers = new HashSet<INetworkConnection>();
             bool result = identity.GetNewObservers(observers, true);
             Assert.That(result, Is.True);
             Assert.That(observers.Count, Is.EqualTo(2));
@@ -784,7 +784,7 @@ namespace Mirror.Tests
         {
             // get new observers. no observer components so it should just clear
             // it and not do anything else
-            var observers = new HashSet<NetworkConnection>
+            var observers = new HashSet<INetworkConnection>
             {
                 new NetworkConnection(null)
             };
@@ -796,7 +796,7 @@ namespace Mirror.Tests
         public void GetNewObserversFalseIfNoComponents()
         {
             // get new observers. no observer components so it should be false
-            var observers = new HashSet<NetworkConnection>();
+            var observers = new HashSet<INetworkConnection>();
             bool result = identity.GetNewObservers(observers, true);
             Assert.That(result, Is.False);
         }

--- a/Assets/Mirror/Tests/Editor/WeaverTest.cs
+++ b/Assets/Mirror/Tests/Editor/WeaverTest.cs
@@ -279,14 +279,14 @@ namespace Mirror.Tests
         public void NetworkBehaviourTargetRpcParamOut()
         {
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
-            Assert.That(weaverErrors, Contains.Item("Mirror.Weaver error: System.Void MirrorTest.MirrorTestPlayer::TargetRpcCantHaveParamOut(Mirror.NetworkConnection,System.Int32&) cannot have out parameters"));
+            Assert.That(weaverErrors, Contains.Item("Mirror.Weaver error: System.Void MirrorTest.MirrorTestPlayer::TargetRpcCantHaveParamOut(Mirror.INetworkConnection,System.Int32&) cannot have out parameters"));
         }
 
         [Test]
         public void NetworkBehaviourTargetRpcParamOptional()
         {
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
-            Assert.That(weaverErrors, Contains.Item("Mirror.Weaver error: System.Void MirrorTest.MirrorTestPlayer::TargetRpcCantHaveParamOptional(Mirror.NetworkConnection,System.Int32) cannot have optional parameters"));
+            Assert.That(weaverErrors, Contains.Item("Mirror.Weaver error: System.Void MirrorTest.MirrorTestPlayer::TargetRpcCantHaveParamOptional(Mirror.INetworkConnection,System.Int32) cannot have optional parameters"));
         }
 
         [Test]

--- a/Assets/Mirror/Tests/Editor/WeaverTest.cs
+++ b/Assets/Mirror/Tests/Editor/WeaverTest.cs
@@ -384,7 +384,7 @@ namespace Mirror.Tests
         public void NetworkBehaviourClientRpcParamNetworkConnection()
         {
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
-            Assert.That(weaverErrors, Contains.Item("Mirror.Weaver error: System.Void MirrorTest.MirrorTestPlayer::RpcCantHaveParamOptional(Mirror.NetworkConnection) has invalid parameer monkeyCon. Cannot pass NeworkConnections"));
+            Assert.That(weaverErrors, Contains.Item("Mirror.Weaver error: System.Void MirrorTest.MirrorTestPlayer::RpcCantHaveParamOptional(Mirror.INetworkConnection) has invalid parameer monkeyCon. Cannot pass NeworkConnections"));
         }
 
         [Test]
@@ -433,7 +433,7 @@ namespace Mirror.Tests
         public void NetworkBehaviourCmdParamNetworkConnection()
         {
             Assert.That(CompilationFinishedHook.WeaveFailed, Is.True);
-            Assert.That(weaverErrors, Contains.Item("Mirror.Weaver error: System.Void MirrorTest.MirrorTestPlayer::CmdCantHaveParamOptional(Mirror.NetworkConnection) has invalid parameer monkeyCon. Cannot pass NeworkConnections"));
+            Assert.That(weaverErrors, Contains.Item("Mirror.Weaver error: System.Void MirrorTest.MirrorTestPlayer::CmdCantHaveParamOptional(Mirror.INetworkConnection) has invalid parameer monkeyCon. Cannot pass NeworkConnections"));
         }
 
         [Test]

--- a/Assets/Mirror/Tests/Editor/WeaverTests~/NetworkBehaviourClientRpcParamNetworkConnection.cs
+++ b/Assets/Mirror/Tests/Editor/WeaverTests~/NetworkBehaviourClientRpcParamNetworkConnection.cs
@@ -5,6 +5,6 @@ namespace MirrorTest
     class MirrorTestPlayer : NetworkBehaviour
     {
         [ClientRpc]
-        public void RpcCantHaveParamOptional(NetworkConnection monkeyCon) { }
+        public void RpcCantHaveParamOptional(INetworkConnection monkeyCon) { }
     }
 }

--- a/Assets/Mirror/Tests/Editor/WeaverTests~/NetworkBehaviourCmdParamNetworkConnection.cs
+++ b/Assets/Mirror/Tests/Editor/WeaverTests~/NetworkBehaviourCmdParamNetworkConnection.cs
@@ -5,6 +5,6 @@ namespace MirrorTest
     class MirrorTestPlayer : NetworkBehaviour
     {
         [Command]
-        public void CmdCantHaveParamOptional(NetworkConnection monkeyCon) { }
+        public void CmdCantHaveParamOptional(INetworkConnection monkeyCon) { }
     }
 }

--- a/Assets/Mirror/Tests/Editor/WeaverTests~/NetworkBehaviourTargetRpcDuplicateName.cs
+++ b/Assets/Mirror/Tests/Editor/WeaverTests~/NetworkBehaviourTargetRpcDuplicateName.cs
@@ -8,9 +8,9 @@ namespace MirrorTest
     class MirrorTestPlayer : NetworkBehaviour
     {
         [TargetRpc]
-        public void TargetRpcCantHaveSameName(NetworkConnection monkeyCon, int abc) { }
+        public void TargetRpcCantHaveSameName(INetworkConnection monkeyCon, int abc) { }
 
         [TargetRpc]
-        public void TargetRpcCantHaveSameName(NetworkConnection monkeyCon, int abc, int def) { }
+        public void TargetRpcCantHaveSameName(INetworkConnection monkeyCon, int abc, int def) { }
     }
 }

--- a/Assets/Mirror/Tests/Editor/WeaverTests~/NetworkBehaviourTargetRpcParamAbstract.cs
+++ b/Assets/Mirror/Tests/Editor/WeaverTests~/NetworkBehaviourTargetRpcParamAbstract.cs
@@ -12,6 +12,6 @@ namespace MirrorTest
         }
 
         [TargetRpc]
-        public void TargetRpcCantHaveParamAbstract(NetworkConnection monkeyCon, AbstractClass monkeys) { }
+        public void TargetRpcCantHaveParamAbstract(INetworkConnection monkeyCon, AbstractClass monkeys) { }
     }
 }

--- a/Assets/Mirror/Tests/Editor/WeaverTests~/NetworkBehaviourTargetRpcParamComponent.cs
+++ b/Assets/Mirror/Tests/Editor/WeaverTests~/NetworkBehaviourTargetRpcParamComponent.cs
@@ -12,6 +12,6 @@ namespace MirrorTest
         }
 
         [TargetRpc]
-        public void TargetRpcCantHaveParamComponent(NetworkConnection monkeyCon, ComponentClass monkeyComp) { }
+        public void TargetRpcCantHaveParamComponent(INetworkConnection monkeyCon, ComponentClass monkeyComp) { }
     }
 }

--- a/Assets/Mirror/Tests/Editor/WeaverTests~/NetworkBehaviourTargetRpcParamNetworkConnection.cs
+++ b/Assets/Mirror/Tests/Editor/WeaverTests~/NetworkBehaviourTargetRpcParamNetworkConnection.cs
@@ -5,6 +5,6 @@ namespace MirrorTest
     class MirrorTestPlayer : NetworkBehaviour
     {
         [TargetRpc]
-        public void TargetRpcCantHaveParamOptional(NetworkConnection monkeyCon) { }
+        public void TargetRpcCantHaveParamOptional(INetworkConnection monkeyCon) { }
     }
 }

--- a/Assets/Mirror/Tests/Editor/WeaverTests~/NetworkBehaviourTargetRpcParamNetworkConnectionNotFirst.cs
+++ b/Assets/Mirror/Tests/Editor/WeaverTests~/NetworkBehaviourTargetRpcParamNetworkConnectionNotFirst.cs
@@ -5,6 +5,6 @@ namespace MirrorTest
     class MirrorTestPlayer : NetworkBehaviour
     {
         [TargetRpc]
-        public void TargetRpcCantHaveParamOptional(int abc, NetworkConnection monkeyCon) { }
+        public void TargetRpcCantHaveParamOptional(int abc, INetworkConnection monkeyCon) { }
     }
 }

--- a/Assets/Mirror/Tests/Editor/WeaverTests~/NetworkBehaviourTargetRpcParamOptional.cs
+++ b/Assets/Mirror/Tests/Editor/WeaverTests~/NetworkBehaviourTargetRpcParamOptional.cs
@@ -7,6 +7,6 @@ namespace MirrorTest
     class MirrorTestPlayer : NetworkBehaviour
     {
         [TargetRpc]
-        public void TargetRpcCantHaveParamOptional(NetworkConnection monkeyCon, int monkeys = 12) { }
+        public void TargetRpcCantHaveParamOptional(INetworkConnection monkeyCon, int monkeys = 12) { }
     }
 }

--- a/Assets/Mirror/Tests/Editor/WeaverTests~/NetworkBehaviourTargetRpcParamOut.cs
+++ b/Assets/Mirror/Tests/Editor/WeaverTests~/NetworkBehaviourTargetRpcParamOut.cs
@@ -7,7 +7,7 @@ namespace MirrorTest
     class MirrorTestPlayer : NetworkBehaviour
     {
         [TargetRpc]
-        public void TargetRpcCantHaveParamOut(NetworkConnection monkeyCon, out int monkeys)
+        public void TargetRpcCantHaveParamOut(INetworkConnection monkeyCon, out int monkeys)
         {
             monkeys = 12;
         }

--- a/Assets/Mirror/Tests/Editor/WeaverTests~/NetworkBehaviourTargetRpcParamRef.cs
+++ b/Assets/Mirror/Tests/Editor/WeaverTests~/NetworkBehaviourTargetRpcParamRef.cs
@@ -7,6 +7,6 @@ namespace MirrorTest
     class MirrorTestPlayer : NetworkBehaviour
     {
         [TargetRpc]
-        public void TargetRpcCantHaveParamRef(NetworkConnection monkeyCon, ref int monkeys) { }
+        public void TargetRpcCantHaveParamRef(INetworkConnection monkeyCon, ref int monkeys) { }
     }
 }

--- a/Assets/Mirror/Tests/Editor/WeaverTests~/TargetRpcNetworkConnectionNotFirst.cs
+++ b/Assets/Mirror/Tests/Editor/WeaverTests~/TargetRpcNetworkConnectionNotFirst.cs
@@ -8,6 +8,6 @@ namespace MirrorTest
     class MirrorTestPlayer : NetworkBehaviour
     {
         [TargetRpc]
-        void TargetRpcMethod(int potatoesRcool, NetworkConnection nc) { }
+        void TargetRpcMethod(int potatoesRcool, INetworkConnection nc) { }
     }
 }

--- a/Assets/Mirror/Tests/Editor/WeaverTests~/TargetRpcValid.cs
+++ b/Assets/Mirror/Tests/Editor/WeaverTests~/TargetRpcValid.cs
@@ -8,6 +8,6 @@ namespace MirrorTest
     class MirrorTestPlayer : NetworkBehaviour
     {
         [TargetRpc]
-        void TargetThatIsTotallyValid(NetworkConnection nc) { }
+        void TargetThatIsTotallyValid(INetworkConnection nc) { }
     }
 }

--- a/Assets/Mirror/Tests/Runtime/NetworkClientTest.cs
+++ b/Assets/Mirror/Tests/Runtime/NetworkClientTest.cs
@@ -13,7 +13,7 @@ namespace Mirror.Tests
     {
         public int called;
 
-        public override void OnClientAuthenticate(NetworkConnection conn)
+        public override void OnClientAuthenticate(INetworkConnection conn)
         {
             ++called;
         }

--- a/Assets/Mirror/Tests/Runtime/NetworkIdentityTests.cs
+++ b/Assets/Mirror/Tests/Runtime/NetworkIdentityTests.cs
@@ -95,7 +95,7 @@ namespace Mirror.Tests
             // test the callback too
             int callbackCalled = 0;
 
-            void Callback(NetworkConnection conn, NetworkIdentity networkIdentity, bool state)
+            void Callback(INetworkConnection conn, NetworkIdentity networkIdentity, bool state)
             {
                 ++callbackCalled;
                 Assert.That(networkIdentity, Is.EqualTo(identity));

--- a/Assets/Mirror/Tests/Runtime/NetworkManagerTest.cs
+++ b/Assets/Mirror/Tests/Runtime/NetworkManagerTest.cs
@@ -96,7 +96,7 @@ namespace Mirror.Tests
         public IEnumerator ConnectedClientTest() => RunAsync(async () =>
         {
             await manager.StartServer();
-            UnityAction<NetworkConnection> func = Substitute.For<UnityAction<NetworkConnection>>();
+            UnityAction<INetworkConnection> func = Substitute.For<UnityAction<INetworkConnection>>();
             manager.client.Connected.AddListener(func);
 
             await manager.client.ConnectAsync(new System.Uri("tcp4://localhost"));
@@ -109,7 +109,7 @@ namespace Mirror.Tests
         public IEnumerator ConnectedClientUriTest() => RunAsync(async () =>
         {
             await manager.StartServer();
-            UnityAction<NetworkConnection> func = Substitute.For<UnityAction<NetworkConnection>>();
+            UnityAction<INetworkConnection> func = Substitute.For<UnityAction<INetworkConnection>>();
             manager.client.Connected.AddListener(func);
             await manager.client.ConnectAsync(new System.Uri("tcp4://localhost"));
             func.Received().Invoke(Arg.Any<NetworkConnection>());
@@ -123,7 +123,7 @@ namespace Mirror.Tests
         public IEnumerator ConnectedHostTest() => RunAsync(async () =>
         {
             await manager.StartServer();
-            UnityAction<NetworkConnection> func = Substitute.For<UnityAction<NetworkConnection>>();
+            UnityAction<INetworkConnection> func = Substitute.For<UnityAction<INetworkConnection>>();
             manager.client.Connected.AddListener(func);
             manager.client.ConnectHost(manager.server);
             func.Received().Invoke(Arg.Any<NetworkConnection>());

--- a/Assets/Mirror/Tests/Runtime/NetworkServerTest.cs
+++ b/Assets/Mirror/Tests/Runtime/NetworkServerTest.cs
@@ -75,7 +75,7 @@ namespace Mirror.Tests
     {
         public int called;
 
-        public override void OnServerAuthenticate(NetworkConnection conn)
+        public override void OnServerAuthenticate(INetworkConnection conn)
         {
             ++called;
         }
@@ -159,12 +159,12 @@ namespace Mirror.Tests
         [Test]
         public void ConnectedEventTest()
         {
-            UnityAction<NetworkConnection> func = Substitute.For<UnityAction<NetworkConnection>>();
+            UnityAction<INetworkConnection> func = Substitute.For<UnityAction<INetworkConnection>>();
             server.Connected.AddListener(func);
 
             transport.AcceptCompletionSource.SetResult(tconn42);
 
-            func.Received().Invoke(Arg.Any<NetworkConnection>());
+            func.Received().Invoke(Arg.Any<INetworkConnection>());
         }
 
         [Test]
@@ -195,7 +195,7 @@ namespace Mirror.Tests
         public void DisconnectMessageHandlerTest()
         {
             // subscribe to disconnected
-            UnityAction<NetworkConnection> func = Substitute.For<UnityAction<NetworkConnection>>();
+            UnityAction<INetworkConnection> func = Substitute.For<UnityAction<INetworkConnection>>();
             server.Disconnected.AddListener(func);
 
             // accept a connection and disconnect

--- a/Assets/Mirror/Tests/Runtime/NetworkServerTests.cs
+++ b/Assets/Mirror/Tests/Runtime/NetworkServerTests.cs
@@ -14,9 +14,9 @@ namespace Mirror.Tests
         NetworkServer server;
         GameObject serverGO;
 
-        NetworkConnection connectionToServer;
+        INetworkConnection connectionToServer;
 
-        NetworkConnection connectionToClient;
+        INetworkConnection connectionToClient;
         WovenTestMessage message;
         NetworkIdentity identity;
 
@@ -177,7 +177,7 @@ namespace Mirror.Tests
         public IEnumerator RegisterMessage2()
         {
 
-            Action<NetworkConnection, WovenTestMessage> func = Substitute.For<Action<NetworkConnection, WovenTestMessage>>();
+            Action<INetworkConnection, WovenTestMessage> func = Substitute.For<Action<INetworkConnection, WovenTestMessage>>();
 
             connectionToClient.RegisterHandler<WovenTestMessage>(func);
 

--- a/Assets/Mirror/Tests/Runtime/RpcTests.cs
+++ b/Assets/Mirror/Tests/Runtime/RpcTests.cs
@@ -39,10 +39,10 @@ namespace Mirror.Tests
 
         public int targetRpcArg1;
         public string targetRpcArg2;
-        public NetworkConnection targetRpcConn;
+        public INetworkConnection targetRpcConn;
 
         [TargetRpc]
-        public void TargetRpcTest(NetworkConnection conn, int arg1, string arg2)
+        public void TargetRpcTest(INetworkConnection conn, int arg1, string arg2)
         {
             this.targetRpcConn = conn;
             this.targetRpcArg1 = arg1;


### PR DESCRIPTION
Most things don't need to know which implementation of NetworkConnection
we are using.  Instead interact with the interface.

This allows us to mock the NetworkConnection and improve testing of
NetworkClient and NetworkServer

BREAKING CHANGE:  Message handlers now receive INetworkConnection instead of NetworkConnection