### PR TITLE
feature: Add weaver attributes for HasAuthority and IsLocalPlayer

### DIFF
--- a/Assets/Mirror/Editor/Weaver/Weaver.cs
+++ b/Assets/Mirror/Editor/Weaver/Weaver.cs
@@ -85,6 +85,8 @@ namespace Mirror.Weaver
         public static MethodReference NetworkBehaviourIsServer;
         public static MethodReference NetworkBehaviourIsClient;
         public static MethodReference NetworkBehaviourIsLocalClient;
+        public static MethodReference NetworkBehaviourHasAuthority;
+        public static MethodReference NetworkBehaviourIsLocalPlayer;
 
         // custom attribute types
         public static TypeReference SyncVarType;
@@ -293,6 +295,8 @@ namespace Mirror.Weaver
             NetworkBehaviourIsServer = Resolvers.ResolveProperty(NetworkBehaviourType, CurrentAssembly, "IsServer");
             NetworkBehaviourIsClient = Resolvers.ResolveProperty(NetworkBehaviourType, CurrentAssembly, "IsClient");
             NetworkBehaviourIsLocalClient = Resolvers.ResolveProperty(NetworkBehaviourType, CurrentAssembly, "IsLocalClient");
+            NetworkBehaviourHasAuthority = Resolvers.ResolveProperty(NetworkBehaviourType, CurrentAssembly, "HasAuthority");
+            NetworkBehaviourIsLocalPlayer = Resolvers.ResolveProperty(NetworkBehaviourType, CurrentAssembly, "IsLocalPlayer");
 
             MonoBehaviourType = UnityAssembly.MainModule.GetType("UnityEngine.MonoBehaviour");
             ScriptableObjectType = UnityAssembly.MainModule.GetType("UnityEngine.ScriptableObject");

--- a/Assets/Mirror/Runtime/CustomAttributes.cs
+++ b/Assets/Mirror/Runtime/CustomAttributes.cs
@@ -84,6 +84,34 @@ namespace Mirror
     public class ClientCallbackAttribute : Attribute { }
 
     /// <summary>
+    /// Prevents players without authority from running this method.
+    /// <para>Prints a warning if a player without authority tries to execute this method.</para>
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method)]
+    public class HasAuthorityAttribute : Attribute { }
+
+    /// <summary>
+    /// Prevents players without authority from running this method.
+    /// <para>No warning is printed.</para>
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method)]
+    public class HasAuthorityCallbackAttribute : Attribute { }
+
+    /// <summary>
+    /// Prevents nonlocal players from running this method.
+    /// <para>Prints a warning if a nonlocal player tries to execute this method.</para>
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method)]
+    public class LocalPlayerAttribute : Attribute { }
+
+    /// <summary>
+    /// Prevents a nonlocal player from running this method.
+    /// <para>No warning is printed.</para>
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method)]
+    public class LocalPlayerCallbackAttribute : Attribute { }
+
+    /// <summary>
     /// Converts a string property into a Scene property in the inspector
     /// </summary>
     public class SceneAttribute : PropertyAttribute { }


### PR DESCRIPTION
A minor quality of life addition would be to add two new attributes for HasAuthority and IsLocalPlayer. 
I personally check for authority quite frequently as a safeguard and an attribute would speed up my workflow a bit. 
One could also see it as a way to "complete the set" since there's already attributes for checking if the object is a server and client, so why not if it is a local player or it has authority?

The attributes are just `[HasAuthority]` and `[LocalPlayer]`. Callback versions are also provided.

For now, the weaver instructions have been put in the ServerClientAttributeProcessor class as I didn't want to edit too much in the weaver. A change that could make sense with the addition of these attributes is to rename the ServerClientAttributeProcessor class to something like GuardAttributeProcessor instead since it's main purpose is to add guards