### PR TITLE
perf: Remove 2 messages when player connects

### DIFF
--- a/Assets/Mirror/Runtime/Messages.cs
+++ b/Assets/Mirror/Runtime/Messages.cs
@@ -95,10 +95,6 @@ namespace Mirror
         public ArraySegment<byte> payload;
     }
 
-    public struct ObjectSpawnStartedMessage { }
-
-    public struct ObjectSpawnFinishedMessage { }
-
     public struct ObjectDestroyMessage
     {
         public uint netId;

--- a/Assets/Mirror/Runtime/NetworkClient.cs
+++ b/Assets/Mirror/Runtime/NetworkClient.cs
@@ -234,6 +234,7 @@ namespace Mirror
             connectState = ConnectState.Connected;
             Connected.Invoke(Connection);
 
+            PrepareToSpawnSceneObjects();
             // start processing messages
             try
             {
@@ -302,8 +303,6 @@ namespace Mirror
             Connection.RegisterHandler<SpawnMessage>(OnHostClientSpawn);
             // host mode reuses objects in the server
             // so we don't need to spawn them
-            Connection.RegisterHandler<ObjectSpawnStartedMessage>(msg => { });
-            Connection.RegisterHandler<ObjectSpawnFinishedMessage>(msg => { });
             Connection.RegisterHandler<UpdateVarsMessage>(msg => { });
             Connection.RegisterHandler<RpcMessage>(OnRpcMessage);
         }
@@ -314,8 +313,6 @@ namespace Mirror
             Connection.RegisterHandler<ObjectHideMessage>(OnObjectHide);
             Connection.RegisterHandler<NetworkPongMessage>(Time.OnClientPong);
             Connection.RegisterHandler<SpawnMessage>(OnSpawn);
-            Connection.RegisterHandler<ObjectSpawnStartedMessage>(OnObjectSpawnStarted);
-            Connection.RegisterHandler<ObjectSpawnFinishedMessage>(OnObjectSpawnFinished);
             Connection.RegisterHandler<UpdateVarsMessage>(OnUpdateVarsMessage);
             Connection.RegisterHandler<RpcMessage>(OnRpcMessage);
         }
@@ -330,7 +327,6 @@ namespace Mirror
 
             ClearSpawners();
             DestroyAllClientObjects();
-            isSpawnFinished = false;
             hostServer = null;
 
             connectState = ConnectState.Disconnected;
@@ -648,12 +644,9 @@ namespace Mirror
             Spawned[msg.netId] = identity;
 
             // objects spawned as part of initial state are started on a second pass
-            if (isSpawnFinished)
-            {
-                identity.NotifyAuthority();
-                identity.StartClient();
-                CheckForLocalPlayer(identity);
-            }
+            identity.NotifyAuthority();
+            identity.StartClient();
+            CheckForLocalPlayer(identity);
         }
 
         internal void OnSpawn(SpawnMessage msg)
@@ -740,30 +733,6 @@ namespace Mirror
             }
             logger.LogWarning("Could not find scene object with sceneid:" + sceneId.ToString("X"));
             return null;
-        }
-
-        internal void OnObjectSpawnStarted(ObjectSpawnStartedMessage _)
-        {
-            logger.Log("SpawnStarted");
-
-            PrepareToSpawnSceneObjects();
-            isSpawnFinished = false;
-        }
-
-        internal void OnObjectSpawnFinished(ObjectSpawnFinishedMessage _)
-        {
-            logger.Log("SpawnFinished");
-
-            // paul: Initialize the objects in the same order as they were initialized
-            // in the server.   This is important if spawned objects
-            // use data from scene objects
-            foreach (NetworkIdentity identity in Spawned.Values.OrderBy(uv => uv.NetId))
-            {
-                identity.NotifyAuthority();
-                identity.StartClient();
-                CheckForLocalPlayer(identity);
-            }
-            isSpawnFinished = true;
         }
 
         internal void OnObjectHide(ObjectHideMessage msg)

--- a/Assets/Mirror/Runtime/NetworkClient.cs
+++ b/Assets/Mirror/Runtime/NetworkClient.cs
@@ -84,8 +84,6 @@ namespace Mirror
 
         public readonly NetworkTime Time = new NetworkTime();
 
-        bool isSpawnFinished;
-
         public Transport Transport;
 
         /// <summary>

--- a/Assets/Mirror/Runtime/NetworkSceneManager.cs
+++ b/Assets/Mirror/Runtime/NetworkSceneManager.cs
@@ -338,6 +338,8 @@ namespace Mirror
                     client.OnAuthenticated(client.Connection);
                 }
 
+                client.PrepareToSpawnSceneObjects();
+
                 OnClientSceneChanged(sceneName, sceneOperation);
             }
         }

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -578,9 +578,6 @@ namespace Mirror
                 return;
             }
 
-            // let connection know that we are about to start spawning...
-            conn.Send(new ObjectSpawnStartedMessage());
-
             // add connection to each nearby NetworkIdentity's observers, which
             // internally sends a spawn message for each one to the connection.
             foreach (NetworkIdentity identity in Spawned.Values)
@@ -598,11 +595,6 @@ namespace Mirror
                     }
                 }
             }
-
-            // let connection know that we finished spawning, so it can call
-            // OnStartClient on each one (only after all were spawned, which
-            // is how Unity's Start() function works too)
-            conn.Send(new ObjectSpawnFinishedMessage());
         }
 
         /// <summary>

--- a/Assets/Tests/Editor/MessageTests.cs
+++ b/Assets/Tests/Editor/MessageTests.cs
@@ -82,19 +82,6 @@ namespace Mirror.Tests
         }
 
         [Test]
-        public void ObjectSpawnFinishedMessageTest()
-        {
-            TestSerializeDeserialize(new ObjectSpawnFinishedMessage());
-        }
-
-        [Test]
-        public void ObjectSpawnStartedMessageTest()
-        {
-            // try setting value with constructor
-            TestSerializeDeserialize(new ObjectSpawnStartedMessage());
-        }
-
-        [Test]
         public void ReadyMessageTest()
         {
             TestSerializeDeserialize(new ReadyMessage());


### PR DESCRIPTION
Before:

when I connection is established, we spawned the objects like this:

1) ObjectSpawnStartedMessage
2) SpawnMessage
3) SpawnMessage
...
n) SpawnMessage
n+1) ObjectSpawnFinishdMessage (and initialize all objects)

After:

when I connection is established, we spawned the objects like this:

1) SpawnMessage (initialize)
2) SpawnMessage (initialize)
3) SpawnMessage (initialize)
...
n) SpawnMessage (initialize)

BREAKING CHANGE: It is no longer guaranteed that all objects are spawned before we start calling events