### PR TITLE
fix: reading and writing a network identity before spawning

### DIFF
--- a/Assets/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirror/Runtime/NetworkBehaviour.cs
@@ -393,9 +393,12 @@ namespace Mirror
                 return identityField;
             }
 
-            // client always looks up based on netId because objects might get in and out of range
-            // over and over again, which shouldn't null them forever
-            Client.Spawned.TryGetValue(netId, out identityField);
+            if (IsClient)
+            {
+                // client always looks up based on netId because objects might get in and out of range
+                // over and over again, which shouldn't null them forever
+                Client.Spawned.TryGetValue(netId, out identityField);
+            }
             return identityField;
         }
 

--- a/Assets/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirror/Runtime/NetworkBehaviour.cs
@@ -350,7 +350,9 @@ namespace Mirror
                 newNetId = newIdentity.NetId;
                 if (newNetId == 0)
                 {
-                    logger.LogWarning("SetSyncVarNetworkIdentity NetworkIdentity " + newIdentity + " has a zero netId. Maybe it is not spawned yet?");
+                    // it has not been spawned yet,  so just consider them different
+                    // so that we call the setter
+                    return false;
                 }
             }
 

--- a/Assets/Tests/Editor/SyncVarTest.cs
+++ b/Assets/Tests/Editor/SyncVarTest.cs
@@ -13,6 +13,9 @@ namespace Mirror.Tests
 
         [SyncVar]
         public Guild guild;
+
+        [SyncVar]
+        public NetworkIdentity target;
     }
 
     public class SyncVarTest
@@ -154,6 +157,17 @@ namespace Mirror.Tests
             player3.syncMode = SyncMode.Observers;
 
             Assert.That(identity.GetSyncModeObserversMask(), Is.EqualTo(0b101));
+        }
+
+        [Test]
+        public void SetNetworkIdentitySyncvar()
+        {
+            var gameObject = new GameObject("player", typeof(NetworkIdentity), typeof(MockPlayer));
+            MockPlayer player = gameObject.GetComponent<MockPlayer>();
+
+            player.target = gameObject.GetComponent<NetworkIdentity>();
+
+            Assert.That(player.target, Is.EqualTo(player.GetComponent<NetworkIdentity>()));
         }
     }
 }

--- a/Assets/Tests/Runtime/NetworkBehaviourTests.cs
+++ b/Assets/Tests/Runtime/NetworkBehaviourTests.cs
@@ -239,7 +239,7 @@ namespace Mirror.Tests
             var go = new GameObject();
             NetworkIdentity ni = go.AddComponent<NetworkIdentity>();
             bool result = component.SyncVarNetworkIdentityEqualExposed(ni, 0);
-            Assert.That(result, Is.True);
+            Assert.That(result, Is.False);
 
             // clean up
             GameObject.Destroy(go);


### PR DESCRIPTION
Accessing a syncvar network identity before the object is spawned gives NRE

fixes #399