### PR TITLE
fix: Additive Scene Example was missing Player Auth on movement.

### DIFF
--- a/Assets/Mirror/Examples/AdditiveScenes/Prefabs/Player.prefab
+++ b/Assets/Mirror/Examples/AdditiveScenes/Prefabs/Player.prefab
@@ -210,6 +210,27 @@ MonoBehaviour:
   sceneId: 0
   serverOnly: 0
   m_AssetId: 
+  OnStartServer:
+    m_PersistentCalls:
+      m_Calls: []
+  OnStartClient:
+    m_PersistentCalls:
+      m_Calls: []
+  OnStartLocalPlayer:
+    m_PersistentCalls:
+      m_Calls: []
+  OnStartAuthority:
+    m_PersistentCalls:
+      m_Calls: []
+  OnStopAuthority:
+    m_PersistentCalls:
+      m_Calls: []
+  OnStopClient:
+    m_PersistentCalls:
+      m_Calls: []
+  OnStopServer:
+    m_PersistentCalls:
+      m_Calls: []
 --- !u!114 &887491563423388292
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -224,10 +245,10 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   syncMode: 0
   syncInterval: 0
-  clientAuthority: 1
-  localPositionSensitivity: 0.01
-  localRotationSensitivity: 0.01
-  localScaleSensitivity: 0.01
+  ClientAuthority: 1
+  LocalPositionSensitivity: 0.01
+  LocalRotationSensitivity: 0.01
+  LocalScaleSensitivity: 0.01
 --- !u!143 &8993127209816276930
 CharacterController:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
Caused a scene loading bug.