### PR TITLE
fix: set KcpConnection timeout back to 5 seconds

### DIFF
--- a/Assets/Mirror/Runtime/Transport/Kcp/KcpConnection.cs
+++ b/Assets/Mirror/Runtime/Transport/Kcp/KcpConnection.cs
@@ -19,7 +19,7 @@ namespace Mirror.KCP
 
         // If we don't receive anything these many milliseconds
         // then consider us disconnected
-        public const int TIMEOUT = 15000;
+        public const int TIMEOUT = 5000;
 
         volatile uint lastReceived;
 


### PR DESCRIPTION
This was changed during a stress test from the original 3 seconds. It ended up not solving the problem at the time but was not changed back.