### PR TITLE
feat: onstopserver event in NetworkIdentity

### DIFF
--- a/Assets/Mirror/Runtime/NetworkClient.cs
+++ b/Assets/Mirror/Runtime/NetworkClient.cs
@@ -671,8 +671,6 @@ namespace Mirror
 
         void ApplySpawnPayload(NetworkIdentity identity, SpawnMessage msg)
         {
-            identity.Reset();
-
             if (msg.assetId != Guid.Empty)
                 identity.AssetId = msg.assetId;
 

--- a/Assets/Mirror/Runtime/NetworkClient.cs
+++ b/Assets/Mirror/Runtime/NetworkClient.cs
@@ -142,14 +142,14 @@ namespace Mirror
             {
                 IConnection transportConnection = await transport.ConnectAsync(uri);
 
-                
+
                 RegisterSpawnPrefabs();
                 InitializeAuthEvents();
 
                 // setup all the handlers
                 Connection = new NetworkConnection(transportConnection);
                 Time.Reset();
-           
+
                 RegisterMessageHandlers(Connection);
                 Time.UpdateClient(this);
                 _ = OnConnected();
@@ -205,7 +205,7 @@ namespace Mirror
         async Task OnConnected()
         {
             // reset network time stats
-            
+
 
             // the handler may want to send messages to the client
             // thus we should set the connected state before calling the handler
@@ -317,7 +317,7 @@ namespace Mirror
             connectState = ConnectState.None;
 
             if (authenticator != null)
-            { 
+            {
                 authenticator.OnClientAuthenticated -= OnAuthenticated;
 
                 Connected.RemoveListener(authenticator.OnClientAuthenticateInternal);
@@ -380,7 +380,7 @@ namespace Mirror
 
             if (logger.LogEnabled()) logger.Log("ClientScene.Ready() called with connection [" + conn + "]");
 
-            
+
             // Set these before sending the ReadyMessage, otherwise host client
             // will fail in InternalAddPlayer with null readyConnection.
             ready = true;
@@ -647,7 +647,7 @@ namespace Mirror
             }
             else
             {
-                identity.MarkForReset();
+                identity.Reset();
                 identity.gameObject.SetActive(false);
                 spawnableObjects[identity.sceneId] = identity;
             }

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -54,10 +54,6 @@ namespace Mirror
         // configuration
         NetworkBehaviour[] networkBehavioursCache;
 
-        // member used to mark a identity for future reset
-        // check MarkForReset for more information.
-        bool reset;
-
         /// <summary>
         /// Returns true if running as a client and this object was spawned by a server.
         /// </summary>
@@ -257,6 +253,12 @@ namespace Mirror
         /// </summary>
         ///<summary>Called on clients when the server destroys the GameObject.</summary>
         public UnityEvent OnNetworkDestroy = new UnityEvent();
+
+        /// <summary>
+        /// This is called on the server when the object is unspawned
+        /// </summary>
+        /// <remarks>Can be used as hook to save player information</remarks>
+        public UnityEvent OnStopServer = new UnityEvent();
 
         /// <summary>
         /// Gets the NetworkIdentity from the sceneIds dictionary with the corresponding id
@@ -558,15 +560,10 @@ namespace Mirror
             sceneIds.Remove(sceneId);
             sceneIds.Remove(sceneId & 0x00000000FFFFFFFF);
 
-            // Only call NetworkServer.Destroy on server and only if reset is false
-            // reset will be false from incorrect use of Destroy instead of NetworkServer.Destroy
-            // reset will be true if NetworkServer.Destroy was correctly invoked to begin with
-            // Users are supposed to call NetworkServer.Destroy instead of just regular Destroy for networked objects.
-            // This is a safeguard in case users accidentally call regular Destroy instead.
-            // We cover their mistake by calling NetworkServer.Destroy for them.
-            // If, however, they call NetworkServer.Destroy correctly, which leads to NetworkIdentity.MarkForReset,
-            // then we don't need to call it again, so the check for reset is needed to prevent the doubling.
-            if (IsServer && !reset)
+            // Server would be true if you destroy this object directy
+            // or if unity destroys it by switching scenes.
+            // so we have to unspawn the object in that case
+            if (IsServer)
             {
                 Server.Destroy(gameObject);
             }
@@ -1123,23 +1120,11 @@ namespace Mirror
             }
         }
 
-        // marks the identity for future reset, this is because we cant reset the identity during destroy
-        // as people might want to be able to read the members inside OnDestroy(), and we have no way
-        // of invoking reset after OnDestroy is called.
-        internal void MarkForReset() => reset = true;
-
-        // check if it was marked for reset
-        internal bool IsMarkedForReset() => reset;
-
-        // if we have marked an identity for reset we do the actual reset.
-        internal void Reset()
-        {
-            if (!reset)
-                return;
-
+        // The object is no longer networked,  reset all network state
+        internal void MarkForReset()
+        { 
             clientStarted = false;
             localPlayerStarted = false;
-            reset = false;
 
             NetId = 0;
             Server = null;

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -1121,7 +1121,7 @@ namespace Mirror
         }
 
         // The object is no longer networked,  reset all network state
-        internal void MarkForReset()
+        internal void Reset()
         { 
             clientStarted = false;
             localPlayerStarted = false;

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -853,8 +853,8 @@ namespace Mirror
 
             // use owner segment if 'conn' owns this identity, otherwise
             // use observers segment
-            ArraySegment<byte> payload = isOwner ? 
-                ownerWriter.ToArraySegment() : 
+            ArraySegment<byte> payload = isOwner ?
+                ownerWriter.ToArraySegment() :
                 observersWriter.ToArraySegment();
 
             return payload;
@@ -979,7 +979,7 @@ namespace Mirror
 
             identity.OnStopServer.Invoke();
 
-            identity.MarkForReset();
+            identity.Reset();
 
             // when unspawning, dont destroy the server's object
             if (destroyServerObject)

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -559,8 +559,6 @@ namespace Mirror
                 logger.Log("AddPlayer: playerGameObject has no NetworkIdentity. Please add a NetworkIdentity to " + player);
                 return false;
             }
-            identity.Reset();
-
             // cannot have a player object in "Add" version
             if (conn.Identity != null)
             {
@@ -790,7 +788,6 @@ namespace Mirror
             {
                 throw new InvalidOperationException("SpawnObject " + obj + " has no NetworkIdentity. Please add a NetworkIdentity to " + obj);
             }
-            identity.Reset();
             identity.ConnectionToClient = ownerConnection;
             identity.Server = this;
             identity.Client = LocalClient;
@@ -980,12 +977,15 @@ namespace Mirror
                 identity.OnNetworkDestroy.Invoke();
             }
 
+            identity.OnStopServer.Invoke();
+
+            identity.MarkForReset();
+
             // when unspawning, dont destroy the server's object
             if (destroyServerObject)
             {
                 UnityEngine.Object.Destroy(identity.gameObject);
             }
-            identity.MarkForReset();
         }
 
         /// <summary>
@@ -1056,7 +1056,6 @@ namespace Mirror
                 if (ValidateSceneObject(identity))
                 {
                     if (logger.LogEnabled()) logger.Log("SpawnObjects sceneId:" + identity.sceneId.ToString("X") + " name:" + identity.gameObject.name);
-                    identity.Reset();
                     identity.gameObject.SetActive(true);
 
                     Spawn(identity.gameObject);

--- a/Assets/Mirror/Tests/Editor/NetworkIdentityTests.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkIdentityTests.cs
@@ -722,20 +722,12 @@ namespace Mirror.Tests
             // modify it a bit
             // creates .observers and generates a netId
             identity.StartServer();
-            uint netId = identity.NetId;
             identity.ConnectionToClient = new NetworkConnection(null);
             identity.ConnectionToServer = new NetworkConnection(null);
             identity.observers.Add(new NetworkConnection(null));
 
-            // calling reset shouldn't do anything unless it was marked for reset
-            identity.Reset();
-            Assert.That(identity.NetId, Is.EqualTo(netId));
-            Assert.That(identity.ConnectionToClient, !Is.Null);
-            Assert.That(identity.ConnectionToServer, !Is.Null);
-
             // mark for reset and reset
             identity.MarkForReset();
-            identity.Reset();
             Assert.That(identity.NetId, Is.EqualTo(0));
             Assert.That(identity.ConnectionToClient, Is.Null);
             Assert.That(identity.ConnectionToServer, Is.Null);

--- a/Assets/Mirror/Tests/Editor/NetworkIdentityTests.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkIdentityTests.cs
@@ -727,7 +727,7 @@ namespace Mirror.Tests
             identity.observers.Add(new NetworkConnection(null));
 
             // mark for reset and reset
-            identity.MarkForReset();
+            identity.Reset();
             Assert.That(identity.NetId, Is.EqualTo(0));
             Assert.That(identity.ConnectionToClient, Is.Null);
             Assert.That(identity.ConnectionToServer, Is.Null);

--- a/Assets/Mirror/Tests/Runtime/NetworkIdentityTests.cs
+++ b/Assets/Mirror/Tests/Runtime/NetworkIdentityTests.cs
@@ -5,6 +5,8 @@ using InvalidOperationException = System.InvalidOperationException;
 
 using static Mirror.Tests.AsyncUtil;
 using System.Collections;
+using UnityEngine.Events;
+using NSubstitute;
 
 namespace Mirror.Tests
 {
@@ -203,5 +205,19 @@ namespace Mirror.Tests
             Assert.That(identity.ConnectionToClient, Is.Null);
         }
 
+
+        [UnityTest]
+        public IEnumerator OnStopServer()
+        {
+            server.Spawn(gameObject);
+
+            UnityAction mockHandler = Substitute.For<UnityAction>();
+            identity.OnStopServer.AddListener(mockHandler);
+
+            server.UnSpawn(gameObject);
+
+            yield return null;
+            mockHandler.Received().Invoke();
+        }
     }
 }

--- a/Assets/Mirror/Tests/Runtime/NetworkServerTest.cs
+++ b/Assets/Mirror/Tests/Runtime/NetworkServerTest.cs
@@ -411,13 +411,13 @@ namespace Mirror.Tests
             identity.sceneId = 42;
             // spawned objects are active
             go.SetActive(true);
-            Assert.That(identity.IsMarkedForReset(), Is.False);
+            identity.NetId = 20;
 
             // unspawn
             server.UnSpawn(go);
 
             // it should have been marked for reset now
-            Assert.That(identity.IsMarkedForReset(), Is.True);
+            Assert.That(identity.NetId, Is.Zero);
 
             // clean up
             Object.DestroyImmediate(go);


### PR DESCRIPTION
New event that is invoked when an object is unspawned at the server

    Can be used to save the player state in persistent storage for future sessions.

    Completely removes the need for the MarkForReset nonsense