### PR TITLE
tests: fix weaver tests in windows

### DIFF
--- a/Assets/Mirror/Editor/Weaver/CompilationFinishedHook.cs
+++ b/Assets/Mirror/Editor/Weaver/CompilationFinishedHook.cs
@@ -107,6 +107,7 @@ namespace Mirror.Weaver
                 // no assembly found, this can happen if you use the AssemblyBuilder
                 // happens with our weaver tests.
                 // create an assembly object manually
+
                 assembly = CreateUnityAssembly(assemblyPath);
             }
 
@@ -128,7 +129,7 @@ namespace Mirror.Weaver
         private static UnityAssembly CreateUnityAssembly(string assemblyPath)
         {
             // copy from one of the assemblies
-            UnityAssembly first = CompilationPipeline.GetAssemblies().First();
+            UnityAssembly mirrordll = CompilationPipeline.GetAssemblies().First(assembly => assembly.name=="Mirror");
 
             return new UnityAssembly(
                 Path.GetFileNameWithoutExtension(assemblyPath),
@@ -136,8 +137,7 @@ namespace Mirror.Weaver
                 new string[] { },
                 CompilationPipeline.GetDefinesFromAssemblyName(assemblyPath),
                 CompilationPipeline.GetAssemblies(),
-                first.compiledAssemblyReferences,
-
+                mirrordll.compiledAssemblyReferences,
                 AssemblyFlags.None) ;
         }
     }

--- a/Assets/Tests/Editor/Weaver/WeaverAssembler.cs
+++ b/Assets/Tests/Editor/Weaver/WeaverAssembler.cs
@@ -55,27 +55,6 @@ namespace Mirror.Weaver.Tests
             }
         }
 
-        // Add a range of reference files by full path
-        public static void AddReferencesByFullPath(string[] refAsms)
-        {
-            foreach (string asm in refAsms)
-            {
-                ReferenceAssemblies.Add(asm);
-            }
-        }
-
-        // Add a range of reference files by assembly name only
-        public static void AddReferencesByAssemblyName(string[] refAsms)
-        {
-            foreach (string asm in refAsms)
-            {
-                if (FindReferenceAssemblyPath(asm, out string asmFullPath))
-                {
-                    ReferenceAssemblies.Add(asmFullPath);
-                }
-            }
-        }
-
         // Find reference assembly specified by asmName and store its full path in asmFullPath
         // do not pass in paths in asmName, just assembly names
         public static bool FindReferenceAssemblyPath(string asmName, out string asmFullPath)
@@ -157,8 +136,9 @@ namespace Mirror.Weaver.Tests
         {
             var assemblyBuilder = new AssemblyBuilder(Path.Combine(OutputDirectory, OutputFile), SourceFiles.ToArray())
             {
-                additionalReferences = ReferenceAssemblies.ToArray()
+                referencesOptions = ReferencesOptions.UseEngineModules
             };
+
             if (AllowUnsafe)
             {
                 assemblyBuilder.compilerOptions.AllowUnsafeCode = true;

--- a/Assets/Tests/Editor/Weaver/WeaverGeneratedReaderWriterTests.cs
+++ b/Assets/Tests/Editor/Weaver/WeaverGeneratedReaderWriterTests.cs
@@ -7,8 +7,6 @@ namespace Mirror.Weaver.Tests
         [SetUp]
         public override void TestSetup()
         {
-            WeaverAssembler.AddReferencesByAssemblyName(new string[] { "WeaverTestExtraAssembly.dll" });
-
             base.TestSetup();
         }
 

--- a/Assets/Tests/Editor/Weaver/WeaverTests.cs
+++ b/Assets/Tests/Editor/Weaver/WeaverTests.cs
@@ -75,9 +75,6 @@ namespace Mirror.Weaver.Tests
         [OneTimeSetUp]
         public void FixtureSetup()
         {
-            // TextRenderingModule is only referenced to use TextMesh type to throw errors about types from another module
-            WeaverAssembler.AddReferencesByAssemblyName(new string[] { "UnityEngine.dll", "UnityEngine.CoreModule.dll", "UnityEngine.TextRenderingModule.dll", "Mirror.dll" });
-
             CompilationFinishedHook.UnityLogEnabled = false;
             CompilationFinishedHook.OnWeaverError += HandleWeaverError;
             CompilationFinishedHook.OnWeaverWarning += HandleWeaverWarning;


### PR DESCRIPTION
uwee reported these errors:
```cs
TestingScriptableObjectArraySerialization (0.501s)
---
SetUp :   Expected: False
  But was:  True

SetUp : Unhandled log message: '[Error] Assets\Tests\Editor\Weaver\WeaverGeneralTests~\TestingScriptableObjectArraySerialization.cs:22 -- Assets\Tests\Editor\Weaver\WeaverGeneralTests~\TestingScriptableObjectArraySerialization.cs(22,25): error CS0433: The type 'ScriptableObject' exists in both 'UnityEngine.CoreModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' and 'UnityEngine, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null''. Use UnityEngine.TestTools.LogAssert.Expect
---
Weaver: stop because compile errors on target
Assets\Tests\Editor\Weaver\WeaverGeneralTests~\TestingScriptableObjectArraySerialization.cs:22 -- Assets\Tests\Editor\Weaver\WeaverGeneralTests~\TestingScriptableObjectArraySerialization.cs(22,25): error CS0433: The type 'ScriptableObject' exists in both 'UnityEngine.CoreModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' and 'UnityEngine, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'
```

this should? fix it 