### PR TITLE
Stop scene loading operation from being serialized

### DIFF
--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -358,6 +358,7 @@ namespace Mirror
         /// </remarks>
         public string networkSceneName = "";
 
+        [NonSerialized]
         public AsyncOperation loadingSceneAsync;
 
         /// <summary>


### PR DESCRIPTION
For some reason, the `loadingSceneAsync` field gets serialized in 2020.1 (might be a bug?) but to be extra safe, add a NonSerialized attribute to it to be 100% sure it stops it from being serialized.

When it gets serialized it causes an ArgumentNullException to be thrown internally in Unity.