### PR TITLE
Fix NetworkIdentity destroying itself before destroying owned objects

### DIFF
--- a/Assets/Mirror/Runtime/NetworkConnection.cs
+++ b/Assets/Mirror/Runtime/NetworkConnection.cs
@@ -313,11 +313,23 @@ namespace Mirror
             var tmp = new HashSet<NetworkIdentity>(clientOwnedObjects);
             foreach (NetworkIdentity netIdentity in tmp)
             {
+                // It's the same NetworkIdentity as the one being used to destroy things.
+                // Usually it's first in the list and it removes itself and thus not
+                // properly removing all the other objects. By continuing and removing it by
+                // itself later all the objects are properly removed.
+                if (netIdentity.NetId == Identity.NetId)
+                {
+                    continue;
+                }
+
                 if (netIdentity != null)
                 {
                     Identity.Server.Destroy(netIdentity.gameObject);
                 }
             }
+
+            // Destroy the identity by itself.
+            Identity.Server.Destroy(Identity.gameObject);
 
             // clear the hashset because we destroyed them all
             clientOwnedObjects.Clear();


### PR DESCRIPTION
This is a quick fix for #225 

In NetworkConnection - DestroyOwnedObjects it goes through a list of owned objects to destroy. It uses its own identity to fetch the server but the identity is in the list and removes itself first and thus not removing all the child objects properly. 

This can cause objects that have been spawned with authority to not be removed when the client who owns them disconnects. 

This PR adds a check to see if the NetID of the current iterated network identity is the same as the main Identity and if it is, just continue to not destroy itself and then remove it outside the for loop. 