### PR TITLE
feat: Transports can tell if they are supported

### DIFF
--- a/Assets/Mirror/Runtime/Transport/AsyncFallbackTransport.cs
+++ b/Assets/Mirror/Runtime/Transport/AsyncFallbackTransport.cs
@@ -13,102 +13,49 @@ namespace Mirror
         {
             get
             {
-                foreach (Transport transport in transports)
-                {
-                    try
-                    {
-                        return transport.Scheme;
-                    }
-                    catch (PlatformNotSupportedException)
-                    {
-                        // try the next transport
-                    }
-                }
-                throw new PlatformNotSupportedException("None of the transports is supported in this platform");
+                return GetTransport().Scheme;
             }
         }
 
-        public override async Task<IConnection> AcceptAsync()
+        private Transport GetTransport()
         {
             foreach (Transport transport in transports)
             {
-                try
-                {
-                    return await transport.AcceptAsync();
-                }
-                catch (PlatformNotSupportedException)
-                {
-                    // try the next transport
-                }
+                if (transport.Supported)
+                    return transport;
             }
-
             throw new PlatformNotSupportedException("None of the transports is supported in this platform");
-       }
+        }
 
-        public override async Task<IConnection> ConnectAsync(Uri uri)
+        public override bool Supported => GetTransport() != null;
+
+        public override Task<IConnection> AcceptAsync()
         {
-            foreach (Transport transport in transports)
-            {
-                try
-                {
-                    return await transport.ConnectAsync(uri);
-                }
-                catch (PlatformNotSupportedException)
-                {
-                    // try the next transport
-                }
-            }
-            throw new PlatformNotSupportedException($"No transport was able to connect to {uri}");
+            return GetTransport().AcceptAsync();
+        }
+
+        public override Task<IConnection> ConnectAsync(Uri uri)
+        {
+            return GetTransport().ConnectAsync(uri);
         }
 
         public override void Disconnect()
         {
             foreach (Transport transport in transports)
             {
-                try
-                {
+                if (transport.Supported)
                     transport.Disconnect();
-                    return;
-                }
-                catch (PlatformNotSupportedException)
-                {
-                    // try the next transport
-                }
             }
-            throw new PlatformNotSupportedException($"No transport available in this platform");
         }
 
-        public override async Task ListenAsync()
+        public override Task ListenAsync()
         {
-            foreach (Transport transport in transports)
-            {
-                try
-                {
-                    await transport.ListenAsync();
-                    return;
-                }
-                catch (PlatformNotSupportedException)
-                {
-                    // try the next transport
-                }
-            }
-            throw new PlatformNotSupportedException($"No transport available in this platform");
+            return GetTransport().ListenAsync();
         }
 
         public override Uri ServerUri()
         {
-            foreach (Transport transport in transports)
-            {
-                try
-                {
-                    return transport.ServerUri();
-                }
-                catch (PlatformNotSupportedException)
-                {
-                    // try the next transport
-                }
-            }
-            throw new PlatformNotSupportedException($"No transport available in this platform");
+            return GetTransport().ServerUri();
         }
     }
 }

--- a/Assets/Mirror/Runtime/Transport/AsyncMultiplexTransport.cs
+++ b/Assets/Mirror/Runtime/Transport/AsyncMultiplexTransport.cs
@@ -80,7 +80,12 @@ namespace Mirror
 
         public override  Task<IConnection> ConnectAsync(Uri uri)
         {
-            return GetTransport().ConnectAsync(uri);
+            foreach (Transport transport in transports)
+            {
+                if (transport.Supported && transport.Scheme == uri.Scheme)
+                    return transport.ConnectAsync(uri);
+            }
+            throw new ArgumentException($"No transport was able to connect to {uri}");
         }
 
         public override void Disconnect()

--- a/Assets/Mirror/Runtime/Transport/AsyncMultiplexTransport.cs
+++ b/Assets/Mirror/Runtime/Transport/AsyncMultiplexTransport.cs
@@ -6,12 +6,12 @@ using System.Threading.Tasks;
 
 namespace Mirror
 {
-    public class AsyncMultiplexTransport :  Transport
+    public class AsyncMultiplexTransport : Transport
     {
 
-        public  Transport[] transports;
+        public Transport[] transports;
 
-        private Dictionary<Task<IConnection>,  Transport> Accepters;
+        private Dictionary<Task<IConnection>, Transport> Accepters;
 
         public override string Scheme
         {
@@ -19,18 +19,24 @@ namespace Mirror
             {
                 foreach (Transport transport in transports)
                 {
-                    try
-                    {
+                    if (transport.Supported)
                         return transport.Scheme;
-                    }
-                    catch (PlatformNotSupportedException)
-                    {
-                        // try the next transport
-                    }
                 }
                 throw new PlatformNotSupportedException("No transport was able to provide scheme");
             }
         }
+
+        private Transport GetTransport()
+        {
+            foreach (Transport transport in transports)
+            {
+                if (transport.Supported)
+                    return transport;
+            }
+            throw new PlatformNotSupportedException("None of the transports is supported in this platform");
+        }
+
+        public override bool Supported => GetTransport() != null;
 
         public override async Task<IConnection> AcceptAsync()
         {
@@ -72,20 +78,9 @@ namespace Mirror
             }
         }
 
-        public override async Task<IConnection> ConnectAsync(Uri uri)
+        public override  Task<IConnection> ConnectAsync(Uri uri)
         {
-            foreach (Transport transport in transports)
-            {
-                try
-                {
-                    return await transport.ConnectAsync(uri);
-                }
-                catch (ArgumentException)
-                {
-                    // try the next transport
-                }
-            }
-            throw new ArgumentException($"No transport was able to connect to {uri}");
+            return GetTransport().ConnectAsync(uri);
         }
 
         public override void Disconnect()

--- a/Assets/Mirror/Runtime/Transport/AsyncTcp/AsyncTcpTransport.cs
+++ b/Assets/Mirror/Runtime/Transport/AsyncTcp/AsyncTcpTransport.cs
@@ -3,6 +3,7 @@ using System;
 using System.Net;
 using System.Net.Sockets;
 using System.Threading.Tasks;
+using UnityEngine;
 
 namespace Mirror.AsyncTcp
 {
@@ -12,6 +13,8 @@ namespace Mirror.AsyncTcp
         public int Port = 7777;
 
         public override string Scheme => "tcp4";
+
+        public override bool Supported => Application.platform != RuntimePlatform.WebGLPlayer;
 
         public override Task ListenAsync()
         {

--- a/Assets/Mirror/Runtime/Transport/Transport.cs
+++ b/Assets/Mirror/Runtime/Transport/Transport.cs
@@ -26,6 +26,12 @@ namespace Mirror
         public abstract void Disconnect();
 
         /// <summary>
+        /// Determines if this transport is supported in the current platform
+        /// </summary>
+        /// <returns>true if the transport works in this platform</returns>
+        public abstract bool Supported { get; }
+
+        /// <summary>
         /// Connect to a server located at a provided uri
         /// </summary>
         /// <param name="uri">address of the server to connect to</param>

--- a/Assets/Mirror/Runtime/Transport/Websocket/AsyncWsTransport.cs
+++ b/Assets/Mirror/Runtime/Transport/Websocket/AsyncWsTransport.cs
@@ -18,6 +18,9 @@ namespace Mirror.Websocket
 
         public override string Scheme => "ws";
 
+        // supported in all platforms
+        public override bool Supported => true;
+
         public override async Task<IConnection> AcceptAsync()
         {
             try

--- a/Assets/Mirror/Tests/Common/LoopbackTransport.cs
+++ b/Assets/Mirror/Tests/Common/LoopbackTransport.cs
@@ -17,6 +17,8 @@ namespace Mirror.Tests
 
         public override string Scheme => "local";
 
+        public override bool Supported => true;
+
         public override Task<IConnection> ConnectAsync(Uri uri)
         {
             (IConnection c1, IConnection c2) = PipeConnection.CreatePipe();

--- a/Assets/Mirror/Tests/Common/MockTransport.cs
+++ b/Assets/Mirror/Tests/Common/MockTransport.cs
@@ -17,6 +17,8 @@ namespace Mirror.Tests
 
         public override string Scheme => "tcp4";
 
+        public override bool Supported => true;
+
         public override async Task<IConnection> ConnectAsync(Uri uri)
         {
             return await ConnectConnections.DequeueAsync();

--- a/Assets/Mirror/Tests/Editor/Transport/AsyncMultiplexTransportTest.cs
+++ b/Assets/Mirror/Tests/Editor/Transport/AsyncMultiplexTransportTest.cs
@@ -35,6 +35,9 @@ namespace Mirror.Tests
             transport1 = Substitute.For<Transport>();
             transport2 = Substitute.For<Transport>();
 
+            transport1.Supported.Returns(true);
+            transport2.Supported.Returns(true);
+
             transport.transports = new[] { transport1, transport2 };
             conn1 = Substitute.For<IConnection>();
             conn2 = Substitute.For<IConnection>();
@@ -130,8 +133,8 @@ namespace Mirror.Tests
         [Test]
         public void SchemeNone()
         {
-            transport1.Scheme.Returns(x => { throw new PlatformNotSupportedException(); });
-            transport2.Scheme.Returns(x => { throw new PlatformNotSupportedException(); });
+            transport1.Supported.Returns(false);
+            transport2.Supported.Returns(false);
 
             Assert.Throws<PlatformNotSupportedException>(() =>
             {
@@ -142,6 +145,9 @@ namespace Mirror.Tests
         [UnityTest]
         public IEnumerator Connect() => RunAsync(async () =>
         {
+            transport1.Scheme.Returns("yomama");
+            transport2.Scheme.Returns("tcp4");
+
             transport1.ConnectAsync(Arg.Any<Uri>())
                 .Returns(Task.FromException<IConnection>(new ArgumentException("Invalid protocol")));
 


### PR DESCRIPTION
Transports now have a Supported property, which is true if the transport works on the current platform.

For example, TCP is supported everywhere except WebGL