### PR TITLE
feat: Server attribute now throws error

### DIFF
--- a/Assets/Mirror/Components/NetworkSceneChecker.cs
+++ b/Assets/Mirror/Components/NetworkSceneChecker.cs
@@ -29,7 +29,7 @@ namespace Mirror
 
         Scene currentScene;
 
-        [ServerCallback]
+        [Server(error=false)]
         void Awake()
         {
             currentScene = gameObject.scene;
@@ -46,7 +46,7 @@ namespace Mirror
             sceneCheckerObjects[currentScene].Add(NetIdentity);
         }
 
-        [ServerCallback]
+        [Server(error=false)]
         void Update()
         {
             if (currentScene == gameObject.scene)

--- a/Assets/Mirror/Editor/Weaver/Processors/MonoBehaviourProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/MonoBehaviourProcessor.cs
@@ -58,9 +58,6 @@ namespace Mirror.Weaver
                         case "Mirror.ServerAttribute":
                             Weaver.Error($"Server method {md.Name} must be declared inside a NetworkBehaviour", md);
                             break;
-                        case "Mirror.ServerCallbackAttribute":
-                            Weaver.Error($"ServerCallback method {md.Name} must be declared inside a NetworkBehaviour", md);
-                            break;
                         case "Mirror.ClientAttribute":
                             Weaver.Error($"Client method {md.Name} must be declared inside a NetworkBehaviour", md);
                             break;

--- a/Assets/Mirror/Editor/Weaver/Weaver.cs
+++ b/Assets/Mirror/Editor/Weaver/Weaver.cs
@@ -87,6 +87,8 @@ namespace Mirror.Weaver
         public static MethodReference NetworkBehaviourHasAuthority;
         public static MethodReference NetworkBehaviourIsLocalPlayer;
 
+        public static MethodReference MethodInvocationExceptionConstructor;
+
         // custom attribute types
         public static TypeReference SyncVarType;
         public static TypeReference CommandType;
@@ -304,6 +306,9 @@ namespace Mirror.Weaver
                 ScriptableObjectType, CurrentAssembly,
                 md => md.Name == "CreateInstance" && md.HasGenericParameters);
 
+            var MethodInvocationException = NetAssembly.MainModule.GetType("Mirror.MethodInvocationException");
+
+            MethodInvocationExceptionConstructor = Resolvers.ResolveMethodWithArg(MethodInvocationException, CurrentAssembly, ".ctor", "System.String");
 
             MessageBaseType = NetAssembly.MainModule.GetType("Mirror.MessageBase");
             IMessageBaseType = NetAssembly.MainModule.GetType("Mirror.IMessageBase");

--- a/Assets/Mirror/Examples/AdditiveScenes/Scripts/ShootingTankBehaviour.cs
+++ b/Assets/Mirror/Examples/AdditiveScenes/Scripts/ShootingTankBehaviour.cs
@@ -12,7 +12,7 @@ namespace Mirror.Examples.Additive
 
         NetworkAnimator networkAnimator;
 
-        [ServerCallback]
+        [Server(error=false)]
         void Start()
         {
             networkAnimator = GetComponent<NetworkAnimator>();

--- a/Assets/Mirror/Examples/Basic/Scripts/Player.cs
+++ b/Assets/Mirror/Examples/Basic/Scripts/Player.cs
@@ -56,7 +56,7 @@ namespace Mirror.Examples.Basic
         }
 
         // This only runs on the server, called from OnStartServer via InvokeRepeating
-        [ServerCallback]
+        [Server(error=false)]
         void UpdateData()
         {
             playerData = Random.Range(100, 1000);

--- a/Assets/Mirror/Examples/Benchmarks/10k/Scripts/Health.cs
+++ b/Assets/Mirror/Examples/Benchmarks/10k/Scripts/Health.cs
@@ -4,7 +4,7 @@ namespace Mirror.Examples
     {
         [SyncVar] public int health = 10;
 
-        [ServerCallback]
+        [Server(error = false)]
         public void Update()
         {
             health = (health + 1) % 10;

--- a/Assets/Mirror/Examples/Benchmarks/2k NetworkTransforms/Scripts/MonsterMovement.cs
+++ b/Assets/Mirror/Examples/Benchmarks/2k NetworkTransforms/Scripts/MonsterMovement.cs
@@ -17,7 +17,7 @@ namespace Mirror.Examples.OneK
             start = transform.position;
         }
 
-        [ServerCallback]
+        [Server(error = false)]
         void Update()
         {
             if (moving)

--- a/Assets/Mirror/Examples/MultipleAdditiveScenes/Scripts/PhysicsCollision.cs
+++ b/Assets/Mirror/Examples/MultipleAdditiveScenes/Scripts/PhysicsCollision.cs
@@ -21,7 +21,7 @@ namespace Mirror.Examples.MultipleAdditiveScenes
             rigidbody3D.isKinematic = !IsServer;
         }
 
-        [ServerCallback]
+        [Server(error=false)]
         void OnCollisionStay(Collision other)
         {
             if (other.gameObject.CompareTag("Player"))

--- a/Assets/Mirror/Examples/MultipleAdditiveScenes/Scripts/Reward.cs
+++ b/Assets/Mirror/Examples/MultipleAdditiveScenes/Scripts/Reward.cs
@@ -17,7 +17,7 @@ namespace Mirror.Examples.MultipleAdditiveScenes
                 randomColor = GetComponent<RandomColor>();
         }
 
-        [ServerCallback]
+        [Server(error=false)]
         void OnTriggerEnter(Collider other)
         {
             if (other.gameObject.CompareTag("Player"))

--- a/Assets/Mirror/Examples/Pong/Scripts/Ball.cs
+++ b/Assets/Mirror/Examples/Pong/Scripts/Ball.cs
@@ -33,7 +33,7 @@ namespace Mirror.Examples.Pong
         }
 
         // only call this on server
-        [ServerCallback]
+        [Server(error=false)]
         void OnCollisionEnter2D(Collision2D col)
         {
             // Note: 'col' holds the collision information. If the

--- a/Assets/Mirror/Examples/Tanks/Scripts/Projectile.cs
+++ b/Assets/Mirror/Examples/Tanks/Scripts/Projectile.cs
@@ -38,7 +38,7 @@ namespace Mirror.Examples.Tanks
 
         // ServerCallback because we don't want a warning if OnTriggerEnter is
         // called on the client
-        [ServerCallback]
+        [Server(error=false)]
         void OnTriggerEnter(Collider co)
         {
             //Hit another player

--- a/Assets/Mirror/Examples/Tanks/Scripts/Projectile.cs
+++ b/Assets/Mirror/Examples/Tanks/Scripts/Projectile.cs
@@ -36,7 +36,7 @@ namespace Mirror.Examples.Tanks
             Server.Destroy(gameObject);
         }
 
-        // ServerCallback because we don't want a warning if OnTriggerEnter is
+        // [Server] because we don't want a warning if OnTriggerEnter is
         // called on the client
         [Server(error=false)]
         void OnTriggerEnter(Collider co)

--- a/Assets/Mirror/Runtime/CustomAttributes.cs
+++ b/Assets/Mirror/Runtime/CustomAttributes.cs
@@ -59,17 +59,40 @@ namespace Mirror
 
     /// <summary>
     /// Prevents clients from running this method.
-    /// <para>Prints a warning if a client tries to execute this method.</para>
     /// </summary>
     [AttributeUsage(AttributeTargets.Method)]
-    public class ServerAttribute : Attribute { }
+    public class ServerAttribute : Attribute
+    {
+        /// <summary>
+        /// If true,  when the method is called from a client, it throws an error
+        /// If false, no error is thrown, but the method won't execute
+        /// useful for unity built in methods such as Await, Update, Start, etc.
+        /// </summary>
+        public bool error = true;
+    }
+
 
     /// <summary>
-    /// Prevents clients from running this method.
-    /// <para>No warning is thrown.</para>
+    /// Exception thrown if a guarded method is invoked incorrectly
     /// </summary>
-    [AttributeUsage(AttributeTargets.Method)]
-    public class ServerCallbackAttribute : Attribute { }
+    [Serializable]
+    public class MethodInvocationException : Exception
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="T:MethodInvocationException"/> class
+        /// </summary>
+        public MethodInvocationException()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="T:MethodInvocationException"/> class
+        /// </summary>
+        /// <param name="message">A <see cref="T:System.String"/> that describes the exception. </param>
+        public MethodInvocationException(string message) : base(message)
+        {
+        }
+    }
 
     /// <summary>
     /// Prevents the server from running this method.

--- a/Assets/Mirror/Runtime/CustomAttributes.cs
+++ b/Assets/Mirror/Runtime/CustomAttributes.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.Serialization;
 using UnityEngine;
 
 namespace Mirror
@@ -75,7 +76,8 @@ namespace Mirror
     /// <summary>
     /// Exception thrown if a guarded method is invoked incorrectly
     /// </summary>
-    public class MethodInvocationException : Exception
+    [Serializable]
+    public class MethodInvocationException : Exception, ISerializable
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="T:MethodInvocationException"/> class

--- a/Assets/Mirror/Runtime/CustomAttributes.cs
+++ b/Assets/Mirror/Runtime/CustomAttributes.cs
@@ -77,7 +77,7 @@ namespace Mirror
     /// Exception thrown if a guarded method is invoked incorrectly
     /// </summary>
     [Serializable]
-    public class MethodInvocationException : Exception, ISerializable
+    public class MethodInvocationException : Exception
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="T:MethodInvocationException"/> class

--- a/Assets/Mirror/Runtime/CustomAttributes.cs
+++ b/Assets/Mirror/Runtime/CustomAttributes.cs
@@ -93,6 +93,12 @@ namespace Mirror
         public MethodInvocationException(string message) : base(message)
         {
         }
+
+        // A constructor is needed for serialization when an
+        // exception propagates from a remoting server to the client.
+        protected MethodInvocationException(SerializationInfo info,StreamingContext context) : base(info, context)
+        {
+        }
     }
 
     /// <summary>

--- a/Assets/Mirror/Runtime/CustomAttributes.cs
+++ b/Assets/Mirror/Runtime/CustomAttributes.cs
@@ -75,7 +75,6 @@ namespace Mirror
     /// <summary>
     /// Exception thrown if a guarded method is invoked incorrectly
     /// </summary>
-    [Serializable]
     public class MethodInvocationException : Exception
     {
         /// <summary>

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverMonoBehaviourTests.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverMonoBehaviourTests.cs
@@ -49,7 +49,7 @@ namespace Mirror.Weaver.Tests
         [Test]
         public void MonoBehaviourServerCallback()
         {
-            Assert.That(weaverErrors, Contains.Item("ServerCallback method ThisCantBeOutsideNetworkBehaviour must be declared inside a NetworkBehaviour (at System.Void WeaverMonoBehaviourTests.MonoBehaviourServerCallback.MonoBehaviourServerCallback::ThisCantBeOutsideNetworkBehaviour())"));
+            Assert.That(weaverErrors, Contains.Item("Server method ThisCantBeOutsideNetworkBehaviour must be declared inside a NetworkBehaviour (at System.Void WeaverMonoBehaviourTests.MonoBehaviourServerCallback.MonoBehaviourServerCallback::ThisCantBeOutsideNetworkBehaviour())"));
         }
 
         [Test]

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverMonoBehaviourTests~/MonoBehaviourServerCallback.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverMonoBehaviourTests~/MonoBehaviourServerCallback.cs
@@ -5,7 +5,7 @@ namespace WeaverMonoBehaviourTests.MonoBehaviourServerCallback
 {
     class MonoBehaviourServerCallback : MonoBehaviour
     {
-        [ServerCallback]
+        [Server(error = false)]
         void ThisCantBeOutsideNetworkBehaviour() { }
     }
 }

--- a/Assets/Mirror/Tests/Runtime/GuardsTests.cs
+++ b/Assets/Mirror/Tests/Runtime/GuardsTests.cs
@@ -16,7 +16,7 @@ namespace Mirror.Tests
             serverFunctionCalled = true;
         }
 
-        [ServerCallback]
+        [Server(error=false)]
         public void CallServerCallbackFunction()
         {
             serverCallbackFunctionCalled = true;
@@ -70,9 +70,10 @@ namespace Mirror.Tests
         [Test]
         public void CannotCallServerFunctionAsClient()
         {
-            clientComponent.CallServerFunction();
-            LogAssert.Expect(UnityEngine.LogType.Warning, "[Server] function 'System.Void Mirror.Tests.ExampleGuards::CallServerFunction()' called on client");
-            Assert.That(clientComponent.serverFunctionCalled, Is.False);
+            Assert.Throws<MethodInvocationException>(() =>
+            {
+               clientComponent.CallServerFunction();
+            });
         }
 
         [Test]

--- a/Assets/Resources.meta
+++ b/Assets/Resources.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 63ff6fb9db0834ce3999ae706a4d41a7
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/doc/Guides/Attributes.md
+++ b/doc/Guides/Attributes.md
@@ -8,11 +8,9 @@ These attributes can be used for Unity game loop methods like Start or Update, a
 
 -   **NetworkSettings**  
     This attribute has been deprecated because `channels` were moved to transports (where applicable) and `interval` was moved to an inspector property
--   **Server**  
-    Only a server can call the method (throws a warning or an error when called on a client).
--   **ServerCallback**  
-    Same as **Server** but does not throw warning when called on client.
--   **Client**  
+-   **<xref:Mirror.ServerAttribute>**  
+    Only a server can call the method (throws an error when called on a client unless you specify error = false).
+-   **<xref:Mirror.ClientAttribute>**  
     Only a Client can call the method (throws a warning or an error when called on the server).
 -   **ClientCallback**  
     Same as **Client** but does not throw warning when called on server.

--- a/doc/Guides/NetworkBehaviour.md
+++ b/doc/Guides/NetworkBehaviour.md
@@ -68,11 +68,7 @@ Note that in a peer-hosted setup, when one of the clients is acting as both host
 
 ## Server and Client functions
 
-You can tag member functions in NetworkBehaviour scripts with custom attributes to designate them as server-only or client-only functions. `Server` and `ServerCallback` return immediately if the client is not active. Likewise, `Client` and `ClientCallback` return immediately if the server is not active.
-
-The `Server` and `Client` attributes are for your own custom callback functions. They do not generate compile time errors, but they do emit a warning log message if called in the wrong scope.
-
-The `ServerCallback` and `ClientCallback` attributes are for built-in callback functions that are called automatically by Mirror. These attributes do not cause a warning to be generated.
+You can tag member functions in NetworkBehaviour scripts with custom attributes to designate them as server-only or client-only functions. <xref:Mirror.ServerAttribute> will check that the function is called in the server. Likewise, <xref:Mirror.ClientAttribute> will check if the function is called in the client.
 
 For more information, see [Attributes](Attributes.md).
 


### PR DESCRIPTION
If you want to get an error you do this:
```cs
[Server]
public void ServerFunctionOnly() {}
```

If you don't want to get an error, you do this:
```cs
[Server(error = false)]
public void ServerFunctionOnly() {}
```

BREAKING CHANGE: [ServerCallback] is now [Server(error = false)]