### PR TITLE
fix: moved SpawnObjects call for hostmode to after LocalClient Connected

### DIFF
--- a/Assets/Mirror/Runtime/NetworkClient.cs
+++ b/Assets/Mirror/Runtime/NetworkClient.cs
@@ -179,6 +179,9 @@ namespace Mirror
             hostServer = server;
             Connection = new NetworkConnection(c1);
             RegisterHostHandlers();
+
+            server.ActivateHostScene();
+
             _ = OnConnected();
         }
 

--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -139,30 +139,7 @@ namespace Mirror
             // is called after the server is actually properly started.
             OnStartHost.Invoke();
 
-            FinishStartHost();
-        }
-
-        // FinishStartHost is guaranteed to be called after the host server was
-        // fully started and all the asynchronous StartHost magic is finished
-        // (= scene loading), or immediately if there was no asynchronous magic.
-        //
-        // note: we don't really need FinishStartClient/FinishStartServer. the
-        //       host version is enough.
-        void FinishStartHost()
-        {
-            // connect client and call OnStartClient AFTER server scene was
-            // loaded and all objects were spawned.
-            // DO NOT do this earlier. it would cause race conditions where a
-            // client will do things before the server is even fully started.
-            logger.Log("StartHostClient called");
-            StartHostClient();
-        }
-
-        void StartHostClient()
-        {
-            logger.Log("NetworkManager ConnectLocalClient");
-
-            server.ActivateHostScene();
+            logger.Log("NetworkManager StartHost");
         }
 
         /// <summary>

--- a/Assets/Mirror/Runtime/NetworkSceneManager.cs
+++ b/Assets/Mirror/Runtime/NetworkSceneManager.cs
@@ -302,7 +302,6 @@ namespace Mirror
                 }
 
                 // server scene was loaded. now spawn all the objects
-                server.SpawnObjects();
                 server.ActivateHostScene();
 
                 // call OnServerSceneChanged

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -284,6 +284,8 @@ namespace Mirror
         /// </summary>
         internal void ActivateHostScene()
         {
+            SpawnObjects();
+
             foreach (NetworkIdentity identity in Spawned.Values)
             {
                 if (!identity.IsClient)


### PR DESCRIPTION
Lymdun reported issue in discord where a scene object in host mode would always have a null Client.

![image](https://user-images.githubusercontent.com/1385108/89089830-37d7b180-d36d-11ea-8454-63499df87729.png)

This PR fixes that issue due to ActivateHostScene() being called in NetworkManager under StartHostClient(). The test struct for NetworkIdentity has a bad Setup. Will attempt to clean up that file to add tests for this fix.