### PR TITLE
Remove NC Conn set in NetMan OnAuth

### DIFF
--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -654,7 +654,6 @@ namespace Mirror
 
             // will wait for scene id to come from the server.
             clientLoadedScene = true;
-            client.Connection = conn;
         }
 
         void OnClientNotReadyMessageInternal(INetworkConnection conn, NotReadyMessage msg)


### PR DESCRIPTION
It is already set in NC under Connect and ConnectHost. The connection could not have changed during OnAuth so its useless.

NetworkClient.cs:175
NetworkClient.cs:202