### PR TITLE
NS set identity when host

### DIFF
--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -584,7 +584,7 @@ namespace Mirror
             if (conn == LocalConnection)
             {
                 identity.HasAuthority = true;
-                this.LocalClient.InternalAddPlayer(identity);
+                LocalClient.Connection.Identity = identity;
             }
 
             // set ready if not set yet
@@ -642,7 +642,7 @@ namespace Mirror
             if (conn == LocalConnection)
             {
                 identity.HasAuthority = true;
-                client.InternalAddPlayer(identity);
+                LocalClient.Connection.Identity = identity;
             }
 
             // add connection to observers AFTER the playerController was set.


### PR DESCRIPTION
Instead of having the NetworkClient set Connection.Identity in the case of host. Have the NetworkServer set it since it has all of the same information required.

All tests passed locally and ran examples in editor as host.