### PR TITLE
breaking: remove SetClientReady conn as its known

### DIFF
--- a/Assets/Mirror/Runtime/INetworkSceneManager.cs
+++ b/Assets/Mirror/Runtime/INetworkSceneManager.cs
@@ -4,6 +4,6 @@ namespace Mirror
     {
         void ChangeServerScene(string newSceneName, SceneOperation sceneOperation = SceneOperation.Normal);
 
-        void SetClientReady(INetworkConnection conn);
+        void SetClientReady();
     }
 }

--- a/Assets/Mirror/Runtime/NetworkSceneManager.cs
+++ b/Assets/Mirror/Runtime/NetworkSceneManager.cs
@@ -294,18 +294,15 @@ namespace Mirror
         /// Signal that the client connection is ready to enter the game.
         /// <para>This could be for example when a client enters an ongoing game and has finished loading the current scene. The server should respond to the message with an appropriate handler which instantiates the players object for example.</para>
         /// </summary>
-        /// <param name="conn">The client connection which is ready.</param>
-        public void SetClientReady(INetworkConnection conn)
+        public void SetClientReady()
         {
+            if (!client || !client.Active)
+                throw new InvalidOperationException("Ready() called with with invalid of disconnected client");
+
             if (Ready)
-            {
                 throw new InvalidOperationException("A connection has already been set as ready. There can only be one.");
-            }
 
-            if (conn == null)
-                throw new InvalidOperationException("Ready() called with invalid connection object: conn=null");
-
-            if (logger.LogEnabled()) logger.Log("ClientScene.Ready() called with connection [" + conn + "]");
+            if (logger.LogEnabled()) logger.Log("ClientScene.Ready() called.");
 
             // Set these before sending the ReadyMessage, otherwise host client
             // will fail in InternalAddPlayer with null readyConnection.
@@ -313,7 +310,7 @@ namespace Mirror
             client.Connection.IsReady = true;
 
             // Tell server we're ready to have a player object spawned
-            conn.Send(new ReadyMessage());
+            client.Connection.Send(new ReadyMessage());
         }
 
         #endregion

--- a/Assets/Mirror/Runtime/NetworkSceneManager.cs
+++ b/Assets/Mirror/Runtime/NetworkSceneManager.cs
@@ -275,7 +275,7 @@ namespace Mirror
         {
             //set ready after scene change has completed
             if (!Ready)
-                SetClientReady(conn);
+                SetClientReady();
 
             ClientSceneChanged.Invoke(conn);
         }

--- a/Assets/Mirror/Runtime/PlayerSpawner.cs
+++ b/Assets/Mirror/Runtime/PlayerSpawner.cs
@@ -53,7 +53,7 @@ namespace Mirror
             // clientLoadedScene flag to prevent it.
             // Ready/AddPlayer is usually triggered by a scene load completing. if no scene was loaded, then Ready/AddPlayer it here instead.
             if (!client.sceneManager.Ready)
-                client.sceneManager.SetClientReady(connection);
+                client.sceneManager.SetClientReady();
 
             client.Send(new AddPlayerMessage());
         }

--- a/Assets/Mirror/Tests/Runtime/NetworkSceneManagerTests.cs
+++ b/Assets/Mirror/Tests/Runtime/NetworkSceneManagerTests.cs
@@ -95,7 +95,7 @@ namespace Mirror.Tests
         [Test]
         public void ReadyTest()
         {
-            client.sceneManager.SetClientReady(client.Connection);
+            client.sceneManager.SetClientReady();
             Assert.That(sceneManager.Ready);
             Assert.That(client.Connection.IsReady);
         }
@@ -103,20 +103,11 @@ namespace Mirror.Tests
         [Test]
         public void ReadyTwiceTest()
         {
-            sceneManager.SetClientReady(client.Connection);
+            sceneManager.SetClientReady();
 
             Assert.Throws<InvalidOperationException>(() =>
             {
-                sceneManager.SetClientReady(client.Connection);
-            });
-        }
-
-        [Test]
-        public void ReadyNull()
-        {
-            Assert.Throws<InvalidOperationException>(() =>
-            {
-                sceneManager.SetClientReady(null);
+                sceneManager.SetClientReady();
             });
         }
 
@@ -234,7 +225,7 @@ namespace Mirror.Tests
         {
             UnityAction<INetworkConnection> func1 = Substitute.For<UnityAction<INetworkConnection>>();
             client.sceneManager.ClientNotReady.AddListener(func1);
-            client.sceneManager.SetClientReady(client.Connection);
+            client.sceneManager.SetClientReady();
             client.sceneManager.ClientNotReadyMessage(null, new NotReadyMessage());
 
             Assert.That(client.sceneManager.Ready, Is.False);


### PR DESCRIPTION
This would either apply to a ClientOnly or a HostClient. In both cases the method internally calls the client.Connection so there is no need to pass one in as it would be the same anyway.

Removed NULL test as that case is no longer possible.