### PR TITLE
breaking: NetworkServer Host Mode

### DIFF
--- a/Assets/Mirror/Components/Discovery/NetworkDiscoveryHUD.cs
+++ b/Assets/Mirror/Components/Discovery/NetworkDiscoveryHUD.cs
@@ -57,7 +57,7 @@ namespace Mirror.Discovery
             if (GUILayout.Button("Start Host"))
             {
                 discoveredServers.Clear();
-                _ = networkManager.StartHost();
+                _ = networkManager.server.StartHost(networkManager.client);
                 networkDiscovery.AdvertiseServer();
             }
 

--- a/Assets/Mirror/Runtime/NetworkClient.cs
+++ b/Assets/Mirror/Runtime/NetworkClient.cs
@@ -179,7 +179,6 @@ namespace Mirror
 
         internal void ConnectHost(NetworkServer server)
         {
-
             logger.Log("Client Connect Host to Server");
             connectState = ConnectState.Connected;
 
@@ -192,8 +191,6 @@ namespace Mirror
             hostServer = server;
             Connection = GetNewConnection(c1);
             RegisterHostHandlers();
-
-            server.ActivateHostScene();
 
             _ = OnConnected();
         }

--- a/Assets/Mirror/Runtime/NetworkManager.cs
+++ b/Assets/Mirror/Runtime/NetworkManager.cs
@@ -1,7 +1,4 @@
-using System;
-using System.Threading.Tasks;
 using UnityEngine;
-using UnityEngine.Events;
 
 namespace Mirror
 {
@@ -11,10 +8,8 @@ namespace Mirror
     [RequireComponent(typeof(NetworkServer))]
     [RequireComponent(typeof(NetworkClient))]
     [DisallowMultipleComponent]
-    public class NetworkManager : MonoBehaviour, INetworkManager
+    public class NetworkManager : MonoBehaviour
     {
-        static readonly ILogger logger = LogFactory.GetLogger<NetworkManager>();
-
         public NetworkServer server;
         public NetworkClient client;
 
@@ -23,52 +18,5 @@ namespace Mirror
         /// <para>This is set True in StartServer / StartClient, and set False in StopServer / StopClient</para>
         /// </summary>
         public bool IsNetworkActive => server.Active || client.Active;
-
-        /// <summary>
-        /// This is invoked when a host is started.
-        /// <para>StartHost has multiple signatures, but they all cause this hook to be called.</para>
-        /// </summary>
-        public UnityEvent OnStartHost = new UnityEvent();
-
-        /// <summary>
-        /// This is called when a host is stopped.
-        /// </summary>
-        public UnityEvent OnStopHost = new UnityEvent();
-
-        /// <summary>
-        /// This starts a network "host" - a server and client in the same application.
-        /// <para>The client returned from StartHost() is a special "local" client that communicates to the in-process server using a message queue instead of the real network. But in almost all other cases, it can be treated as a normal client.</para>
-        /// </summary>
-        public async Task StartHost()
-        {
-            if (!server)
-                throw new InvalidOperationException("NetworkServer not assigned. Unable to StartHost()");
-            if (!client)
-                throw new InvalidOperationException("NetworkClient not assigned. Unable to StartHost()");
-
-            // start listening to network connections
-            await server.ListenAsync();
-
-            client.ConnectHost(server);
-
-            // call OnStartHost AFTER SetupServer. this way we can use
-            // NetworkServer.Spawn etc. in there too. just like OnStartServer
-            // is called after the server is actually properly started.
-            OnStartHost.Invoke();
-
-            logger.Log("NetworkManager StartHost");
-        }
-
-        /// <summary>
-        /// This stops both the client and the server that the manager is using.
-        /// </summary>
-        public void StopHost()
-        {
-            OnStopHost.Invoke();
-            if(client)
-                client.Disconnect();
-            if(server)
-                server.Disconnect();
-        }
     }
 }

--- a/Assets/Mirror/Runtime/NetworkManagerHud.cs
+++ b/Assets/Mirror/Runtime/NetworkManagerHud.cs
@@ -41,7 +41,7 @@ namespace Mirror
         public void StartHostButtonHandler()
         {
             labelText = "Host Mode";
-            _ = NetworkManager.StartHost();
+            _ = NetworkManager.server.StartHost(NetworkManager.client);
             OnlineSetActive();
         }
 
@@ -62,7 +62,7 @@ namespace Mirror
         public void StopButtonHandler()
         {
             labelText = string.Empty;
-            NetworkManager.StopHost();
+            NetworkManager.server.StopHost();
             OfflineSetActive();
         }
 

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -55,6 +55,17 @@ namespace Mirror
 
         public UnityEvent Stopped = new UnityEvent();
 
+        /// <summary>
+        /// This is invoked when a host is started.
+        /// <para>StartHost has multiple signatures, but they all cause this hook to be called.</para>
+        /// </summary>
+        public UnityEvent OnStartHost = new UnityEvent();
+
+        /// <summary>
+        /// This is called when a host is stopped.
+        /// </summary>
+        public UnityEvent OnStopHost = new UnityEvent();
+
         [Header("Authentication")]
         [Tooltip("Authentication component attached to this object")]
         public NetworkAuthenticator authenticator;
@@ -210,6 +221,38 @@ namespace Mirror
             {
                 Cleanup();
             }
+        }
+
+        /// <summary>
+        /// This starts a network "host" - a server and client in the same application.
+        /// <para>The client returned from StartHost() is a special "local" client that communicates to the in-process server using a message queue instead of the real network. But in almost all other cases, it can be treated as a normal client.</para>
+        /// </summary>
+        public async Task StartHost(NetworkClient client)
+        {
+            if (!client)
+                throw new InvalidOperationException("NetworkClient not assigned. Unable to StartHost()");
+
+            // start listening to network connections
+            await ListenAsync();
+
+            client.ConnectHost(this);
+
+            // call OnStartHost AFTER SetupServer. this way we can use
+            // NetworkServer.Spawn etc. in there too. just like OnStartServer
+            // is called after the server is actually properly started.
+            OnStartHost.Invoke();
+
+            logger.Log("NetworkManager StartHost");
+        }
+
+        /// <summary>
+        /// This stops both the client and the server that the manager is using.
+        /// </summary>
+        public void StopHost()
+        {
+            OnStopHost.Invoke();
+            LocalClient.Disconnect();
+            Disconnect();
         }
 
         /// <summary>

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -237,6 +237,8 @@ namespace Mirror
 
             client.ConnectHost(this);
 
+            ActivateHostScene();
+
             // call OnStartHost AFTER SetupServer. this way we can use
             // NetworkServer.Spawn etc. in there too. just like OnStartServer
             // is called after the server is actually properly started.

--- a/Assets/Mirror/Samples~/Chat/Scripts/ServerWindow.cs
+++ b/Assets/Mirror/Samples~/Chat/Scripts/ServerWindow.cs
@@ -16,7 +16,7 @@ namespace Mirror.Examples.Chat
 
         public void StartHost()
         {
-            _ = NetworkManager.StartHost();
+            _ = NetworkManager.server.StartHost(NetworkManager.client);
         }
 
         public void SetServerIp(string serverIp)

--- a/Assets/Tests/Performance/Runtime/BenchmarkPerformance.cs
+++ b/Assets/Tests/Performance/Runtime/BenchmarkPerformance.cs
@@ -38,7 +38,7 @@ namespace Mirror.Tests.Performance.Runtime
                 yield break;
             }
 
-            System.Threading.Tasks.Task task = benchmarker.StartHost();
+            System.Threading.Tasks.Task task = benchmarker.server.StartHost(benchmarker.client);
 
             while (!task.IsCompleted)
                 yield return null;
@@ -49,7 +49,7 @@ namespace Mirror.Tests.Performance.Runtime
         public IEnumerator TearDown()
         {
             // shutdown
-            benchmarker.StopHost();
+            benchmarker.server.StopHost();
             yield return null;
 
             // unload scene

--- a/Assets/Tests/Performance/Runtime/BenchmarkPerformanceLight.cs
+++ b/Assets/Tests/Performance/Runtime/BenchmarkPerformanceLight.cs
@@ -36,7 +36,7 @@ namespace Mirror.Tests.Performance.Runtime
                 yield break;
             }
 
-            System.Threading.Tasks.Task task = benchmarker.StartHost();
+            System.Threading.Tasks.Task task = benchmarker.server.StartHost(benchmarker.client);
 
             while (!task.IsCompleted)
                 yield return null;
@@ -47,7 +47,7 @@ namespace Mirror.Tests.Performance.Runtime
         public IEnumerator TearDown()
         {
             // shutdown
-            benchmarker.StopHost();
+            benchmarker.server.StopHost();
             yield return null;
 
             // unload scene

--- a/Assets/Tests/Runtime/HostSetup.cs
+++ b/Assets/Tests/Runtime/HostSetup.cs
@@ -44,7 +44,7 @@ namespace Mirror.Tests
             await Task.Delay(1);
 
             // now start the host
-            await manager.StartHost();
+            await manager.server.StartHost(manager.client);
 
             playerGO = new GameObject("playerGO", typeof(Rigidbody));
             identity = playerGO.AddComponent<NetworkIdentity>();
@@ -61,7 +61,7 @@ namespace Mirror.Tests
         public IEnumerator ShutdownHost() => RunAsync(async () =>
         {
             Object.Destroy(playerGO);
-            manager.StopHost();
+            manager.server.StopHost();
 
             await Task.Delay(1);
             Object.Destroy(networkManagerGo);

--- a/Assets/Tests/Runtime/HostSetup.cs
+++ b/Assets/Tests/Runtime/HostSetup.cs
@@ -44,7 +44,7 @@ namespace Mirror.Tests
             await Task.Delay(1);
 
             // now start the host
-            await manager.server.StartHost(manager.client);
+            await manager.server.StartHost(client);
 
             playerGO = new GameObject("playerGO", typeof(Rigidbody));
             identity = playerGO.AddComponent<NetworkIdentity>();

--- a/Assets/Tests/Runtime/NetworkClientTest.cs
+++ b/Assets/Tests/Runtime/NetworkClientTest.cs
@@ -149,6 +149,7 @@ namespace Mirror.Tests
             client.Disconnect();
 
             await WaitFor(() => client.connectState == ConnectState.Disconnected);
+            await WaitFor(() => !client.Active);
         });
     }
 }

--- a/Assets/Tests/Runtime/NetworkManagerTest.cs
+++ b/Assets/Tests/Runtime/NetworkManagerTest.cs
@@ -10,20 +10,13 @@ namespace Mirror.Tests
     public class NetworkManagerTest : HostSetup<MockComponent>
     {
         [Test]
-        public void VariableTest()
-        {
-            Assert.That(manager.server.MaxConnections, Is.EqualTo(4));
-        }
-
-        [Test]
-        public void StartServerTest()
+        public void IsNetworkActiveTest()
         {
             Assert.That(manager.IsNetworkActive, Is.True);
-            Assert.That(manager.server.Active, Is.True);
         }
 
         [UnityTest]
-        public IEnumerator StopServerTest() => RunAsync(async () =>
+        public IEnumerator IsNetworkActiveStopTest() => RunAsync(async () =>
         {
             manager.server.Disconnect();
 

--- a/Assets/Tests/Runtime/NetworkManagerTest.cs
+++ b/Assets/Tests/Runtime/NetworkManagerTest.cs
@@ -48,13 +48,7 @@ namespace Mirror.Tests
             manager.client = null;
             Assert.Throws<InvalidOperationException>(() =>
             {
-                manager.StartHost().GetAwaiter().GetResult();
-            });
-
-            manager.server = null;
-            Assert.Throws<InvalidOperationException>(() =>
-            {
-                manager.StartHost().GetAwaiter().GetResult();
+                manager.server.StartHost(manager.client).GetAwaiter().GetResult();
             });
         }
     }

--- a/Assets/Tests/Runtime/NetworkServerTests.cs
+++ b/Assets/Tests/Runtime/NetworkServerTests.cs
@@ -295,5 +295,11 @@ namespace Mirror.Tests
         {
             Assert.That(server.GetNewConnection(Substitute.For<IConnection>()), Is.Not.Null);
         }
+
+        [Test]
+        public void VariableTest()
+        {
+            Assert.That(server.MaxConnections, Is.EqualTo(4));
+        }
     }
 }


### PR DESCRIPTION
Before this change you needed to have a NetworkManager to be able to run in Host mode. Now you can do that fully from a NetworkServer and NetworkClient.

There are other potential simplifications in the host related code in NS/NC

To fix this breaking change via your existing NetworkManager simply replace:
networkManager.StartHost();
networkManager.server.StartHost(networkManager.client);