### PR TITLE
Dont null connection

### DIFF
--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -564,7 +564,6 @@ namespace Mirror
             {
                 client.OnAuthenticated(client.Connection);
                 clientLoadedScene = true;
-                client.Connection = null;
             }
 
             FinishStartHost();

--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -590,7 +590,6 @@ namespace Mirror
             {
                 client.OnAuthenticated(client.Connection);
                 clientLoadedScene = true;
-                client.Connection = null;
             }
 
             if (client.IsConnected)


### PR DESCRIPTION
This is a fix for the Scene Change Example. It was previously mentioned in an issue.

All tests pass locally. Currently the only test to benefit from this change is one using ServerChangeScene which is the new SceneChange example and the previous RoomManager from Mirror that has been removed from NG. But this change does not seem to negatively effect the other examples.

Host mode works in editor. To test client mode you must run everything outside the editor.

I am having an issue with connecting multiple clients in this example. Due to the logging issue I am having a hard time tracking it down.