### PR TITLE
remove hostServer set as its never not null

### DIFF
--- a/Assets/Mirror/Runtime/NetworkClient.cs
+++ b/Assets/Mirror/Runtime/NetworkClient.cs
@@ -612,7 +612,6 @@ namespace Mirror
             identity.transform.localScale = msg.scale;
             identity.HasAuthority = msg.isOwner;
             identity.NetId = msg.netId;
-            identity.Server = hostServer;
             identity.Client = this;
 
             if (msg.isLocalPlayer)


### PR DESCRIPTION
NetworkClient.cs:615 "identity.Server = hostServer" - is set under Client.ApplySpawnPayload

ApplySpawnPayload is private and only has 1 ref under OnSpawn

OnSpawn is an internal method that is a registered message handler only in client mode.

Therefor NetworkClient.cs:615 "identity.Server = hostServer" will always be null.

Removing this line will leave it null just the same.