### PR TITLE
feat: DoS prevention

### DIFF
--- a/Assets/Mirror/Runtime/Transport/Kcp/HashCash.cs
+++ b/Assets/Mirror/Runtime/Transport/Kcp/HashCash.cs
@@ -106,9 +106,9 @@ namespace Mirror.KCP
             // we find one that validaes
             while (true)
             {
-                byte[] sha1 = token.Sha1();
+                byte[] hash = token.Hash();
 
-                if (Validate(sha1, bits))
+                if (Validate(hash, bits))
                     return token;
 
                 token = new HashCash(token.dt, token.resource, token.salt, token.counter + 1);
@@ -119,16 +119,16 @@ namespace Mirror.KCP
 
 
         #region Validation
-        private static readonly SHA1CryptoServiceProvider sha1CryptoService = new SHA1CryptoServiceProvider();
+        private static readonly HashAlgorithm hashAlgorithm = SHA256.Create();
 
         private static readonly byte[] buffer = new byte[HashCashEncoding.SIZE];
 
 
-        internal byte[] Sha1()
+        internal byte[] Hash()
         {
             int length = HashCashEncoding.Encode(buffer, 0, this);
 
-            return sha1CryptoService.ComputeHash(buffer, 0, length);
+            return hashAlgorithm.ComputeHash(buffer, 0, length);
         }
 
         // validate that the first n bits in a hash are zero
@@ -153,7 +153,7 @@ namespace Mirror.KCP
 
         internal bool ValidateHash(int bits = 20)
         {
-            return Validate(Sha1(), bits);
+            return Validate(Hash(), bits);
         }
 
         public bool Validate(string resource, int bits = 18)

--- a/Assets/Mirror/Runtime/Transport/Kcp/HashCash.cs
+++ b/Assets/Mirror/Runtime/Transport/Kcp/HashCash.cs
@@ -105,14 +105,14 @@ namespace Mirror.KCP
 
             // note we create these here so Mine does not depend
             // on static state.  This way Mine is thread safe
-            HashAlgorithm hashAlgorithm = SHA256.Create();
-            byte[] buffer = new byte[HashCashEncoding.SIZE];
+            HashAlgorithm hashAlg = SHA256.Create();
+            byte[] buf = new byte[HashCashEncoding.SIZE];
 
             // calculate hash after hash until
             // we find one that validaes
             while (true)
             {
-                byte[] hash = token.Hash(hashAlgorithm, buffer);
+                byte[] hash = token.Hash(hashAlg, buf);
 
                 if (Validate(hash, bits))
                     return token;

--- a/Assets/Mirror/Runtime/Transport/Kcp/HashCash.cs
+++ b/Assets/Mirror/Runtime/Transport/Kcp/HashCash.cs
@@ -143,7 +143,7 @@ namespace Mirror.KCP
         }
 
         public bool Validate(string resource, int bits = 20)
-            => Validate(resource.GetStableHashCode(), bits = 20);
+            => Validate(resource.GetStableHashCode(), bits);
 
         private bool Validate(int resource, int bits = 20)
         {
@@ -155,7 +155,7 @@ namespace Mirror.KCP
             if (this.dt < DateTime.UtcNow.AddMinutes(-10f))
                 return false;
 
-            return this.ValidateHash(20);
+            return this.ValidateHash(bits);
         }
 
         #endregion

--- a/Assets/Mirror/Runtime/Transport/Kcp/HashCash.cs
+++ b/Assets/Mirror/Runtime/Transport/Kcp/HashCash.cs
@@ -64,6 +64,11 @@ namespace Mirror.KCP
             return hashCode;
         }
 
+        internal static HashCash Mine()
+        {
+            throw new NotImplementedException();
+        }
+
         #region mining
 
         public static HashCash Mine(string resource, int bits = 18)

--- a/Assets/Mirror/Runtime/Transport/Kcp/HashCash.cs
+++ b/Assets/Mirror/Runtime/Transport/Kcp/HashCash.cs
@@ -160,6 +160,10 @@ namespace Mirror.KCP
             if (this.dt < DateTime.UtcNow.AddMinutes(-10f))
                 return false;
 
+            // tokens cannot come from the future
+            if (this.dt > DateTime.UtcNow.AddMinutes(5f))
+                return false;
+
             return this.ValidateHash(bits);
         }
 

--- a/Assets/Mirror/Runtime/Transport/Kcp/HashCash.cs
+++ b/Assets/Mirror/Runtime/Transport/Kcp/HashCash.cs
@@ -103,6 +103,8 @@ namespace Mirror.KCP
 
             var token = new HashCash(DateTime.UtcNow, resource, (ulong)newSalt, 0);
 
+            // note we create these here so Mine does not depend
+            // on static state.  This way Mine is thread safe
             HashAlgorithm hashAlgorithm = SHA256.Create();
             byte[] buffer = new byte[HashCashEncoding.SIZE];
 
@@ -119,13 +121,6 @@ namespace Mirror.KCP
             }
         }
 
-        // same as Hash, but thread safe
-        private byte[] Hash(HashAlgorithm hashAlgorithm, byte[] buffer)
-        {
-            int length = HashCashEncoding.Encode(buffer, 0, this);
-
-            return hashAlgorithm.ComputeHash(buffer, 0, length);
-        }
 
         #endregion
 
@@ -135,8 +130,11 @@ namespace Mirror.KCP
 
         private static readonly byte[] buffer = new byte[HashCashEncoding.SIZE];
 
+        // not thread safe
+        internal byte[] Hash() => Hash(hashAlgorithm, buffer);
 
-        internal byte[] Hash()
+        // calculate the hash of a hashcash token
+        private byte[] Hash(HashAlgorithm hashAlgorithm, byte[] buffer)
         {
             int length = HashCashEncoding.Encode(buffer, 0, this);
 

--- a/Assets/Mirror/Runtime/Transport/Kcp/HashCash.cs
+++ b/Assets/Mirror/Runtime/Transport/Kcp/HashCash.cs
@@ -97,7 +97,10 @@ namespace Mirror.KCP
         {
             var random = new Random();
 
-            var token = new HashCash(DateTime.UtcNow, resource, (ulong)((random.Next() << 32) | random.Next()), 0);
+            long salt = random.Next();
+            salt = (salt << 32) | (long)random.Next();
+
+            var token = new HashCash(DateTime.UtcNow, resource, (ulong)salt, 0);
 
             // calculate hash after hash until
             // we find one that validaes

--- a/Assets/Mirror/Runtime/Transport/Kcp/HashCash.cs
+++ b/Assets/Mirror/Runtime/Transport/Kcp/HashCash.cs
@@ -17,6 +17,7 @@ namespace Mirror.KCP
     /// 2) the resource must match the expected resource in the server
     /// 3) the token has not been seen in the server yet
     /// 4) the sha1 hash of the token must start with zeroes. The more zeroes,  the more difficulty
+    /// </remarks>
     public struct HashCash : IEquatable<HashCash>
     {
         /// <summary>

--- a/Assets/Mirror/Runtime/Transport/Kcp/HashCash.cs
+++ b/Assets/Mirror/Runtime/Transport/Kcp/HashCash.cs
@@ -1,0 +1,116 @@
+﻿
+using System;
+using UnityEngine;
+
+namespace Mirror.KCP
+{
+
+    /// <summary>
+    /// minimalistic hashcash-like token
+    /// a simplification of the hashcash header described here:
+    /// https://github.com/cliftonm/hashcash
+    /// </summary>
+    /// <remarks> to make it light weight in the server I adjusted the field to plain numbers</remarks>
+    /// <remarks> When hashing this structure with sha1
+    /// for a token to validate it has to:
+    /// 1) be recent,  so dt must be in the near past in utc time
+    /// 2) the resource must match the expected resource in the server
+    /// 3) the token has not been seen in the server yet
+    /// 4) the sha1 hash of the token must start with zeroes. The more zeroes,  the more difficulty
+    public struct HashCash : IEquatable<HashCash>
+    {
+        /// <summary>
+        /// Date and time when the token was generated
+        /// </summary>
+        public DateTime dt;
+        /// <summary>
+        /// a number that represents the resource this hashcash is for.
+        /// In the original they have a string,  so just use a string hash here
+        /// </summary>
+        public int resource;
+
+        /// <summary>
+        /// the random number.  In the original they have
+        /// a byte[],  but we can limit it to 64 bits
+        /// </summary>
+        public ulong salt;
+        /// <summary>
+        /// counter used for making the token valid
+        /// </summary>
+        public ulong counter;
+
+        public bool Equals(HashCash other)
+        {
+            return dt == other.dt &&
+                resource == other.resource &&
+                salt == other.salt &&
+                counter == other.counter;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return this.Equals((HashCash)obj);
+        }
+
+        public override int GetHashCode()
+        {
+            int hashCode = -858276690;
+            hashCode = hashCode * -1521134295 + dt.GetHashCode();
+            hashCode = hashCode * -1521134295 + resource.GetHashCode();
+            hashCode = hashCode * -1521134295 + salt.GetHashCode();
+            hashCode = hashCode * -1521134295 + counter.GetHashCode();
+            return hashCode;
+        }
+    }
+
+    public static class HashCashEncoding
+    {
+        /// <summary>
+        /// Encode a hashcash token into a buffer
+        /// </summary>
+        /// <param name="buffer">the buffer where to store the hashcash</param>
+        /// <param name="index">the index in the buffer where to put it</param>
+        /// <param name="hashCash">the token to be encoded</param>
+        /// <returns>the length of the written data</returns>
+        public static int Encode(byte[] buffer, int index, HashCash hashCash)
+        {
+            int offset = index;
+
+            offset += Utils.Encode64U(buffer, offset, (ulong)hashCash.dt.Ticks);
+            offset += Utils.Encode32U(buffer, offset, (uint)hashCash.resource);
+            offset += Utils.Encode64U(buffer, offset, hashCash.salt);
+            offset += Utils.Encode64U(buffer, offset, hashCash.counter);
+
+            return offset - index ;
+        }
+
+        /// <summary>
+        /// Encode a hashcash token into a buffer
+        /// </summary>
+        /// <param name="buffer">the buffer where to store the hashcash</param>
+        /// <param name="index">the index in the buffer where to put it</param>
+        /// <param name="hashCash">the token to be encoded</param>
+        /// <returns>the length of the written data</returns>
+        public static (int offset, HashCash decoded) Decode(byte[] buffer, int index)
+        {
+            var (offset, ticks) = Utils.Decode64U(buffer, index);
+            uint resource;
+            (offset, resource) = Utils.Decode32U(buffer, offset);
+            ulong salt;
+            (offset, salt) = Utils.Decode64U(buffer, offset);
+            ulong counter;
+            (offset, counter) = Utils.Decode64U(buffer, offset);
+
+            var token = new HashCash
+            {
+                dt = new DateTime((long)ticks),
+                resource = (int)resource,
+                salt = salt,
+                counter = counter
+            };
+
+            return (offset, token);
+        }
+
+    }
+}

--- a/Assets/Mirror/Runtime/Transport/Kcp/HashCash.cs
+++ b/Assets/Mirror/Runtime/Transport/Kcp/HashCash.cs
@@ -1,5 +1,6 @@
 ﻿
 using System;
+using System.Security.Cryptography;
 using UnityEngine;
 
 namespace Mirror.KCP
@@ -62,10 +63,46 @@ namespace Mirror.KCP
             hashCode = hashCode * -1521134295 + counter.GetHashCode();
             return hashCode;
         }
+
+        #region mining
+
+
+        /// <summary>
+        /// Mines a hashcash token for a given resource
+        /// </summary>
+        /// <param name="resource">The resource for which we are mining the token
+        /// the resource can be any number, but should be unique to your game
+        /// for example,  use Application.productName.GetStableHashCode()</param>
+        /// <returns>A valid HashCash for the resource</returns>
+        public static HashCash Mine(int resource)
+        {
+            return new HashCash();
+        }
+
+        #endregion
+
+
+        #region Validation
+        private static SHA1CryptoServiceProvider sha1CryptoService = new SHA1CryptoServiceProvider();
+
+        private static byte[] buffer = new byte[HashCashEncoding.SIZE];
+
+
+        internal byte[] Sha1()
+        {
+            int length = HashCashEncoding.Encode(buffer, 0, this);
+
+            return sha1CryptoService.ComputeHash(buffer, 0, length);
+        }
+
+        #endregion
     }
 
     public static class HashCashEncoding
     {
+        // takes 20 bytes to serialize a hash cash token
+        public const int SIZE = 28;
+
         /// <summary>
         /// Encode a hashcash token into a buffer
         /// </summary>
@@ -94,7 +131,7 @@ namespace Mirror.KCP
         /// <returns>the length of the written data</returns>
         public static (int offset, HashCash decoded) Decode(byte[] buffer, int index)
         {
-            var (offset, ticks) = Utils.Decode64U(buffer, index);
+            (int offset, ulong ticks) = Utils.Decode64U(buffer, index);
             uint resource;
             (offset, resource) = Utils.Decode32U(buffer, offset);
             ulong salt;
@@ -112,6 +149,5 @@ namespace Mirror.KCP
 
             return (offset, token);
         }
-
     }
 }

--- a/Assets/Mirror/Runtime/Transport/Kcp/HashCash.cs
+++ b/Assets/Mirror/Runtime/Transport/Kcp/HashCash.cs
@@ -66,7 +66,7 @@ namespace Mirror.KCP
 
         #region mining
 
-        public static HashCash Mine(string resource, int bits = 20)
+        public static HashCash Mine(string resource, int bits = 18)
             => Mine(resource.GetStableHashCode(), bits);
 
         /// <summary>
@@ -76,7 +76,7 @@ namespace Mirror.KCP
         /// the resource can be any number, but should be unique to your game
         /// for example,  use Application.productName.GetStableHashCode()</param>
         /// <returns>A valid HashCash for the resource</returns>
-        private static HashCash Mine(int resource, int bits = 20)
+        private static HashCash Mine(int resource, int bits = 18)
         {
             var random = new System.Random();
 
@@ -118,7 +118,7 @@ namespace Mirror.KCP
         }
 
         // validate that the first n bits in a hash are zero
-        internal static bool Validate(byte[] hash, int bits = 20)
+        internal static bool Validate(byte[] hash, int bits = 18)
         {
             int bytesToCheck = bits >> 3 ;
             int remainderBitsToCheck = bits & 0b111;
@@ -142,10 +142,10 @@ namespace Mirror.KCP
             return Validate(Sha1(), bits);
         }
 
-        public bool Validate(string resource, int bits = 20)
+        public bool Validate(string resource, int bits = 18)
             => Validate(resource.GetStableHashCode(), bits);
 
-        private bool Validate(int resource, int bits = 20)
+        private bool Validate(int resource, int bits = 18)
         {
             // this token is for some other resource
             if (this.resource != resource)

--- a/Assets/Mirror/Runtime/Transport/Kcp/HashCash.cs
+++ b/Assets/Mirror/Runtime/Transport/Kcp/HashCash.cs
@@ -66,7 +66,8 @@ namespace Mirror.KCP
 
         #region mining
 
-        public static HashCash Mine(string resource, int bits = 20) => Mine(resource.GetStableHashCode(), bits);
+        public static HashCash Mine(string resource, int bits = 20)
+            => Mine(resource.GetStableHashCode(), bits);
 
         /// <summary>
         /// Mines a hashcash token for a given resource
@@ -75,9 +76,9 @@ namespace Mirror.KCP
         /// the resource can be any number, but should be unique to your game
         /// for example,  use Application.productName.GetStableHashCode()</param>
         /// <returns>A valid HashCash for the resource</returns>
-        public static HashCash Mine(int resource, int bits = 20)
+        private static HashCash Mine(int resource, int bits = 20)
         {
-            System.Random random = new System.Random();
+            var random = new System.Random();
 
             var token = new HashCash
             {
@@ -141,6 +142,21 @@ namespace Mirror.KCP
             return Validate(Sha1(), bits);
         }
 
+        public bool Validate(string resource, int bits = 20)
+            => Validate(resource.GetStableHashCode(), bits = 20);
+
+        private bool Validate(int resource, int bits = 20)
+        {
+            // this token is for some other resource
+            if (this.resource != resource)
+                return false;
+
+            // tokens are valid for 10 minutes
+            if (this.dt < DateTime.UtcNow.AddMinutes(-10f))
+                return false;
+
+            return this.ValidateHash(20);
+        }
 
         #endregion
     }

--- a/Assets/Mirror/Runtime/Transport/Kcp/HashCash.cs
+++ b/Assets/Mirror/Runtime/Transport/Kcp/HashCash.cs
@@ -97,10 +97,10 @@ namespace Mirror.KCP
         {
             var random = new Random();
 
-            long salt = random.Next();
-            salt = (salt << 32) | (long)random.Next();
+            long newSalt = random.Next();
+            newSalt = (newSalt << 32) | (long)random.Next();
 
-            var token = new HashCash(DateTime.UtcNow, resource, (ulong)salt, 0);
+            var token = new HashCash(DateTime.UtcNow, resource, (ulong)newSalt, 0);
 
             // calculate hash after hash until
             // we find one that validaes

--- a/Assets/Mirror/Runtime/Transport/Kcp/HashCash.cs.meta
+++ b/Assets/Mirror/Runtime/Transport/Kcp/HashCash.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 81def0a568d024fe0b62c09b5292056d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Mirror/Runtime/Transport/Kcp/KcpClientConnection.cs
+++ b/Assets/Mirror/Runtime/Transport/Kcp/KcpClientConnection.cs
@@ -76,7 +76,9 @@ namespace Mirror.KCP
             // in the very first message we must mine a hashcash token
             // and send that as a hello
             // the server won't accept connections otherwise
-            var token = HashCash.Mine(Application.productName, bits);
+            string applicationName = Application.productName;
+
+            HashCash token = await UniTask.RunOnThreadPool( () => HashCash.Mine(applicationName, bits));
             byte[] hello = new byte[1000];
             int length = HashCashEncoding.Encode(hello, 0, token);
 

--- a/Assets/Mirror/Runtime/Transport/Kcp/KcpClientConnection.cs
+++ b/Assets/Mirror/Runtime/Transport/Kcp/KcpClientConnection.cs
@@ -1,6 +1,9 @@
+using System;
+using System.IO;
 using System.Net;
 using System.Net.Sockets;
 using Cysharp.Threading.Tasks;
+using UnityEngine;
 
 namespace Mirror.KCP
 {
@@ -19,7 +22,7 @@ namespace Mirror.KCP
         {
         }
 
-        internal async UniTask ConnectAsync(string host, ushort port)
+        internal async UniTask ConnectAsync(string host, ushort port, int bits)
         {
             IPAddress[] ipAddress = await Dns.GetHostAddressesAsync(host);
             if (ipAddress.Length < 1)
@@ -32,7 +35,7 @@ namespace Mirror.KCP
 
             ReceiveLoop().Forget();
 
-            await Handshake();
+            await HandshakeAsync(bits);
         }
 
         async UniTaskVoid ReceiveLoop()
@@ -66,6 +69,26 @@ namespace Mirror.KCP
         protected override void RawSend(byte[] data, int length)
         {
             socket.Send(data, length, SocketFlags.None);
+        }
+
+        protected async UniTask HandshakeAsync(int bits)
+        {
+            // in the very first message we must mine a hashcash token
+            // and send that as a hello
+            // the server won't accept connections otherwise
+            var token = HashCash.Mine(Application.productName, bits);
+            byte[] hello = new byte[1000];
+            int length = HashCashEncoding.Encode(hello, 0, token);
+
+            var data = new ArraySegment<byte>(hello, 0, length);
+            // send a greeting and see if the server replies
+            await SendAsync(data);
+
+            var stream = new MemoryStream();
+            if (!await ReceiveAsync(stream))
+            {
+                throw new OperationCanceledException("Unable to establish connection, no Handshake message received.");
+            }
         }
     }
 }

--- a/Assets/Mirror/Runtime/Transport/Kcp/KcpConnection.cs
+++ b/Assets/Mirror/Runtime/Transport/Kcp/KcpConnection.cs
@@ -182,17 +182,6 @@ namespace Mirror.KCP
             return true;
         }
 
-        internal async UniTask Handshake()
-        {
-            // send a greeting and see if the server replies
-            await SendAsync(Hello);
-            var stream = new MemoryStream();
-            if (!await ReceiveAsync(stream))
-            {
-                throw new OperationCanceledException("Unable to establish connection, no Handshake message received.");
-            }
-        }
-
         /// <summary>
         ///     Disconnect this connection
         /// </summary>

--- a/Assets/Mirror/Runtime/Transport/Kcp/KcpServerConnection.cs
+++ b/Assets/Mirror/Runtime/Transport/Kcp/KcpServerConnection.cs
@@ -1,5 +1,8 @@
+using System;
+using System.IO;
 using System.Net;
 using System.Net.Sockets;
+using Cysharp.Threading.Tasks;
 
 namespace Mirror.KCP
 {
@@ -10,6 +13,22 @@ namespace Mirror.KCP
             this.socket = socket;
             this.remoteEndpoint = remoteEndpoint;
             SetupKcp();
+        }
+
+        internal async UniTask HandshakeAsync()
+        {
+            // send a greeting and see if the server replies
+            await SendAsync(Hello);
+            var stream = new MemoryStream();
+
+            // receive our first message and just throw it away
+            // this first message is the one that contains the Hashcash,
+            // but we don't care,  we already validated it before creating
+            // the connection
+            if (!await ReceiveAsync(stream))
+            {
+                throw new OperationCanceledException("Unable to establish connection, no Handshake message received.");
+            }
         }
 
         protected override void RawSend(byte[] data, int length)

--- a/Assets/Mirror/Runtime/Transport/Kcp/KcpTransport.cs
+++ b/Assets/Mirror/Runtime/Transport/Kcp/KcpTransport.cs
@@ -112,7 +112,7 @@ namespace Mirror.KCP
 
             while (expireQueue.Count > 0)
             {
-                var token = expireQueue.Peek();
+                HashCash token = expireQueue.Peek();
                 if (token.dt > threshold)
                     return;
 

--- a/Assets/Mirror/Runtime/Transport/Kcp/KcpTransport.cs
+++ b/Assets/Mirror/Runtime/Transport/Kcp/KcpTransport.cs
@@ -14,6 +14,10 @@ namespace Mirror.KCP
         [Header("Transport Configuration")]
         public ushort Port = 7777;
 
+        [Range(15, 20)]
+        [Tooltip("Used for DoS prevention,  clients must mine a HashCash with these many bits in order to connect, higher means more secure, but slower for the clients")]
+        public int HashCashBits = 18;
+
         internal readonly Dictionary<IPEndPoint, KcpServerConnection> connectedClients = new Dictionary<IPEndPoint, KcpServerConnection>(new IPEndpointComparer());
         readonly Channel<KcpServerConnection> acceptedConnections = Channel.CreateSingleConsumerUnbounded<KcpServerConnection>();
 
@@ -53,6 +57,11 @@ namespace Mirror.KCP
             // is this a new connection?                    
             if (!connectedClients.TryGetValue(endpoint as IPEndPoint, out KcpServerConnection connection))
             {
+                // very first message from this endpoint.
+                // lets validate it before we start KCP
+                if (!Validate(data, msgLength))
+                    return;
+
                 // add it to a queue
                 connection = new KcpServerConnection(socket, endpoint);
                 acceptedConnections.Writer.TryWrite(connection);
@@ -64,6 +73,52 @@ namespace Mirror.KCP
             }
 
             connection.RawInput(data, msgLength);
+        }
+
+        private readonly HashSet<HashCash> used = new HashSet<HashCash>();
+        private readonly Queue<HashCash> expireQueue = new Queue<HashCash>();
+
+        private bool Validate(byte[] data, int msgLength)
+        {
+            // do we have enough data in the buffer for a HashCash token?
+            if (msgLength < Kcp.OVERHEAD + KcpConnection.RESERVED + HashCashEncoding.SIZE)
+                return false;
+
+            // read the token
+            (_, HashCash token) = HashCashEncoding.Decode(data, Kcp.OVERHEAD + KcpConnection.RESERVED);
+
+            RemoveExpiredTokens();
+
+            // have this token been used?
+            if (used.Contains(token))
+                return false;
+
+
+            // does the token validate?
+            if (!token.Validate(Application.productName, HashCashBits))
+                return false;
+
+            used.Add(token);
+            expireQueue.Enqueue(token);
+
+            // brand new token, and it is for this app,  go on
+            return true;
+        }
+
+        // remove all the tokens that expired
+        private void RemoveExpiredTokens()
+        {
+            DateTime threshold = DateTime.UtcNow.AddMinutes(-10);
+
+            while (expireQueue.Count > 0)
+            {
+                var token = expireQueue.Peek();
+                if (token.dt > threshold)
+                    return;
+
+                expireQueue.Dequeue();
+                used.Remove(token);
+            }
         }
 
         /// <summary>
@@ -85,7 +140,7 @@ namespace Mirror.KCP
         {
             KcpServerConnection connection = await acceptedConnections.Reader.ReadAsync();
 
-            await connection.Handshake();
+            await connection.HandshakeAsync();
 
             return connection;
         }
@@ -124,7 +179,7 @@ namespace Mirror.KCP
 
             ushort port = (ushort)(uri.IsDefaultPort? Port : uri.Port);
 
-            await client.ConnectAsync(uri.Host, port);
+            await client.ConnectAsync(uri.Host, port, HashCashBits);
             return client;
         }
     }

--- a/Assets/Tests/Performance/Runtime/MultipleClients/Scenes/Scene.unity
+++ b/Assets/Tests/Performance/Runtime/MultipleClients/Scenes/Scene.unity
@@ -310,7 +310,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   Port: 7777
-  _bindAddress: localhost
+  HashCashBits: 15
 --- !u!4 &1193428351
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/Tests/Runtime/Transport/HashcashTest.cs
+++ b/Assets/Tests/Runtime/Transport/HashcashTest.cs
@@ -42,7 +42,7 @@ namespace Mirror.Tests
         {
             HashCash hashCash2 = hashCash;
 
-            Assert.That(hashCash2.Sha1(), Is.EqualTo(hashCash.Sha1()));
+            Assert.That(hashCash2.Hash(), Is.EqualTo(hashCash.Hash()));
         }
 
         [Test]
@@ -50,7 +50,7 @@ namespace Mirror.Tests
         {
             var hashCash2 = new HashCash(hashCash.dt, hashCash.resource + 1, hashCash.salt, hashCash.counter);
 
-            Assert.That(hashCash2.Sha1(), Is.Not.EqualTo(hashCash.Sha1()));
+            Assert.That(hashCash2.Hash(), Is.Not.EqualTo(hashCash.Hash()));
         }
 
         [Test]
@@ -64,7 +64,7 @@ namespace Mirror.Tests
         public void TestMiningNotGoodEnough()
         {
             var mined = HashCash.Mine("yomama", 10);
-            Assert.That(mined.ValidateHash(11), Is.False);
+            Assert.That(mined.ValidateHash(20), Is.False);
         }
 
         [Test]
@@ -117,7 +117,6 @@ namespace Mirror.Tests
                 Assert.That(mined.Validate("yomama", 18), Is.True);
 
                 stopWatch.Stop();
-                Debug.Log($"It took {stopWatch.ElapsedMilliseconds} to mine");
             }
         }
     }

--- a/Assets/Tests/Runtime/Transport/HashcashTest.cs
+++ b/Assets/Tests/Runtime/Transport/HashcashTest.cs
@@ -62,8 +62,30 @@ namespace Mirror.Tests
         [Test]
         public void TestMining()
         {
-            HashCash mined = HashCash.Mine("yomama".GetStableHashCode());
+            var mined = HashCash.Mine("yomama", 10);
+            Assert.That(mined.ValidateHash(10), Is.True);
+        }
 
+        [Test]
+        public void TestNotMined()
+        {
+            // we didn't mine this one,  so it should not validate
+            Assert.That(hashCash.ValidateHash(10), Is.False);
+        }
+
+        [Test]
+        public void InvalidHash()
+        {
+            byte[] hash = new byte[20] {
+                0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19 };
+            Assert.That(HashCash.Validate(hash, 16), Is.False);
+        }
+        [Test]
+        public void ValidHash()
+        {
+            byte[] hash = new byte[20] {
+                0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19 };
+            Assert.That(HashCash.Validate(hash, 15), Is.True);
         }
 
     }

--- a/Assets/Tests/Runtime/Transport/HashcashTest.cs
+++ b/Assets/Tests/Runtime/Transport/HashcashTest.cs
@@ -116,13 +116,17 @@ namespace Mirror.Tests
         [Test]
         public void ValidToken2()
         {
-            Stopwatch stopWatch = new Stopwatch();
-            stopWatch.Start();
-            var mined = HashCash.Mine("yomama", 15);
-            // token is for wrong resource
-            Assert.That(mined.Validate("yomama", 15), Is.True);
+            var stopWatch = new Stopwatch();
+            for (int i = 0; i < 10; i++)
+            {
+                stopWatch.Restart();
+                var mined = HashCash.Mine("yomama", 18);
+                // token is for wrong resource
+                Assert.That(mined.Validate("yomama", 18), Is.True);
 
-            Debug.Log($"It took {stopWatch.ElapsedMilliseconds} to mine");
+                stopWatch.Stop();
+                Debug.Log($"It took {stopWatch.ElapsedMilliseconds} to mine");
+            }
         }
     }
 }

--- a/Assets/Tests/Runtime/Transport/HashcashTest.cs
+++ b/Assets/Tests/Runtime/Transport/HashcashTest.cs
@@ -67,6 +67,13 @@ namespace Mirror.Tests
         }
 
         [Test]
+        public void TestMiningNotGoodEnough()
+        {
+            var mined = HashCash.Mine("yomama", 10);
+            Assert.That(mined.ValidateHash(11), Is.False);
+        }
+
+        [Test]
         public void TestNotMined()
         {
             // we didn't mine this one,  so it should not validate
@@ -88,5 +95,20 @@ namespace Mirror.Tests
             Assert.That(HashCash.Validate(hash, 15), Is.True);
         }
 
+        [Test]
+        public void InvalidResource()
+        {
+            var mined = HashCash.Mine("yomama", 10);
+            // token is for wrong resource
+            Assert.That(mined.Validate("filomon", 10), Is.False);
+        }
+
+        [Test]
+        public void ValidToken()
+        {
+            var mined = HashCash.Mine("yomama", 10);
+            // token is for wrong resource
+            Assert.That(mined.Validate("yomama", 10), Is.True);
+        }
     }
 }

--- a/Assets/Tests/Runtime/Transport/HashcashTest.cs
+++ b/Assets/Tests/Runtime/Transport/HashcashTest.cs
@@ -9,6 +9,8 @@ using UnityEngine;
 using Random = UnityEngine.Random;
 using System.Linq;
 using Mirror.KCP;
+using System.Diagnostics;
+using Debug = UnityEngine.Debug;
 
 namespace Mirror.Tests
 {
@@ -109,6 +111,18 @@ namespace Mirror.Tests
             var mined = HashCash.Mine("yomama", 10);
             // token is for wrong resource
             Assert.That(mined.Validate("yomama", 10), Is.True);
+        }
+
+        [Test]
+        public void ValidToken2()
+        {
+            Stopwatch stopWatch = new Stopwatch();
+            stopWatch.Start();
+            var mined = HashCash.Mine("yomama", 15);
+            // token is for wrong resource
+            Assert.That(mined.Validate("yomama", 15), Is.True);
+
+            Debug.Log($"It took {stopWatch.ElapsedMilliseconds} to mine");
         }
     }
 }

--- a/Assets/Tests/Runtime/Transport/HashcashTest.cs
+++ b/Assets/Tests/Runtime/Transport/HashcashTest.cs
@@ -77,14 +77,14 @@ namespace Mirror.Tests
         [Test]
         public void InvalidHash()
         {
-            byte[] hash = new byte[20] {
+            byte[] hash = new byte[] {
                 0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19 };
             Assert.That(HashCash.Validate(hash, 16), Is.False);
         }
         [Test]
         public void ValidHash()
         {
-            byte[] hash = new byte[20] {
+            byte[] hash = new byte[] {
                 0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19 };
             Assert.That(HashCash.Validate(hash, 15), Is.True);
         }

--- a/Assets/Tests/Runtime/Transport/HashcashTest.cs
+++ b/Assets/Tests/Runtime/Transport/HashcashTest.cs
@@ -1,0 +1,52 @@
+﻿using System.Collections;
+using NUnit.Framework;
+using UnityEngine.TestTools;
+using Cysharp.Threading.Tasks;
+using System;
+using System.IO;
+
+using UnityEngine;
+using Random = UnityEngine.Random;
+using System.Linq;
+using Mirror.KCP;
+
+namespace Mirror.Tests
+{
+
+    public class HashcashTest : MonoBehaviour
+    {
+        [Test]
+        public void TokenStructure (){
+            var hashCash = new HashCash
+            {
+                dt = DateTime.UtcNow,
+                resource = "yomama".GetStableHashCode(),
+                salt = 123123,
+                counter = 10,
+            };
+
+            Assert.That(hashCash.resource, Is.EqualTo("yomama".GetStableHashCode()));
+        }
+
+        [Test]
+        public void EncodingDecoding()
+        {
+            byte[] buffer = new byte[1000];
+
+            var hashCash = new HashCash
+            {
+                dt = DateTime.UtcNow,
+                resource = "yomama".GetStableHashCode(),
+                salt = 123123,
+                counter = 10,
+            };
+
+            int encodeLength = HashCashEncoding.Encode(buffer, 0, hashCash);
+
+            (int offset, HashCash decoded) = HashCashEncoding.Decode(buffer, 0);
+
+            Assert.That(offset, Is.EqualTo(encodeLength));
+            Assert.That(decoded, Is.EqualTo(hashCash));
+        }
+    }
+}

--- a/Assets/Tests/Runtime/Transport/HashcashTest.cs
+++ b/Assets/Tests/Runtime/Transport/HashcashTest.cs
@@ -15,31 +15,24 @@ namespace Mirror.Tests
 
     public class HashcashTest : MonoBehaviour
     {
-        [Test]
-        public void TokenStructure (){
-            var hashCash = new HashCash
+        HashCash hashCash;
+
+        [SetUp]
+        public void Setup()
+        {
+            hashCash = new HashCash
             {
                 dt = DateTime.UtcNow,
                 resource = "yomama".GetStableHashCode(),
                 salt = 123123,
                 counter = 10,
             };
-
-            Assert.That(hashCash.resource, Is.EqualTo("yomama".GetStableHashCode()));
         }
 
         [Test]
         public void EncodingDecoding()
         {
             byte[] buffer = new byte[1000];
-
-            var hashCash = new HashCash
-            {
-                dt = DateTime.UtcNow,
-                resource = "yomama".GetStableHashCode(),
-                salt = 123123,
-                counter = 10,
-            };
 
             int encodeLength = HashCashEncoding.Encode(buffer, 0, hashCash);
 
@@ -48,5 +41,30 @@ namespace Mirror.Tests
             Assert.That(offset, Is.EqualTo(encodeLength));
             Assert.That(decoded, Is.EqualTo(hashCash));
         }
+
+        [Test]
+        public void TestShaMatch()
+        {
+            HashCash hashCash2 = hashCash;
+
+            Assert.That(hashCash2.Sha1(), Is.EqualTo(hashCash.Sha1()));
+        }
+
+        [Test]
+        public void TestShaDiff()
+        {
+            HashCash hashCash2 = hashCash;
+            hashCash2.resource++;
+
+            Assert.That(hashCash2.Sha1(), Is.Not.EqualTo(hashCash.Sha1()));
+        }
+
+        [Test]
+        public void TestMining()
+        {
+            HashCash mined = HashCash.Mine("yomama".GetStableHashCode());
+
+        }
+
     }
 }

--- a/Assets/Tests/Runtime/Transport/HashcashTest.cs
+++ b/Assets/Tests/Runtime/Transport/HashcashTest.cs
@@ -1,13 +1,7 @@
-﻿using System.Collections;
-using NUnit.Framework;
-using UnityEngine.TestTools;
-using Cysharp.Threading.Tasks;
+﻿using NUnit.Framework;
 using System;
-using System.IO;
 
 using UnityEngine;
-using Random = UnityEngine.Random;
-using System.Linq;
 using Mirror.KCP;
 using System.Diagnostics;
 using Debug = UnityEngine.Debug;
@@ -22,13 +16,12 @@ namespace Mirror.Tests
         [SetUp]
         public void Setup()
         {
-            hashCash = new HashCash
-            {
-                dt = DateTime.UtcNow,
-                resource = "yomama".GetStableHashCode(),
-                salt = 123123,
-                counter = 10,
-            };
+            hashCash = new HashCash(
+                DateTime.UtcNow,
+                "yomama",
+                123123,
+                10
+            );
         }
 
         [Test]
@@ -55,8 +48,7 @@ namespace Mirror.Tests
         [Test]
         public void TestShaDiff()
         {
-            HashCash hashCash2 = hashCash;
-            hashCash2.resource++;
+            var hashCash2 = new HashCash(hashCash.dt, hashCash.resource + 1, hashCash.salt, hashCash.counter);
 
             Assert.That(hashCash2.Sha1(), Is.Not.EqualTo(hashCash.Sha1()));
         }

--- a/Assets/Tests/Runtime/Transport/HashcashTest.cs
+++ b/Assets/Tests/Runtime/Transport/HashcashTest.cs
@@ -4,7 +4,6 @@ using System;
 using UnityEngine;
 using Mirror.KCP;
 using System.Diagnostics;
-using Debug = UnityEngine.Debug;
 
 namespace Mirror.Tests
 {

--- a/Assets/Tests/Runtime/Transport/HashcashTest.cs
+++ b/Assets/Tests/Runtime/Transport/HashcashTest.cs
@@ -104,19 +104,5 @@ namespace Mirror.Tests
             Assert.That(mined.Validate("yomama", 10), Is.True);
         }
 
-        [Test]
-        public void ValidToken2()
-        {
-            var stopWatch = new Stopwatch();
-            for (int i = 0; i < 10; i++)
-            {
-                stopWatch.Restart();
-                var mined = HashCash.Mine("yomama", 18);
-                // token is for wrong resource
-                Assert.That(mined.Validate("yomama", 18), Is.True);
-
-                stopWatch.Stop();
-            }
-        }
     }
 }

--- a/Assets/Tests/Runtime/Transport/HashcashTest.cs
+++ b/Assets/Tests/Runtime/Transport/HashcashTest.cs
@@ -3,7 +3,6 @@ using System;
 
 using UnityEngine;
 using Mirror.KCP;
-using System.Diagnostics;
 
 namespace Mirror.Tests
 {
@@ -103,6 +102,5 @@ namespace Mirror.Tests
             // token is for wrong resource
             Assert.That(mined.Validate("yomama", 10), Is.True);
         }
-
     }
 }

--- a/Assets/Tests/Runtime/Transport/HashcashTest.cs.meta
+++ b/Assets/Tests/Runtime/Transport/HashcashTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 31a422d9c66b54082bb2f9adcfe1781d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Implementing hashcash to prevent DoS attacks.

In the handshake,  the client must mine and provide a valid Hashcash token.  The server will validate the token before opening the connection.
