### PR TITLE
Test cleanup

### DIFF
--- a/Assets/Mirror/Tests/Runtime/ClientServerSetup.cs
+++ b/Assets/Mirror/Tests/Runtime/ClientServerSetup.cs
@@ -10,9 +10,7 @@ using Object = UnityEngine.Object;
 
 namespace Mirror.Tests
 {
-
     // set's up a host
-
     public class ClientServerSetup<T> where T : NetworkBehaviour
     {
 
@@ -52,7 +50,6 @@ namespace Mirror.Tests
             playerPrefab.GetComponent<NetworkIdentity>().AssetId = Guid.NewGuid();
             client.RegisterPrefab(playerPrefab);
 
-
             // wait for client and server to initialize themselves
             await Task.Delay(1);
 
@@ -66,7 +63,6 @@ namespace Mirror.Tests
             connectionToServer = client.Connection;
             connectionToClient = server.connections.First();
 
-
             // create a player object in the server
             serverPlayerGO = GameObject.Instantiate(playerPrefab);
             serverIdentity = serverPlayerGO.GetComponent<NetworkIdentity>();
@@ -79,8 +75,6 @@ namespace Mirror.Tests
             clientPlayerGO = connectionToServer.Identity.gameObject;
             clientIdentity = clientPlayerGO.GetComponent<NetworkIdentity>();
             clientComponent = clientPlayerGO.GetComponent<T>();
-
-
         });
 
         [UnityTearDown]

--- a/Assets/Mirror/Tests/Runtime/HostSetup.cs
+++ b/Assets/Mirror/Tests/Runtime/HostSetup.cs
@@ -8,9 +8,7 @@ using static Mirror.Tests.AsyncUtil;
 
 namespace Mirror.Tests
 {
-
     // set's up a host
-
     public class HostSetup<T> where T : NetworkBehaviour
     {
 
@@ -49,7 +47,6 @@ namespace Mirror.Tests
             server.AddPlayerForConnection(server.LocalConnection, playerGO);
 
             client.Update();
-
         });
 
         [TearDown]

--- a/Assets/Mirror/Tests/Runtime/NetworkManagerTest.cs
+++ b/Assets/Mirror/Tests/Runtime/NetworkManagerTest.cs
@@ -56,12 +56,12 @@ namespace Mirror.Tests
             });
         }
 
-        [UnityTest]
-        public IEnumerator StartServerTest() => RunAsync(async () =>
+        [Test]
+        public void StartServerTest()
         {
             Assert.That(manager.IsNetworkActive, Is.True);
             Assert.That(manager.server.Active, Is.True);
-        });
+        }
 
         [UnityTest]
         public IEnumerator StopServerTest() => RunAsync(async () =>

--- a/Assets/Mirror/Tests/Runtime/NetworkManagerTest.cs
+++ b/Assets/Mirror/Tests/Runtime/NetworkManagerTest.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Collections;
-using System.Net.Sockets;
 using System.Threading.Tasks;
-using NSubstitute;
 using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.TestTools;

--- a/Assets/Mirror/Tests/Runtime/NetworkManagerTest.cs
+++ b/Assets/Mirror/Tests/Runtime/NetworkManagerTest.cs
@@ -5,7 +5,6 @@ using System.Threading.Tasks;
 using NSubstitute;
 using NUnit.Framework;
 using UnityEngine;
-using UnityEngine.Events;
 using UnityEngine.TestTools;
 using static Mirror.Tests.AsyncUtil;
 
@@ -25,33 +24,8 @@ namespace Mirror.Tests
     }
 
     [TestFixture]
-    public class NetworkManagerTest
+    public class NetworkManagerTest : HostSetup<MockComponent>
     {
-        GameObject gameObject;
-        NetworkManager manager;
-
-        IConnection tconn1;
-        IConnection tconn2;
-
-        [SetUp]
-        public void SetupNetworkManager()
-        {
-            gameObject = new GameObject();
-            gameObject.AddComponent<LoopbackTransport>();
-            manager = gameObject.AddComponent<NetworkManager>();
-            manager.startOnHeadless = false;
-            manager.client = gameObject.GetComponent<NetworkClient>();
-            manager.server = gameObject.GetComponent<NetworkServer>();
-
-            (tconn1, tconn2) = PipeConnection.CreatePipe();
-        }
-
-        [TearDown]
-        public void TearDownNetworkManager()
-        {
-            UnityEngine.Object.DestroyImmediate(gameObject);
-        }
-
         [Test]
         public void VariableTest()
         {
@@ -60,9 +34,6 @@ namespace Mirror.Tests
             Assert.That(manager.showDebugMessages, Is.False);
             Assert.That(manager.serverTickRate, Is.EqualTo(30));
             Assert.That(manager.server.MaxConnections, Is.EqualTo(4));
-            Assert.That(manager.IsNetworkActive, Is.False);
-
-            Assert.That(manager.networkSceneName, Is.Empty);
         }
 
         [Test]
@@ -90,23 +61,13 @@ namespace Mirror.Tests
         [UnityTest]
         public IEnumerator StartServerTest() => RunAsync(async () =>
         {
-            Assert.That(manager.server.Active, Is.False);
-
-            await manager.StartServer();
-
             Assert.That(manager.IsNetworkActive, Is.True);
             Assert.That(manager.server.Active, Is.True);
-
-            manager.StopServer();
         });
 
         [UnityTest]
         public IEnumerator StopServerTest() => RunAsync(async () =>
         {
-            // wait for NetworkManager to initialize
-            await Task.Delay(1);
-
-            await manager.StartServer();
             manager.StopServer();
 
             // wait for manager to stop
@@ -116,78 +77,8 @@ namespace Mirror.Tests
         });
 
         [UnityTest]
-        public IEnumerator StartClientTest()
-        {
-            manager.StartClient("localhost");
-
-            yield return null;
-            Assert.That(manager.IsNetworkActive, Is.False);
-
-            manager.StopClient();
-        }
-
-        [UnityTest]
-        public IEnumerator ConnectedClientTest() => RunAsync(async () =>
-        {
-            await manager.StartServer();
-            UnityAction<INetworkConnection> func = Substitute.For<UnityAction<INetworkConnection>>();
-            manager.client.Connected.AddListener(func);
-
-            await manager.client.ConnectAsync(new System.Uri("tcp4://localhost"));
-            func.Received().Invoke(Arg.Any<NetworkConnection>());
-            manager.client.Disconnect();
-            manager.StopServer();
-        });
-
-        [UnityTest]
-        public IEnumerator ConnectedClientUriTest() => RunAsync(async () =>
-        {
-            await manager.StartServer();
-            UnityAction<INetworkConnection> func = Substitute.For<UnityAction<INetworkConnection>>();
-            manager.client.Connected.AddListener(func);
-            await manager.client.ConnectAsync(new System.Uri("tcp4://localhost"));
-            func.Received().Invoke(Arg.Any<NetworkConnection>());
-            manager.client.Disconnect();
-            manager.StopServer();
-            await Task.Delay(1);
-
-        });
-
-        [UnityTest]
-        public IEnumerator ConnectedHostTest() => RunAsync(async () =>
-        {
-            await manager.StartServer();
-            UnityAction<INetworkConnection> func = Substitute.For<UnityAction<INetworkConnection>>();
-            manager.client.Connected.AddListener(func);
-            manager.client.ConnectHost(manager.server);
-            func.Received().Invoke(Arg.Any<NetworkConnection>());
-            manager.client.Disconnect();
-            manager.StopServer();
-
-            await Task.Delay(1);
-        });
-
-        [UnityTest]
-        public IEnumerator ConnectionRefusedTest() => RunAsync(async () =>
-        {
-            try
-            {
-                await manager.StartClient("localhost");
-                Assert.Fail("If server is not available, it should throw exception");
-            }
-            catch (SocketException)
-            {
-                // Good
-            }
-        });
-
-        [UnityTest]
         public IEnumerator StopClientTest() => RunAsync(async () =>
         {
-            await manager.StartServer();
-
-            await manager.StartClient("localhost");
-
             manager.StopClient();
             manager.StopServer();
 

--- a/Assets/Mirror/Tests/Runtime/NetworkServerTests.cs
+++ b/Assets/Mirror/Tests/Runtime/NetworkServerTests.cs
@@ -19,6 +19,16 @@ namespace Mirror.Tests
     {
         WovenTestMessage message;
 
+        void InitializeMessage()
+        {
+            message = new WovenTestMessage
+            {
+                IntValue = 1,
+                DoubleValue = 1.0,
+                StringValue = "hello"
+            };
+        }
+
         [Test]
         public void InitializeTest()
         {
@@ -94,6 +104,8 @@ namespace Mirror.Tests
         [UnityTest]
         public IEnumerator SendToAll()
         {
+            InitializeMessage();
+
             Action<WovenTestMessage> func = Substitute.For<Action<WovenTestMessage>>();
 
             connectionToServer.RegisterHandler(func);
@@ -112,6 +124,8 @@ namespace Mirror.Tests
         [UnityTest]
         public IEnumerator SendToClientOfPlayer()
         {
+            InitializeMessage();
+
             Action<WovenTestMessage> func = Substitute.For<Action<WovenTestMessage>>();
 
             connectionToServer.RegisterHandler(func);
@@ -169,6 +183,8 @@ namespace Mirror.Tests
         [UnityTest]
         public IEnumerator RegisterMessage1()
         {
+            InitializeMessage();
+
             Action<WovenTestMessage> func = Substitute.For<Action<WovenTestMessage>>();
 
             connectionToClient.RegisterHandler(func);
@@ -184,6 +200,7 @@ namespace Mirror.Tests
         [UnityTest]
         public IEnumerator RegisterMessage2()
         {
+            InitializeMessage();
 
             Action<INetworkConnection, WovenTestMessage> func = Substitute.For<Action<INetworkConnection, WovenTestMessage>>();
 
@@ -202,6 +219,8 @@ namespace Mirror.Tests
         [UnityTest]
         public IEnumerator UnRegisterMessage1()
         {
+            InitializeMessage();
+
             Action<WovenTestMessage> func = Substitute.For<Action<WovenTestMessage>>();
 
             connectionToClient.RegisterHandler(func);

--- a/Assets/Mirror/Tests/Runtime/NetworkServerTests.cs
+++ b/Assets/Mirror/Tests/Runtime/NetworkServerTests.cs
@@ -71,16 +71,6 @@ namespace Mirror.Tests
         }
 
         [Test]
-        public void SpawnTest()
-        {
-            var gameObject = new GameObject();
-            gameObject.AddComponent<NetworkIdentity>();
-            server.Spawn(gameObject);
-
-            Assert.That(gameObject.GetComponent<NetworkIdentity>().Server, Is.SameAs(server));
-        }
-
-        [Test]
         public void SendToClientOfPlayerExceptionTest()
         {
             GameObject gameObject = new GameObject();

--- a/Assets/Mirror/Tests/Runtime/NetworkServerTests.cs
+++ b/Assets/Mirror/Tests/Runtime/NetworkServerTests.cs
@@ -214,6 +214,5 @@ namespace Mirror.Tests
             func.Received(0).Invoke(
                 Arg.Any<WovenTestMessage>());
         }
-
     }
 }

--- a/Assets/Mirror/Tests/Runtime/NetworkServerTests.cs
+++ b/Assets/Mirror/Tests/Runtime/NetworkServerTests.cs
@@ -40,8 +40,7 @@ namespace Mirror.Tests
         [Test]
         public void SendToClientOfPlayerExceptionTest()
         {
-            GameObject gameObject = new GameObject();
-            SimpleNetworkServer comp = gameObject.AddComponent<SimpleNetworkServer>();
+            SimpleNetworkServer comp = serverPlayerGO.AddComponent<SimpleNetworkServer>();
 
             Assert.Throws<InvalidOperationException>(() =>
             {


### PR DESCRIPTION
this change reduces re inviting the wheel for each test. Also had to remove some tests that were trying to check values before start. I will add those all back as another class since Setup cant be avoided.

I needed this to be more standard for my attempts at separating NC into two pieces. Tests were failing in all sorts of different ways due to their varying construction and initialization.