### PR TITLE
breaking: remove redundant scene ready value

### DIFF
--- a/Assets/Mirror/Runtime/PlayerSpawner.cs
+++ b/Assets/Mirror/Runtime/PlayerSpawner.cs
@@ -52,7 +52,7 @@ namespace Mirror
             // that when we have online/offline scenes. so we need the
             // clientLoadedScene flag to prevent it.
             // Ready/AddPlayer is usually triggered by a scene load completing. if no scene was loaded, then Ready/AddPlayer it here instead.
-            if (!sceneManager.Ready)
+            if (!client.Connection.IsReady)
                 sceneManager.SetClientReady();
 
             client.Send(new AddPlayerMessage());

--- a/Assets/Mirror/Tests/Runtime/NetworkSceneManagerTests.cs
+++ b/Assets/Mirror/Tests/Runtime/NetworkSceneManagerTests.cs
@@ -96,7 +96,6 @@ namespace Mirror.Tests
         public void ReadyTest()
         {
             sceneManager.SetClientReady();
-            Assert.That(sceneManager.Ready);
             Assert.That(client.Connection.IsReady);
         }
 
@@ -228,7 +227,7 @@ namespace Mirror.Tests
             clientSceneManager.SetClientReady();
             clientSceneManager.ClientNotReadyMessage(null, new NotReadyMessage());
 
-            Assert.That(clientSceneManager.Ready, Is.False);
+            Assert.That(client.Connection.IsReady, Is.False);
             func1.Received(1).Invoke(Arg.Any<INetworkConnection>());
         }
 


### PR DESCRIPTION
This logic is already covered by NetworkConnection.IsReady. It represents when a scene load is either in progress (false) or completed (true)