### PR TITLE
feat: HasAuthority attribute now throws error

### DIFF
--- a/Assets/Mirror/Runtime/CustomAttributes.cs
+++ b/Assets/Mirror/Runtime/CustomAttributes.cs
@@ -117,17 +117,17 @@ namespace Mirror
 
     /// <summary>
     /// Prevents players without authority from running this method.
-    /// <para>Prints a warning if a player without authority tries to execute this method.</para>
     /// </summary>
     [AttributeUsage(AttributeTargets.Method)]
-    public class HasAuthorityAttribute : Attribute { }
-
-    /// <summary>
-    /// Prevents players without authority from running this method.
-    /// <para>No warning is printed.</para>
-    /// </summary>
-    [AttributeUsage(AttributeTargets.Method)]
-    public class HasAuthorityCallbackAttribute : Attribute { }
+    public class HasAuthorityAttribute : Attribute 
+    { 
+        /// <summary>
+        /// If true,  when the method is called from a client, it throws an error
+        /// If false, no error is thrown, but the method won't execute
+        /// useful for unity built in methods such as Await, Update, Start, etc.
+        /// </summary>
+        public bool error = true;
+    }
 
     /// <summary>
     /// Prevents nonlocal players from running this method.

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverClientServerAttributeTests.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverClientServerAttributeTests.cs
@@ -23,6 +23,13 @@ namespace Mirror.Weaver.Tests
             CheckAddedCode(Weaver.NetworkBehaviourIsClient, "WeaverClientServerAttributeTests.NetworkBehaviourClient.NetworkBehaviourClient", "ClientOnlyMethod");
         }
 
+        [Test]
+        public void NetworkBehaviourHasAuthority()
+        {
+            Assert.That(weaverErrors, Is.Empty);
+            CheckAddedCode(Weaver.NetworkBehaviourHasAuthority, "WeaverClientServerAttributeTests.NetworkBehaviourHasAuthority.NetworkBehaviourHasAuthority", "HasAuthorityMethod");
+        }
+
         /// <summary>
         /// Checks that first Instructions in MethodBody is addedString
         /// </summary>

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverClientServerAttributeTests~/NetworkBehaviourHasAuthority.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverClientServerAttributeTests~/NetworkBehaviourHasAuthority.cs
@@ -1,0 +1,13 @@
+using Mirror;
+
+namespace WeaverClientServerAttributeTests.NetworkBehaviourHasAuthority
+{
+    class NetworkBehaviourHasAuthority : NetworkBehaviour
+    {
+        [HasAuthority]
+        void HasAuthorityMethod()
+        {
+            // test method
+        }
+    }
+}

--- a/Assets/Mirror/Tests/Runtime/GuardsTests.cs
+++ b/Assets/Mirror/Tests/Runtime/GuardsTests.cs
@@ -123,7 +123,7 @@ namespace Mirror.Tests
         public void CanCallHasAuthorityCallbackFunctionAsClient()
         {
             clientComponent.CallAuthorityNoErrorFunction();
-            Assert.That(clientComponent.clientCallbackFunctionCalled, Is.True);
+            Assert.That(clientComponent.hasAuthorityNoErrorCalled, Is.True);
         }
 
         [Test]

--- a/Assets/Mirror/Tests/Runtime/GuardsTests.cs
+++ b/Assets/Mirror/Tests/Runtime/GuardsTests.cs
@@ -1,5 +1,6 @@
 using NUnit.Framework;
 using UnityEngine.TestTools;
+using UnityEngine;
 
 namespace Mirror.Tests
 {
@@ -9,6 +10,8 @@ namespace Mirror.Tests
         public bool serverCallbackFunctionCalled;
         public bool clientFunctionCalled;
         public bool clientCallbackFunctionCalled;
+        public bool hasAuthorityCalled;
+        public bool hasAuthorityNoErrorCalled;
 
         [Server]
         public void CallServerFunction()
@@ -32,6 +35,18 @@ namespace Mirror.Tests
         public void CallClientCallbackFunction()
         {
             clientCallbackFunctionCalled = true;
+        }
+
+        [HasAuthority]
+        public void CallAuthorityFunction() 
+        {
+            hasAuthorityCalled = true;
+        }
+
+        [HasAuthority(error = false)]
+        public void CallAuthorityNoErrorFunction() 
+        {
+            hasAuthorityNoErrorCalled = true;
         }
     }
 
@@ -97,5 +112,44 @@ namespace Mirror.Tests
             Assert.That(clientComponent.clientCallbackFunctionCalled, Is.True);
         }
 
+        [Test]
+        public void CanCallHasAuthorityFunctionAsClient()
+        {
+            clientComponent.CallAuthorityFunction();
+            Assert.That(clientComponent.hasAuthorityCalled, Is.True);
+        }
+
+        [Test]
+        public void CanCallHasAuthorityCallbackFunctionAsClient()
+        {
+            clientComponent.CallAuthorityNoErrorFunction();
+            Assert.That(clientComponent.clientCallbackFunctionCalled, Is.True);
+        }
+
+        [Test]
+        public void GuardHasAuthorityError()
+        {
+            var obj = new GameObject("randomObject", typeof(NetworkIdentity), typeof(ExampleGuards));
+            ExampleGuards guardedComponent = obj.GetComponent<ExampleGuards>();
+
+            Assert.Throws<MethodInvocationException>( () => 
+            {
+                guardedComponent.CallAuthorityFunction();
+            });
+
+            Object.Destroy(obj);
+        }
+
+        [Test]
+        public void GuardHasAuthorityNoError()
+        {
+            var obj = new GameObject("randomObject", typeof(NetworkIdentity), typeof(ExampleGuards));
+            ExampleGuards guardedComponent = obj.GetComponent<ExampleGuards>();
+
+            guardedComponent.CallAuthorityNoErrorFunction();
+            Assert.That(guardedComponent.hasAuthorityNoErrorCalled, Is.False);
+
+            Object.Destroy(obj);
+        }
     }
 }


### PR DESCRIPTION
If you want to get an error you do this:
```cs
[HasAuthority]
public void ClientFunctionOnly() {}
```

If you don't want to get an error, you do this:
```cs
[HasAuthority(error = false)]
public void ClientFunctionOnly() {}
```

BREAKING CHANGE: [HasAuthorityCallback] is now [HasAuthority(error = false)]