### PR TITLE
feat: LocalPlayer attribute now throws error

### DIFF
--- a/Assets/Mirror/Editor/Weaver/Processors/ServerClientAttributeProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/ServerClientAttributeProcessor.cs
@@ -30,10 +30,7 @@ namespace Mirror.Weaver
                         InjectHasAuthorityGuard(td, md, false);
                         break;
                     case "Mirror.LocalPlayerAttribute":
-                        InjectLocalPlayerGuard(td, md, true);
-                        break;
-                    case "Mirror.LocalPlayerCallbackAttribute":
-                        InjectLocalPlayerGuard(td, md, false);
+                        InjectLocalPlayerGuard(td, md, attr);
                         break;
                     default:
                         break;
@@ -115,8 +112,10 @@ namespace Mirror.Weaver
             worker.InsertBefore(top, worker.Create(OpCodes.Ret));
         }
 
-        static void InjectLocalPlayerGuard(TypeDefinition td, MethodDefinition md, bool logWarning)
+        static void InjectLocalPlayerGuard(TypeDefinition td, MethodDefinition md, CustomAttribute attribute)
         {
+            bool throwError = attribute.GetField<bool>("error", true);
+
             if (!Weaver.IsNetworkBehaviour(td))
             {
                 Weaver.Error($"Local Player method {md.Name} must be declared in a NetworkBehaviour", md);
@@ -128,10 +127,11 @@ namespace Mirror.Weaver
             worker.InsertBefore(top, worker.Create(OpCodes.Ldarg_0));
             worker.InsertBefore(top, worker.Create(OpCodes.Call, Weaver.NetworkBehaviourIsLocalPlayer));
             worker.InsertBefore(top, worker.Create(OpCodes.Brtrue, top));
-            if (logWarning)
+            if (throwError)
             {
                 worker.InsertBefore(top, worker.Create(OpCodes.Ldstr, "[Local Player] function '" + md.FullName + "' called on nonlocal player"));
-                worker.InsertBefore(top, worker.Create(OpCodes.Call, Weaver.logWarningReference));
+                worker.InsertBefore(top, worker.Create(OpCodes.Newobj, Weaver.MethodInvocationExceptionConstructor));
+                worker.InsertBefore(top, worker.Create(OpCodes.Throw));
             }
 
             InjectGuardParameters(md, worker, top);

--- a/Assets/Mirror/Runtime/CustomAttributes.cs
+++ b/Assets/Mirror/Runtime/CustomAttributes.cs
@@ -131,17 +131,17 @@ namespace Mirror
 
     /// <summary>
     /// Prevents nonlocal players from running this method.
-    /// <para>Prints a warning if a nonlocal player tries to execute this method.</para>
     /// </summary>
     [AttributeUsage(AttributeTargets.Method)]
-    public class LocalPlayerAttribute : Attribute { }
-
-    /// <summary>
-    /// Prevents a nonlocal player from running this method.
-    /// <para>No warning is printed.</para>
-    /// </summary>
-    [AttributeUsage(AttributeTargets.Method)]
-    public class LocalPlayerCallbackAttribute : Attribute { }
+    public class LocalPlayerAttribute : Attribute
+    {
+        /// <summary>
+        /// If true,  when the method is called from a client, it throws an error
+        /// If false, no error is thrown, but the method won't execute
+        /// useful for unity built in methods such as Await, Update, Start, etc.
+        /// </summary>
+        public bool error = true;
+    }
 
     /// <summary>
     /// Converts a string property into a Scene property in the inspector

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverClientServerAttributeTests.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverClientServerAttributeTests.cs
@@ -30,6 +30,13 @@ namespace Mirror.Weaver.Tests
             CheckAddedCode(Weaver.NetworkBehaviourHasAuthority, "WeaverClientServerAttributeTests.NetworkBehaviourHasAuthority.NetworkBehaviourHasAuthority", "HasAuthorityMethod");
         }
 
+        [Test]
+        public void NetworkBehaviourLocalPlayer()
+        {
+            Assert.That(weaverErrors, Is.Empty);
+            CheckAddedCode(Weaver.NetworkBehaviourIsLocalPlayer, "WeaverClientServerAttributeTests.NetworkBehaviourLocalPlayer.NetworkBehaviourLocalPlayer", "LocalPlayerMethod");
+        }
+
         /// <summary>
         /// Checks that first Instructions in MethodBody is addedString
         /// </summary>

--- a/Assets/Mirror/Tests/Editor/Weaver/WeaverClientServerAttributeTests~/NetworkBehaviourLocalPlayer.cs
+++ b/Assets/Mirror/Tests/Editor/Weaver/WeaverClientServerAttributeTests~/NetworkBehaviourLocalPlayer.cs
@@ -1,0 +1,13 @@
+using Mirror;
+
+namespace WeaverClientServerAttributeTests.NetworkBehaviourLocalPlayer
+{
+    class NetworkBehaviourLocalPlayer : NetworkBehaviour
+    {
+        [LocalPlayer]
+        void LocalPlayerMethod()
+        {
+            // test method
+        }
+    }
+}


### PR DESCRIPTION
If you want to get an error you do this:
```cs
[LocalPlayer]
public void LocalPlayerFunctionOnly() {}
```

If you don't want to get an error, you do this:
```cs
[LocalPlayer(error = false)]
public void LocalPlayerFunctionOnly() {}
```

BREAKING CHANGE: [LocalPlayerCallback] is now [LocalPlayer(error = false)]