### PR TITLE
fix: examples run in background

### DIFF
--- a/Assets/Mirror/Examples/AdditiveScenes/Scenes/MainScene.unity
+++ b/Assets/Mirror/Examples/AdditiveScenes/Scenes/MainScene.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.43667555, g: 0.48427176, b: 0.5645241, a: 1}
+  m_IndirectSpecularColor: {r: 0.4366757, g: 0.48427194, b: 0.5645252, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -390,7 +390,10 @@ MonoBehaviour:
   OnStopAuthority:
     m_PersistentCalls:
       m_Calls: []
-  OnNetworkDestroy:
+  OnStopClient:
+    m_PersistentCalls:
+      m_Calls: []
+  OnStopServer:
     m_PersistentCalls:
       m_Calls: []
 --- !u!114 &159607913
@@ -536,6 +539,7 @@ GameObject:
   - component: {fileID: 534669905}
   - component: {fileID: 534669904}
   - component: {fileID: 534669903}
+  - component: {fileID: 534669906}
   m_Layer: 0
   m_Name: Main Camera
   m_TagString: MainCamera
@@ -608,6 +612,18 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
+--- !u!114 &534669906
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 534669902}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fc6b510c425006f458e9b99cb817c55b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &589935540
 GameObject:
   m_ObjectHideFlags: 0
@@ -1874,7 +1890,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   dontDestroyOnLoad: 0
   startOnHeadless: 1
-  showDebugMessages: 0
   serverTickRate: 30
   server: {fileID: 1661834283}
   client: {fileID: 1661834282}
@@ -1960,6 +1975,15 @@ MonoBehaviour:
   Authenticated:
     m_PersistentCalls:
       m_Calls: []
+  ClientNotReady:
+    m_PersistentCalls:
+      m_Calls: []
+  ClientChangeScene:
+    m_PersistentCalls:
+      m_Calls: []
+  ClientSceneChanged:
+    m_PersistentCalls:
+      m_Calls: []
   Disconnected:
     m_PersistentCalls:
       m_Calls: []
@@ -1993,6 +2017,12 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls: []
   Authenticated:
+    m_PersistentCalls:
+      m_Calls: []
+  ServerChangeScene:
+    m_PersistentCalls:
+      m_Calls: []
+  ServerSceneChanged:
     m_PersistentCalls:
       m_Calls: []
   Disconnected:

--- a/Assets/Mirror/Examples/Basic/Scenes/Example.unity
+++ b/Assets/Mirror/Examples/Basic/Scenes/Example.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.4465934, g: 0.49642956, b: 0.57482487, a: 1}
+  m_IndirectSpecularColor: {r: 0.44657898, g: 0.4964133, b: 0.5748178, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -192,7 +192,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   dontDestroyOnLoad: 0
   startOnHeadless: 0
-  showDebugMessages: 0
   serverTickRate: 30
   server: {fileID: 249891959}
   client: {fileID: 249891958}
@@ -237,6 +236,15 @@ MonoBehaviour:
   Authenticated:
     m_PersistentCalls:
       m_Calls: []
+  ClientNotReady:
+    m_PersistentCalls:
+      m_Calls: []
+  ClientChangeScene:
+    m_PersistentCalls:
+      m_Calls: []
+  ClientSceneChanged:
+    m_PersistentCalls:
+      m_Calls: []
   Disconnected:
     m_PersistentCalls:
       m_Calls: []
@@ -268,6 +276,12 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls: []
   Authenticated:
+    m_PersistentCalls:
+      m_Calls: []
+  ServerChangeScene:
+    m_PersistentCalls:
+      m_Calls: []
+  ServerSceneChanged:
     m_PersistentCalls:
       m_Calls: []
   Disconnected:
@@ -303,6 +317,7 @@ GameObject:
   - component: {fileID: 288173827}
   - component: {fileID: 288173826}
   - component: {fileID: 288173825}
+  - component: {fileID: 288173828}
   m_Layer: 0
   m_Name: Main Camera
   m_TagString: MainCamera
@@ -375,6 +390,18 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &288173828
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 288173824}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fc6b510c425006f458e9b99cb817c55b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &379082678
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Mirror/Examples/ChangeScene/Scenes/Main.unity
+++ b/Assets/Mirror/Examples/ChangeScene/Scenes/Main.unity
@@ -187,7 +187,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   dontDestroyOnLoad: 1
   startOnHeadless: 1
-  showDebugMessages: 0
   serverTickRate: 30
   server: {fileID: 450078217}
   client: {fileID: 450078216}
@@ -218,6 +217,15 @@ MonoBehaviour:
   Authenticated:
     m_PersistentCalls:
       m_Calls: []
+  ClientNotReady:
+    m_PersistentCalls:
+      m_Calls: []
+  ClientChangeScene:
+    m_PersistentCalls:
+      m_Calls: []
+  ClientSceneChanged:
+    m_PersistentCalls:
+      m_Calls: []
   Disconnected:
     m_PersistentCalls:
       m_Calls: []
@@ -243,6 +251,12 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls: []
   Authenticated:
+    m_PersistentCalls:
+      m_Calls: []
+  ServerChangeScene:
+    m_PersistentCalls:
+      m_Calls: []
+  ServerSceneChanged:
     m_PersistentCalls:
       m_Calls: []
   Disconnected:
@@ -342,6 +356,7 @@ GameObject:
   - component: {fileID: 1334311557}
   - component: {fileID: 1334311556}
   - component: {fileID: 1334311555}
+  - component: {fileID: 1334311558}
   m_Layer: 0
   m_Name: Main Camera
   m_TagString: MainCamera
@@ -414,6 +429,18 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1334311558
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1334311554}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fc6b510c425006f458e9b99cb817c55b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &1818873914788449007
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Mirror/Examples/Chat/Scenes/Main.unity
+++ b/Assets/Mirror/Examples/Chat/Scenes/Main.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.4465934, g: 0.49642956, b: 0.57482487, a: 1}
+  m_IndirectSpecularColor: {r: 0.44657898, g: 0.4964133, b: 0.5748178, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -339,7 +339,10 @@ MonoBehaviour:
   OnStopAuthority:
     m_PersistentCalls:
       m_Calls: []
-  OnNetworkDestroy:
+  OnStopClient:
+    m_PersistentCalls:
+      m_Calls: []
+  OnStopServer:
     m_PersistentCalls:
       m_Calls: []
 --- !u!1 &90143746
@@ -3032,7 +3035,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   dontDestroyOnLoad: 1
   startOnHeadless: 1
-  showDebugMessages: 0
   serverTickRate: 30
   server: {fileID: 1783103028}
   client: {fileID: 1783103027}
@@ -3080,12 +3082,21 @@ MonoBehaviour:
   Authenticated:
     m_PersistentCalls:
       m_Calls: []
+  ClientNotReady:
+    m_PersistentCalls:
+      m_Calls: []
+  ClientChangeScene:
+    m_PersistentCalls:
+      m_Calls: []
+  ClientSceneChanged:
+    m_PersistentCalls:
+      m_Calls: []
   Disconnected:
     m_PersistentCalls:
       m_Calls: []
   spawnPrefabs:
   - {fileID: 5075528875289742095, guid: e5905ffa27de84009b346b49d518ba03, type: 3}
-  Transport: {fileID: 0}
+  Transport: {fileID: 1783103024}
 --- !u!114 &1783103028
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -3108,6 +3119,12 @@ MonoBehaviour:
   Authenticated:
     m_PersistentCalls:
       m_Calls: []
+  ServerChangeScene:
+    m_PersistentCalls:
+      m_Calls: []
+  ServerSceneChanged:
+    m_PersistentCalls:
+      m_Calls: []
   Disconnected:
     m_PersistentCalls:
       m_Calls: []
@@ -3116,7 +3133,7 @@ MonoBehaviour:
       m_Calls: []
   authenticator: {fileID: 0}
   Listening: 1
-  transport: {fileID: 0}
+  transport: {fileID: 1783103024}
 --- !u!1 &1863915624
 GameObject:
   m_ObjectHideFlags: 0
@@ -3234,6 +3251,7 @@ GameObject:
   - component: {fileID: 1897504369}
   - component: {fileID: 1897504368}
   - component: {fileID: 1897504367}
+  - component: {fileID: 1897504370}
   m_Layer: 0
   m_Name: Main Camera
   m_TagString: MainCamera
@@ -3306,6 +3324,18 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1897504370
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1897504366}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fc6b510c425006f458e9b99cb817c55b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1904406264
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Mirror/Examples/Discovery/Scenes/Scene.unity
+++ b/Assets/Mirror/Examples/Discovery/Scenes/Scene.unity
@@ -304,6 +304,7 @@ GameObject:
   - component: {fileID: 1392889998}
   - component: {fileID: 1392889997}
   - component: {fileID: 1392889996}
+  - component: {fileID: 1392889999}
   m_Layer: 0
   m_Name: Main Camera
   m_TagString: MainCamera
@@ -376,6 +377,18 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1392889999
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1392889995}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fc6b510c425006f458e9b99cb817c55b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1556883243
 GameObject:
   m_ObjectHideFlags: 0
@@ -432,7 +445,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   dontDestroyOnLoad: 1
   startOnHeadless: 1
-  showDebugMessages: 0
   serverTickRate: 30
   server: {fileID: 1556883250}
   client: {fileID: 1556883249}
@@ -521,6 +533,15 @@ MonoBehaviour:
   Authenticated:
     m_PersistentCalls:
       m_Calls: []
+  ClientNotReady:
+    m_PersistentCalls:
+      m_Calls: []
+  ClientChangeScene:
+    m_PersistentCalls:
+      m_Calls: []
+  ClientSceneChanged:
+    m_PersistentCalls:
+      m_Calls: []
   Disconnected:
     m_PersistentCalls:
       m_Calls: []
@@ -528,7 +549,7 @@ MonoBehaviour:
   - {fileID: 9081919128954505657, guid: ecd52c53a6ef7496693343d3e32dace1, type: 3}
   - {fileID: 9081919128954505657, guid: ecd52c53a6ef7496693343d3e32dace1, type: 3}
   - {fileID: 9081919128954505657, guid: ecd52c53a6ef7496693343d3e32dace1, type: 3}
-  Transport: {fileID: 0}
+  Transport: {fileID: 1556883252}
 --- !u!114 &1556883250
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -551,6 +572,12 @@ MonoBehaviour:
   Authenticated:
     m_PersistentCalls:
       m_Calls: []
+  ServerChangeScene:
+    m_PersistentCalls:
+      m_Calls: []
+  ServerSceneChanged:
+    m_PersistentCalls:
+      m_Calls: []
   Disconnected:
     m_PersistentCalls:
       m_Calls: []
@@ -559,7 +586,7 @@ MonoBehaviour:
       m_Calls: []
   authenticator: {fileID: 0}
   Listening: 1
-  transport: {fileID: 0}
+  transport: {fileID: 1556883252}
 --- !u!114 &1556883252
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Mirror/Examples/ListServer/Scenes/Scene.unity
+++ b/Assets/Mirror/Examples/ListServer/Scenes/Scene.unity
@@ -287,6 +287,7 @@ GameObject:
   - component: {fileID: 88936776}
   - component: {fileID: 88936775}
   - component: {fileID: 88936774}
+  - component: {fileID: 88936778}
   m_Layer: 0
   m_Name: Main Camera
   m_TagString: MainCamera
@@ -367,6 +368,18 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 45, y: 180, z: 0}
+--- !u!114 &88936778
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 88936773}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fc6b510c425006f458e9b99cb817c55b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &123981370
 GameObject:
   m_ObjectHideFlags: 0
@@ -2522,6 +2535,15 @@ MonoBehaviour:
   Authenticated:
     m_PersistentCalls:
       m_Calls: []
+  ClientNotReady:
+    m_PersistentCalls:
+      m_Calls: []
+  ClientChangeScene:
+    m_PersistentCalls:
+      m_Calls: []
+  ClientSceneChanged:
+    m_PersistentCalls:
+      m_Calls: []
   Disconnected:
     m_PersistentCalls:
       m_Calls: []
@@ -2529,7 +2551,7 @@ MonoBehaviour:
   - {fileID: 1916082411674582, guid: 6f43bf5488a7443d19ab2a83c6b91f35, type: 3}
   - {fileID: 2011878188}
   - {fileID: 9081919128954505657, guid: ecd52c53a6ef7496693343d3e32dace1, type: 3}
-  Transport: {fileID: 0}
+  Transport: {fileID: 1282001521}
 --- !u!114 &1282001520
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2544,7 +2566,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   dontDestroyOnLoad: 1
   startOnHeadless: 1
-  showDebugMessages: 0
   serverTickRate: 30
   server: {fileID: 1282001523}
   client: {fileID: 1282001519}
@@ -2610,6 +2631,12 @@ MonoBehaviour:
   Authenticated:
     m_PersistentCalls:
       m_Calls: []
+  ServerChangeScene:
+    m_PersistentCalls:
+      m_Calls: []
+  ServerSceneChanged:
+    m_PersistentCalls:
+      m_Calls: []
   Disconnected:
     m_PersistentCalls:
       m_Calls: []
@@ -2618,7 +2645,7 @@ MonoBehaviour:
       m_Calls: []
   authenticator: {fileID: 0}
   Listening: 1
-  transport: {fileID: 0}
+  transport: {fileID: 1282001521}
 --- !u!1 &1291804677
 GameObject:
   m_ObjectHideFlags: 0
@@ -3324,7 +3351,10 @@ MonoBehaviour:
   OnStopAuthority:
     m_PersistentCalls:
       m_Calls: []
-  OnNetworkDestroy:
+  OnStopClient:
+    m_PersistentCalls:
+      m_Calls: []
+  OnStopServer:
     m_PersistentCalls:
       m_Calls: []
 --- !u!4 &2011878191

--- a/Assets/Mirror/Examples/Pong/Scenes/Scene.unity
+++ b/Assets/Mirror/Examples/Pong/Scenes/Scene.unity
@@ -352,6 +352,7 @@ GameObject:
   - component: {fileID: 1346799730}
   - component: {fileID: 1346799728}
   - component: {fileID: 1346799727}
+  - component: {fileID: 1346799729}
   m_Layer: 0
   m_Name: Main Camera
   m_TagString: MainCamera
@@ -375,6 +376,18 @@ Behaviour:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1346799726}
   m_Enabled: 1
+--- !u!114 &1346799729
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1346799726}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fc6b510c425006f458e9b99cb817c55b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!20 &1346799730
 Camera:
   m_ObjectHideFlags: 0
@@ -887,7 +900,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   dontDestroyOnLoad: 1
   startOnHeadless: 1
-  showDebugMessages: 0
   serverTickRate: 30
   server: {fileID: 1886246555}
   client: {fileID: 1886246554}
@@ -940,6 +952,15 @@ MonoBehaviour:
   Authenticated:
     m_PersistentCalls:
       m_Calls: []
+  ClientNotReady:
+    m_PersistentCalls:
+      m_Calls: []
+  ClientChangeScene:
+    m_PersistentCalls:
+      m_Calls: []
+  ClientSceneChanged:
+    m_PersistentCalls:
+      m_Calls: []
   Disconnected:
     m_PersistentCalls:
       m_Calls: []
@@ -951,7 +972,7 @@ MonoBehaviour:
   - {fileID: 1240244544407914, guid: b1651eaf8c7564a1c86031dfbb8a7b28, type: 3}
   - {fileID: 1240244544407914, guid: b1651eaf8c7564a1c86031dfbb8a7b28, type: 3}
   - {fileID: 1240244544407914, guid: b1651eaf8c7564a1c86031dfbb8a7b28, type: 3}
-  Transport: {fileID: 0}
+  Transport: {fileID: 1886246557}
 --- !u!114 &1886246555
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -974,6 +995,12 @@ MonoBehaviour:
   Authenticated:
     m_PersistentCalls:
       m_Calls: []
+  ServerChangeScene:
+    m_PersistentCalls:
+      m_Calls: []
+  ServerSceneChanged:
+    m_PersistentCalls:
+      m_Calls: []
   Disconnected:
     m_PersistentCalls:
       m_Calls: []
@@ -982,7 +1009,7 @@ MonoBehaviour:
       m_Calls: []
   authenticator: {fileID: 0}
   Listening: 1
-  transport: {fileID: 0}
+  transport: {fileID: 1886246557}
 --- !u!114 &1886246557
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Mirror/Examples/RunInBackground.cs
+++ b/Assets/Mirror/Examples/RunInBackground.cs
@@ -1,0 +1,15 @@
+using UnityEngine;
+
+namespace Mirror.Examples
+{
+    /// <summary>
+    /// Run In Background. Attach this as a component anywhere in the scene if you want the build to run in background.
+    /// </summary>
+    public class RunInBackground : MonoBehaviour
+    {
+        void Start()
+        {
+            Application.runInBackground = true;
+        }
+    }
+}

--- a/Assets/Mirror/Examples/RunInBackground.cs.meta
+++ b/Assets/Mirror/Examples/RunInBackground.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fc6b510c425006f458e9b99cb817c55b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Mirror/Examples/Tanks/Scenes/Scene.unity
+++ b/Assets/Mirror/Examples/Tanks/Scenes/Scene.unity
@@ -133,6 +133,7 @@ GameObject:
   - component: {fileID: 88936776}
   - component: {fileID: 88936775}
   - component: {fileID: 88936774}
+  - component: {fileID: 88936778}
   m_Layer: 0
   m_Name: Main Camera
   m_TagString: MainCamera
@@ -213,6 +214,18 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 45, y: 180, z: 0}
+--- !u!114 &88936778
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 88936773}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fc6b510c425006f458e9b99cb817c55b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &251893064
 GameObject:
   m_ObjectHideFlags: 0
@@ -433,7 +446,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   dontDestroyOnLoad: 1
   startOnHeadless: 1
-  showDebugMessages: 0
   serverTickRate: 30
   server: {fileID: 1282001523}
   client: {fileID: 1282001522}
@@ -487,6 +499,15 @@ MonoBehaviour:
   Authenticated:
     m_PersistentCalls:
       m_Calls: []
+  ClientNotReady:
+    m_PersistentCalls:
+      m_Calls: []
+  ClientChangeScene:
+    m_PersistentCalls:
+      m_Calls: []
+  ClientSceneChanged:
+    m_PersistentCalls:
+      m_Calls: []
   Disconnected:
     m_PersistentCalls:
       m_Calls: []
@@ -494,7 +515,7 @@ MonoBehaviour:
   - {fileID: 5890560936853567077, guid: b7dd46dbf38c643f09e206f9fa4be008, type: 3}
   - {fileID: 1916082411674582, guid: 6f43bf5488a7443d19ab2a83c6b91f35, type: 3}
   - {fileID: 1916082411674582, guid: 6f43bf5488a7443d19ab2a83c6b91f35, type: 3}
-  Transport: {fileID: 0}
+  Transport: {fileID: 1282001524}
 --- !u!114 &1282001523
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -517,6 +538,12 @@ MonoBehaviour:
   Authenticated:
     m_PersistentCalls:
       m_Calls: []
+  ServerChangeScene:
+    m_PersistentCalls:
+      m_Calls: []
+  ServerSceneChanged:
+    m_PersistentCalls:
+      m_Calls: []
   Disconnected:
     m_PersistentCalls:
       m_Calls: []
@@ -525,7 +552,7 @@ MonoBehaviour:
       m_Calls: []
   authenticator: {fileID: 0}
   Listening: 1
-  transport: {fileID: 0}
+  transport: {fileID: 1282001524}
 --- !u!114 &1282001524
 MonoBehaviour:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
When testing Examples in a separate build when not in focus they would freeze and disconnect. RunInBackground was part of NetMan in the past but was removed as its not really part of Networking but it is needed for the Examples to work properly. So I added it as a script under the Mirror.Examples namespace and added it to all of the existing Examples.