### PR TITLE
perf: Only synchronize dirty objects

### DIFF
--- a/Assets/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirror/Runtime/NetworkBehaviour.cs
@@ -185,6 +185,15 @@ namespace Mirror
         protected void InitSyncObject(ISyncObject syncObject)
         {
             syncObjects.Add(syncObject);
+            syncObject.OnChange += SyncObject_OnChange;
+        }
+
+        private void SyncObject_OnChange()
+        {
+            if (IsServer)
+            {
+                Server.DirtyObjects.Add(NetIdentity);
+            }
         }
 
         #region ServerRpcs
@@ -406,6 +415,7 @@ namespace Mirror
         public void SetDirtyBit(ulong dirtyBit)
         {
             SyncVarDirtyBits |= dirtyBit;
+            Server.DirtyObjects.Add(NetIdentity);
         }
 
         /// <summary>
@@ -449,6 +459,14 @@ namespace Mirror
                 return SyncVarDirtyBits != 0L || AnySyncObjectDirty();
             }
             return false;
+        }
+
+        // true if this component has data that has not been
+        // synchronized.  Note that it may not synchronize
+        // right away because of syncInterval
+        public bool StillDirty()
+        {
+            return SyncVarDirtyBits != 0L || AnySyncObjectDirty();
         }
 
         /// <summary>

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -898,6 +898,21 @@ namespace Mirror
             return dirtyComponentsMask;
         }
 
+        /// <summary>
+        /// Determines if there are changes in any component that have not
+        /// been synchronized yet. Probably due to not meeting the syncInterval
+        /// </summary>
+        /// <returns></returns>
+        internal bool StillDirty()
+        {
+            foreach (NetworkBehaviour behaviour in NetworkBehaviours)
+            {
+                if (behaviour.StillDirty())
+                    return true;
+            }
+            return false;
+        }
+
         private ulong GetIntialComponentsMask()
         {
             // set a bit for every behaviour
@@ -1280,9 +1295,6 @@ namespace Mirror
             ClearObservers();
         }
 
-        /// <summary>
-        /// Invoked by NetworkServer.Update during LateUpdate
-        /// </summary>
         internal void ServerUpdate()
         {
             if (observers.Count > 0)
@@ -1297,6 +1309,10 @@ namespace Mirror
             }
         }
 
+        /// <summary>
+        /// return true if the object is successfully synchronized
+        /// </summary>
+        /// <returns></returns>
         void SendUpdateVarsMessage()
         {
             // one writer for owner, one for observers

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -100,6 +100,8 @@ namespace Mirror
 
         public readonly Dictionary<uint, NetworkIdentity> Spawned = new Dictionary<uint, NetworkIdentity>();
 
+        public readonly HashSet<NetworkIdentity> DirtyObjects = new HashSet<NetworkIdentity>();
+
         // just a cached memory area where we can collect connections
         // for broadcasting messages
         private static readonly List<INetworkConnection> connectionsCache = new List<INetworkConnection>();
@@ -375,27 +377,31 @@ namespace Mirror
             SendToReady(identity, msg, true, channelId);
         }
 
+        private readonly List<NetworkIdentity> DirtyObjectsTmp = new List<NetworkIdentity>();
+
         // The user should never need to pump the update loop manually
         internal void Update()
         {
             if (!Active)
                 return;
 
-            // update all server objects
-            foreach (KeyValuePair<uint, NetworkIdentity> kvp in Spawned)
+            DirtyObjectsTmp.Clear();
+
+            foreach (NetworkIdentity identity in DirtyObjects)
             {
-                NetworkIdentity identity = kvp.Value;
                 if (identity != null)
                 {
                     identity.ServerUpdate();
-                }
-                else
-                {
-                    // spawned list should have no null entries because we
-                    // always call Remove in OnObjectDestroy everywhere.
-                    logger.LogWarning("Found 'null' entry in spawned list for netId=" + kvp.Key + ". Please call NetworkServer.Destroy to destroy networked objects. Don't use GameObject.Destroy.");
-                }
+
+                    if (identity.StillDirty())
+                        DirtyObjectsTmp.Add(identity);
+                }                
             }
+
+            DirtyObjects.Clear();
+
+            foreach (NetworkIdentity obj in DirtyObjectsTmp)
+                DirtyObjects.Add(obj);
         }
 
         async Task ConnectionAcceptedAsync(INetworkConnection conn)


### PR DESCRIPTION
Every frame we loop through all network objects and ask them to synchronize.
This is very wasteful, as network objects should not normally change very often.

This PR changes it so that we keep track of objects that are dirty, and we synchronize only those.  On average,  this changes synchronization from O(n) to near O(1).

In my MAC in 10klight example:

### before:
 Time Microsecond Median:7807.40 Min:4853.10 Max:11369.00 Avg:8011.55 Std:1266.32 SampleCount: 240 Sum: 1922772.50
### after:
Time Microsecond Median:4016.30 Min:2247.10 Max:16143.50 Avg:4916.15 Std:2525.00 SampleCount: 240 Sum: 1179876.40

