### PR TITLE
feat: display user-friendly log with an unexpected messages.

### DIFF
--- a/Assets/Mirror/Runtime/MessagePacker.cs
+++ b/Assets/Mirror/Runtime/MessagePacker.cs
@@ -18,8 +18,6 @@ namespace Mirror
     //    (probably even shorter)
     public static class MessagePacker
     {
-        private static readonly ILogger logger = LogFactory.GetLogger(typeof(MessagePacker));
-
         /// <summary>
         /// Map of Message Id => Type
         /// When we receive a message, we can lookup here to find out what type

--- a/Assets/Mirror/Runtime/MessagePacker.cs
+++ b/Assets/Mirror/Runtime/MessagePacker.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using UnityEngine;
 
 namespace Mirror
 {

--- a/Assets/Mirror/Runtime/MessagePacker.cs
+++ b/Assets/Mirror/Runtime/MessagePacker.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
+using UnityEngine;
 
 namespace Mirror
 {
@@ -16,6 +18,27 @@ namespace Mirror
     //    (probably even shorter)
     public static class MessagePacker
     {
+        private static readonly ILogger logger = LogFactory.GetLogger(typeof(MessagePacker));
+
+        /// <summary>
+        /// Map of Message Id => Type
+        /// When we receive a message, we can lookup here to find out what type
+        /// it was.  This is populated by the weaver.
+        /// </summary>
+        private static readonly Dictionary<int, Type> messageTypes = new Dictionary<int, Type>();
+
+        public static Type GetMessageType(int id) => messageTypes[id];
+
+        public static void RegisterMessage<T>()
+        {
+            int id = GetId<T>();
+
+            if (messageTypes.TryGetValue(id, out Type type) && type != typeof(T)) {
+                throw new ArgumentException($"Message {typeof(T)} and {messageTypes[id]} have the same ID. Change the name of one of those messages");
+            }
+            messageTypes[id] = typeof(T);
+        }
+
         public static int GetId<T>()
         {
             return GetId(typeof(T));

--- a/Assets/Tests/Editor/MessagePackerTest.cs
+++ b/Assets/Tests/Editor/MessagePackerTest.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using NUnit.Framework;
-using UnityEngine;
 
 namespace Mirror.Tests
 {

--- a/Assets/Tests/Editor/MessagePackerTest.cs
+++ b/Assets/Tests/Editor/MessagePackerTest.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using NUnit.Framework;
+using UnityEngine;
 
 namespace Mirror.Tests
 {
@@ -88,6 +89,34 @@ namespace Mirror.Tests
             {
                 var reader2 = new NetworkReader(new byte[0]);
                 int msgType2 = MessagePacker.UnpackId(reader2);
+            });
+        }
+
+        struct SomeRandomMessage { };
+
+        [Test]
+        public void RegisterMessage()
+        {
+            MessagePacker.RegisterMessage<SomeRandomMessage>();
+
+            int id = MessagePacker.GetId<SomeRandomMessage>();
+
+            Type type = MessagePacker.GetMessageType(id);
+
+            Assert.That(type, Is.EqualTo(typeof(SomeRandomMessage)));
+        }
+
+        // these 2 messages have a colliding message id
+        struct SomeRandomMessage2121143 { };
+        struct SomeRandomMessage2133122 { };
+
+        [Test]
+        public void RegisterMessage2()
+        {
+            MessagePacker.RegisterMessage<SomeRandomMessage2121143>();
+            Assert.Throws<ArgumentException>(() =>
+            {
+                MessagePacker.RegisterMessage<SomeRandomMessage2133122>();
             });
         }
     }

--- a/Assets/Tests/Editor/MessagePackerTest.cs
+++ b/Assets/Tests/Editor/MessagePackerTest.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using NUnit.Framework;
 using UnityEngine;
@@ -117,6 +118,25 @@ namespace Mirror.Tests
             Assert.Throws<ArgumentException>(() =>
             {
                 MessagePacker.RegisterMessage<SomeRandomMessage2133122>();
+            });
+        }
+
+        [Test]
+        public void FindSystemMessage()
+        {
+            int id = MessagePacker.GetId<SceneMessage>();
+            Type type = MessagePacker.GetMessageType(id);
+            Assert.That(type, Is.EqualTo(typeof(SceneMessage)));
+        }
+
+        struct SomeRandomMessageNotRegistered { };
+        [Test]
+        public void FindUnknownMessage()
+        {
+            int id = MessagePacker.GetId<SomeRandomMessageNotRegistered>();
+            Assert.Throws<KeyNotFoundException>(() =>
+            {
+                Type type = MessagePacker.GetMessageType(id);
             });
         }
     }

--- a/Assets/Tests/Editor/MessagePackerTest.cs
+++ b/Assets/Tests/Editor/MessagePackerTest.cs
@@ -133,7 +133,9 @@ namespace Mirror.Tests
         [Test]
         public void FindUnknownMessage()
         {
-            int id = MessagePacker.GetId<SomeRandomMessageNotRegistered>();
+            // note that GetId<> will cause the weaver to register it
+            // but GetId() will not
+            int id = MessagePacker.GetId(typeof(SomeRandomMessageNotRegistered));
             Assert.Throws<KeyNotFoundException>(() =>
             {
                 Type type = MessagePacker.GetMessageType(id);

--- a/Assets/Tests/Editor/NetworkConnectionTest.cs
+++ b/Assets/Tests/Editor/NetworkConnectionTest.cs
@@ -1,0 +1,41 @@
+﻿using System.IO;
+using NSubstitute;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace Mirror.Tests
+{
+    public class NetworkConnectionTest : MonoBehaviour
+    {
+        [Test]
+        public void NoHandler()
+        {
+            var connection = new NetworkConnection(Substitute.For<IConnection>());
+
+            int messageId = MessagePacker.GetId<SceneMessage>();
+            var reader = new NetworkReader(new byte[] { 1, 2, 3, 4 });
+            InvalidDataException exception = Assert.Throws<InvalidDataException>(() =>
+            {
+                connection.InvokeHandler(messageId, reader, 0);
+            });
+
+            Assert.That(exception.Message, Does.StartWith("Unexpected message Mirror.SceneMessage received"));
+        }
+
+        [Test]
+        public void UnknownMessage()
+        {
+            var connection = new NetworkConnection(Substitute.For<IConnection>());
+
+            int messageId = MessagePacker.GetId<SceneMessage>();
+            var reader = new NetworkReader(new byte[] { 1, 2, 3, 4 });
+            InvalidDataException exception = Assert.Throws<InvalidDataException>(() =>
+            {
+                // some random id with no message
+                connection.InvokeHandler(1234, reader, 0);
+            });
+
+            Assert.That(exception.Message, Does.StartWith("Unexpected message ID 1234 received"));
+        }
+    }
+}

--- a/Assets/Tests/Editor/NetworkConnectionTest.cs.meta
+++ b/Assets/Tests/Editor/NetworkConnectionTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a5e2205a841a1463fa02a35274d6d76a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
display user-friendly log with an unexpected messages.  

### Before:
> Unknown message ID 1234 connection(...). May be due to no existing RegisterHandler for this message.

### After:
> "Unexpected message Mirror.SceneMessage received in connection(...). Did you register a handler for it?"
