### PR TITLE
Always Send NetworkSceneName

### DIFF
--- a/Assets/Mirror/Runtime/NetworkSceneManager.cs
+++ b/Assets/Mirror/Runtime/NetworkSceneManager.cs
@@ -205,9 +205,7 @@ namespace Mirror
         {
             logger.Log("NetworkSceneManager.OnServerAuthenticated");
 
-            // proceed with the login handshake by calling OnServerConnect
-            if (!string.IsNullOrEmpty(NetworkSceneName))
-                conn.Send(new SceneMessage { sceneName = NetworkSceneName });
+            conn.Send(new SceneMessage { sceneName = NetworkSceneName });
         }
 
         /// <summary>


### PR DESCRIPTION
The server should always send its currently active scene to the client. This prevents situations where you are forced to make your server change scenes just to populate a string so the client is also told to sync up.