### PR TITLE
Fields in NetworkManager, NetworkServer, and NetworkClient are now set when created.

### DIFF
--- a/Assets/Mirror/Runtime/NetworkClient.cs
+++ b/Assets/Mirror/Runtime/NetworkClient.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Mirror.AsyncTcp;
 using UnityEngine;
 using UnityEngine.Events;
 using Guid = System.Guid;
@@ -146,6 +147,28 @@ namespace Mirror
         /// NetworkClient can connect to local server in host mode too
         /// </summary>
         public bool IsLocalClient => hostServer != null;
+
+        /// <summary>
+        /// Called when the script gets added to an object. Useful for getting other needed scripts.
+        /// </summary>
+        private void Reset()
+        {
+            // add transport if there is none yet. makes upgrading easier.
+            if (Transport == null)
+            {
+                // First try to get the transport.
+                Transport = GetComponent<AsyncTransport>();
+                // was a transport added yet? if not, add one
+                if (Transport == null)
+                {
+                    Transport = gameObject.AddComponent<AsyncTcpTransport>();
+                    logger.Log("NetworkManager: added default Transport because there was none yet.");
+                }
+#if UNITY_EDITOR
+                UnityEditor.Undo.RecordObject(gameObject, "Added default Transport");
+#endif
+            }
+        }
 
         /// <summary>
         /// Connect client to a NetworkServer instance.

--- a/Assets/Mirror/Runtime/NetworkClient.cs
+++ b/Assets/Mirror/Runtime/NetworkClient.cs
@@ -162,7 +162,7 @@ namespace Mirror
                 if (Transport == null)
                 {
                     Transport = gameObject.AddComponent<AsyncTcpTransport>();
-                    logger.Log("NetworkManager: added default Transport because there was none yet.");
+                    logger.Log("NetworkClient: added default Transport because there was none yet.");
                 }
 #if UNITY_EDITOR
                 UnityEditor.Undo.RecordObject(gameObject, "Added default Transport");

--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -77,9 +77,9 @@ namespace Mirror
         #region Unity Callbacks
 
         /// <summary>
-        /// virtual so that inheriting classes' OnValidate() can call base.OnValidate() too
+        /// virtual so that inheriting classes' Reset() can call base.Reset() too
         /// </summary>
-        public virtual void OnValidate()
+        public virtual void Reset()
         {
             // add transport if there is none yet. makes upgrading easier.
             if (transport == null)
@@ -96,8 +96,10 @@ namespace Mirror
 #endif
             }
 
+            // Try and get the server first.
+            server = GetComponent<NetworkServer>();
             // add NetworkServer if there is none yet. makes upgrading easier.
-            if (GetComponent<NetworkServer>() == null)
+            if (server == null)
             {
                 server = gameObject.AddComponent<NetworkServer>();
                 logger.Log("NetworkManager: added NetworkServer because there was none yet.");
@@ -106,8 +108,10 @@ namespace Mirror
 #endif
             }
 
+            // Try and get the client first.
+            client = GetComponent<NetworkClient>();
             // add NetworkClient if there is none yet. makes upgrading easier.
-            if (GetComponent<NetworkClient>() == null)
+            if (client == null)
             {
                 client = gameObject.AddComponent<NetworkClient>();
                 logger.Log("NetworkManager: added NetworkClient because there was none yet.");

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Mirror.AsyncTcp;
 using UnityEngine;
 using UnityEngine.Events;
 
@@ -121,6 +122,28 @@ namespace Mirror
 
         // transport to use to accept connections
         public AsyncTransport transport;
+
+        /// <summary>
+        /// Called when the script gets added to an object. Useful for getting other needed scripts.
+        /// </summary>
+        private void Reset()
+        {
+            // add transport if there is none yet. makes upgrading easier.
+            if (transport == null)
+            {
+                // First try to get the transport.
+                transport = GetComponent<AsyncTransport>();
+                // was a transport added yet? if not, add one
+                if (transport == null)
+                {
+                    transport = gameObject.AddComponent<AsyncTcpTransport>();
+                    logger.Log("NetworkManager: added default Transport because there was none yet.");
+                }
+#if UNITY_EDITOR
+                UnityEditor.Undo.RecordObject(gameObject, "Added default Transport");
+#endif
+            }
+        }
 
         /// <summary>
         /// This shuts down the server and disconnects all clients.

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -137,7 +137,7 @@ namespace Mirror
                 if (transport == null)
                 {
                     transport = gameObject.AddComponent<AsyncTcpTransport>();
-                    logger.Log("NetworkManager: added default Transport because there was none yet.");
+                    logger.Log("NetworkServer: added default Transport because there was none yet.");
                 }
 #if UNITY_EDITOR
                 UnityEditor.Undo.RecordObject(gameObject, "Added default Transport");

--- a/Assets/Mirror/Tests/Editor/NetworkManagerTest.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkManagerTest.cs
@@ -1,0 +1,21 @@
+using System.Collections;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace Mirror.Tests
+{
+    public class NetworkManagerTest
+    {
+        [UnityTest]
+        public IEnumerator NetworkManagerSetupHasComponents()
+        {
+            NetworkManager networkManager = new GameObject("Network Manager Test").AddComponent<NetworkManager>();
+            yield return null;
+            Assert.IsNotNull(networkManager.client);
+            Assert.IsNotNull(networkManager.server);
+
+            Object.DestroyImmediate(networkManager);
+        }
+    }
+}

--- a/Assets/Mirror/Tests/Editor/NetworkManagerTest.cs.meta
+++ b/Assets/Mirror/Tests/Editor/NetworkManagerTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cadd51da58f5e834caa624870cb34909
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Also changed OnValidate to Reset in NetworkManager since it only needs to be run once.
NetworkManager, NetworkClient, and NetworkServer now gets all the scripts they needed when they are added. For example, NetworkManager gets the NetworkClient and NetworkServer script that is added due to the RequireComponent attribute. 