### PR TITLE
Test cleanup

### DIFF
--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -92,7 +92,7 @@ namespace Mirror
         public readonly HashSet<INetworkConnection> connections = new HashSet<INetworkConnection>();
 
         /// <summary>
-        /// <para>If you enable this, the server will not listen for incoming connections on the regular network port.</para>
+        /// <para>If you disable this, the server will not listen for incoming connections on the regular network port.</para>
         /// <para>This can be used if the game is running in host mode and does not want external players to be able to connect - making it like a single-player game. Also this can be useful when using AddExternalConnection().</para>
         /// </summary>
         public bool Listening = true;

--- a/Assets/Mirror/Tests/Editor/ExponentialMovingAverageTest.cs
+++ b/Assets/Mirror/Tests/Editor/ExponentialMovingAverageTest.cs
@@ -1,4 +1,5 @@
 using NUnit.Framework;
+
 namespace Mirror.Tests
 {
     [TestFixture]

--- a/Assets/Mirror/Tests/Editor/MessagePackerTest.cs
+++ b/Assets/Mirror/Tests/Editor/MessagePackerTest.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using NUnit.Framework;
+
 namespace Mirror.Tests
 {
     [TestFixture]

--- a/Assets/Mirror/Tests/Runtime/ClientServerComponentTests.cs
+++ b/Assets/Mirror/Tests/Runtime/ClientServerComponentTests.cs
@@ -6,7 +6,6 @@ using UnityEngine.TestTools;
 using Guid = System.Guid;
 using Object = UnityEngine.Object;
 using static Mirror.Tests.AsyncUtil;
-using System.Threading.Tasks;
 
 namespace Mirror.Tests
 {

--- a/Assets/Mirror/Tests/Runtime/ClientServerSetup.cs
+++ b/Assets/Mirror/Tests/Runtime/ClientServerSetup.cs
@@ -35,10 +35,7 @@ namespace Mirror.Tests
         protected INetworkConnection connectionToServer;
         protected INetworkConnection connectionToClient;
 
-        public virtual void ExtraSetup()
-        {
-
-        }
+        public virtual void ExtraSetup() { }
 
         [UnitySetUp]
         public IEnumerator Setup() => RunAsync(async () =>
@@ -108,6 +105,8 @@ namespace Mirror.Tests
             clientComponent = clientPlayerGO.GetComponent<T>();
         });
 
+        public virtual void ExtraTearDown() { }
+
         [UnityTearDown]
         public IEnumerator ShutdownHost() => RunAsync(async () =>
         {
@@ -122,6 +121,8 @@ namespace Mirror.Tests
             Object.DestroyImmediate(clientGo);
             Object.DestroyImmediate(serverPlayerGO);
             Object.DestroyImmediate(clientPlayerGO);
+
+            ExtraTearDown();
         });
 
         #endregion

--- a/Assets/Mirror/Tests/Runtime/HostComponentTests.cs
+++ b/Assets/Mirror/Tests/Runtime/HostComponentTests.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections;
-using System.Threading.Tasks;
 using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.TestTools;

--- a/Assets/Mirror/Tests/Runtime/HostSetup.cs
+++ b/Assets/Mirror/Tests/Runtime/HostSetup.cs
@@ -22,6 +22,8 @@ namespace Mirror.Tests
         protected NetworkIdentity identity;
         protected T component;
 
+        public virtual void ExtraSetup() { }
+
         [UnitySetUp]
         public IEnumerator SetupHost() => RunAsync(async () =>
         {
@@ -39,6 +41,8 @@ namespace Mirror.Tests
             sceneManager.client = client;
             sceneManager.server = server;
 
+            ExtraSetup();
+
             // wait for client and server to initialize themselves
             await Task.Delay(1);
 
@@ -54,6 +58,8 @@ namespace Mirror.Tests
             client.Update();
         });
 
+        public virtual void ExtraTearDown() { }
+
         [UnityTearDown]
         public IEnumerator ShutdownHost() => RunAsync(async () =>
         {
@@ -62,6 +68,8 @@ namespace Mirror.Tests
 
             await Task.Delay(1);
             Object.Destroy(networkManagerGo);
+
+            ExtraTearDown();
         });
 
         #endregion

--- a/Assets/Mirror/Tests/Runtime/NetworkIdentityTests.cs
+++ b/Assets/Mirror/Tests/Runtime/NetworkIdentityTests.cs
@@ -10,7 +10,7 @@ using NSubstitute;
 using System;
 using System.Threading.Tasks;
 
-namespace Mirror.Tests.Runtime
+namespace Mirror.Tests
 {
     public class NetworkIdentityTests
     {

--- a/Assets/Mirror/Tests/Runtime/NetworkSceneManagerTests.cs
+++ b/Assets/Mirror/Tests/Runtime/NetworkSceneManagerTests.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections;
-using System.Threading.Tasks;
 using NSubstitute;
 using NUnit.Framework;
 using UnityEngine;
@@ -42,7 +41,7 @@ namespace Mirror.Tests
         {
             client.Disconnect();
 
-            await Task.Delay(1);
+            await WaitFor(() => !client.Active);
 
             sceneManager.ServerSceneChanged.AddListener(TestOnServerOnlySceneChangedInvoke);
 


### PR DESCRIPTION
also trying to clean up the redundant tests from the 2 NetworkServerTest classes. The local test results are different than sonar so marking this as WIP while I figure out what needs to be moved over.

I was in the middle of changing the old NS Test class to use ClientServerSetup but it seems like more than half the tests are redundant.