### PR TITLE
breaking: server cleans up objects in disconnect

### DIFF
--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -126,6 +126,8 @@ namespace Mirror
             }
             if (transport != null)
                 transport.Disconnect();
+
+            DestroyAllObjects();
         }
         
         void Initialize()
@@ -958,6 +960,18 @@ namespace Mirror
             {
                 SpawnObject(obj, ownerConnection);
             }
+        }
+
+        void DestroyAllObjects()
+        {
+            foreach (NetworkIdentity identity in spawned.Values.ToList())
+            {
+                if (identity != null && identity.gameObject != null)
+                {
+                    DestroyObject(identity, true);
+                }
+            }
+            spawned.Clear();
         }
 
         void DestroyObject(NetworkIdentity identity, bool destroyServerObject)


### PR DESCRIPTION
WIP fix for #302.

Looking for opinions on this. If the object is destroyed on the server too via:
`DestroyObject(identity, true);`
Then you are unable to simply hit StartServer again as the objects are missing.
But if you leave that false then the player object remains after disconnect.

Clearly both of those options suck. So any suggestions?