### PR TITLE
fix: test added a Transport but never actually used it

### DIFF
--- a/Assets/Mirror/Tests/Editor/NetworkIdentityTests.cs
+++ b/Assets/Mirror/Tests/Editor/NetworkIdentityTests.cs
@@ -175,7 +175,6 @@ namespace Mirror.Tests
         public void SetUp()
         {
             networkServerGameObject = new GameObject();
-            networkServerGameObject.AddComponent<MockTransport>();
             server = networkServerGameObject.AddComponent<NetworkServer>();
             client = networkServerGameObject.AddComponent<NetworkClient>();
 


### PR DESCRIPTION
Now that Transports are auto assigned this cause tests to fail as the un-Initialized Transport should not be asked to disconnect.