### PR TITLE
fix: fix multiple scene loading order issues

### DIFF
--- a/Assets/Mirror/Runtime/NetworkSceneManager.cs
+++ b/Assets/Mirror/Runtime/NetworkSceneManager.cs
@@ -73,19 +73,19 @@ namespace Mirror
 
         void RegisterClientMessages(INetworkConnection connection)
         {
-            connection.RegisterHandler<NotReadyMessage>(ClientNotReadyMessage);
             connection.RegisterHandler<SceneMessage>(ClientSceneMessage);
-            connection.RegisterHandler<SceneReadyMessage>(ClientSceneReadyMessage);
+            if (!client.IsLocalClient)
+            {
+                connection.RegisterHandler<SceneReadyMessage>(ClientSceneReadyMessage);
+                connection.RegisterHandler<NotReadyMessage>(ClientNotReadyMessage);
+            }
         }
 
         // called after successful authentication
         void OnClientAuthenticated(INetworkConnection conn)
         {
-            //Dont register msg handlers in host mode
-            if (!client.IsLocalClient)
-                RegisterClientMessages(conn);
-
             logger.Log("NetworkSceneManager.OnClientAuthenticated");
+            RegisterClientMessages(conn);
         }
 
         void OnClientDisconnected()

--- a/Assets/Mirror/Runtime/NetworkSceneManager.cs
+++ b/Assets/Mirror/Runtime/NetworkSceneManager.cs
@@ -163,9 +163,6 @@ namespace Mirror
             if (!client || !client.Active)
                 throw new InvalidOperationException("Ready() called with an null or disconnected client");
 
-            if (client.Connection.IsReady)
-                throw new InvalidOperationException("A connection has already been set as ready. There can only be one.");
-
             if (logger.LogEnabled()) logger.Log("ClientScene.Ready() called.");
 
             // Set these before sending the ReadyMessage, otherwise host client

--- a/Assets/Mirror/Runtime/NetworkSceneManager.cs
+++ b/Assets/Mirror/Runtime/NetworkSceneManager.cs
@@ -192,8 +192,7 @@ namespace Mirror
         {
             logger.Log("NetworkSceneManager.OnServerAuthenticated");
 
-            if (!string.IsNullOrEmpty(NetworkSceneName))
-                conn.Send(new SceneMessage { sceneName = NetworkSceneName });
+            conn.Send(new SceneMessage { sceneName = NetworkSceneName });
         }
 
         /// <summary>

--- a/Assets/Mirror/Runtime/NetworkSceneManager.cs
+++ b/Assets/Mirror/Runtime/NetworkSceneManager.cs
@@ -50,7 +50,7 @@ namespace Mirror
         /// <para>This is used to make sure that all scene changes are initialized by Mirror.</para>
         /// <para>Loading a scene manually wont set networkSceneName, so Mirror would still load it again on start.</para>
         /// </remarks>
-        public string NetworkSceneName => SceneManager.GetActiveScene().name;
+        public string NetworkSceneName => SceneManager.GetActiveScene().path;
 
         internal AsyncOperation asyncOperation;
 

--- a/Assets/Mirror/Runtime/NetworkSceneManager.cs
+++ b/Assets/Mirror/Runtime/NetworkSceneManager.cs
@@ -315,7 +315,7 @@ namespace Mirror
                 OnServerSceneChanged(sceneName, sceneOperation);
             }
             // client-only mode?
-            else if (client && client.Active)
+            else if (client && client.Active && !client.IsLocalClient)
             {
                 logger.Log("Finished loading scene in client-only mode.");
 

--- a/Assets/Mirror/Runtime/NetworkSceneManager.cs
+++ b/Assets/Mirror/Runtime/NetworkSceneManager.cs
@@ -148,8 +148,8 @@ namespace Mirror
         internal void OnClientSceneChanged(string sceneName, SceneOperation sceneOperation)
         {
             //set ready after scene change has completed
-            //if (!client.Connection.IsReady)
-            //    SetClientReady();
+            if (!client.Connection.IsReady)
+                SetClientReady();
 
             ClientSceneChanged.Invoke(sceneName, sceneOperation);
         }

--- a/Assets/Mirror/Runtime/NetworkSceneManager.cs
+++ b/Assets/Mirror/Runtime/NetworkSceneManager.cs
@@ -118,7 +118,8 @@ namespace Mirror
             logger.Log("ClientSceneReadyMessage");
 
             //Server has finished changing scene. Allow the client to finish.
-            asyncOperation.allowSceneActivation = true;
+            if(asyncOperation != null)
+                asyncOperation.allowSceneActivation = true;
         }
 
         internal void ClientNotReadyMessage(INetworkConnection conn, NotReadyMessage msg)
@@ -248,14 +249,15 @@ namespace Mirror
                     }
                     else
                     {
+                        asyncOperation = SceneManager.LoadSceneAsync(sceneName);
+                        asyncOperation.completed += OnAsyncComplete;
+
                         //If non host client. Wait for server to finish scene change
                         if (client && client.Active && !client.IsLocalClient)
                         {
                             asyncOperation.allowSceneActivation = false;
                         }
 
-                        asyncOperation = SceneManager.LoadSceneAsync(sceneName);
-                        asyncOperation.completed += OnAsyncComplete;
                         yield return asyncOperation;
                     }
                     

--- a/Assets/Mirror/Runtime/NetworkSceneManager.cs
+++ b/Assets/Mirror/Runtime/NetworkSceneManager.cs
@@ -50,7 +50,7 @@ namespace Mirror
         /// <para>This is used to make sure that all scene changes are initialized by Mirror.</para>
         /// <para>Loading a scene manually wont set networkSceneName, so Mirror would still load it again on start.</para>
         /// </remarks>
-        public string NetworkSceneName { get; protected set; } = "";
+        public string NetworkSceneName => SceneManager.GetActiveScene().name;
 
         internal AsyncOperation asyncOperation;
 
@@ -249,7 +249,6 @@ namespace Mirror
             switch (sceneOperation)
             {
                 case SceneOperation.Normal:
-                    NetworkSceneName = sceneName;
                     asyncOperation = SceneManager.LoadSceneAsync(sceneName);
 
                     //If non host client. Wait for server to finish scene change

--- a/Assets/Mirror/Runtime/NetworkSceneManager.cs
+++ b/Assets/Mirror/Runtime/NetworkSceneManager.cs
@@ -193,6 +193,7 @@ namespace Mirror
             logger.Log("NetworkSceneManager.OnServerAuthenticated");
 
             conn.Send(new SceneMessage { sceneName = NetworkSceneName });
+            conn.Send(new SceneReadyMessage());
         }
 
         /// <summary>

--- a/Assets/Mirror/Runtime/NetworkSceneManager.cs
+++ b/Assets/Mirror/Runtime/NetworkSceneManager.cs
@@ -319,11 +319,6 @@ namespace Mirror
             {
                 logger.Log("Finished loading scene in client-only mode.");
 
-                if (client.Connection != null && sceneOperation == SceneOperation.Normal)
-                {
-                    client.OnAuthenticated(client.Connection);
-                }
-
                 client.PrepareToSpawnSceneObjects();
 
                 OnClientSceneChanged(sceneName, sceneOperation);

--- a/Assets/Mirror/Runtime/NetworkSceneManager.cs
+++ b/Assets/Mirror/Runtime/NetworkSceneManager.cs
@@ -249,18 +249,22 @@ namespace Mirror
                 case SceneOperation.Normal:
                     //Scene is already active.
                     if (NetworkSceneName.Equals(sceneName))
-                        break;
-
-                    asyncOperation = SceneManager.LoadSceneAsync(sceneName);
-                    asyncOperation.completed += OnAsyncComplete;
-
-                    //If non host client. Wait for server to finish scene change
-                    if(client && client.Active && !client.IsLocalClient)
                     {
-                        asyncOperation.allowSceneActivation = false;
+                        FinishLoadScene(sceneName, sceneOperation);
                     }
+                    else
+                    {
+                        //If non host client. Wait for server to finish scene change
+                        if (client && client.Active && !client.IsLocalClient)
+                        {
+                            asyncOperation.allowSceneActivation = false;
+                        }
 
-                    yield return asyncOperation;
+                        asyncOperation = SceneManager.LoadSceneAsync(sceneName);
+                        asyncOperation.completed += OnAsyncComplete;
+                        yield return asyncOperation;
+                    }
+                    
                     break;
                 case SceneOperation.LoadAdditive:
                     // Ensure additive scene is not already loaded since we don't know which was passed in the Scene message

--- a/Assets/Mirror/Runtime/NetworkSceneManager.cs
+++ b/Assets/Mirror/Runtime/NetworkSceneManager.cs
@@ -100,12 +100,6 @@ namespace Mirror
             {
                 throw new InvalidOperationException("ClientSceneMessage: cannot change network scene while client is disconnected");
             }
-
-            if (client.IsLocalClient)
-            {
-                throw new InvalidOperationException("ClientSceneMessage: cannot change client network scene while operating in host mode");
-            }
-
             if (string.IsNullOrEmpty(msg.sceneName))
             {
                 throw new ArgumentNullException(msg.sceneName, "ClientSceneMessage: " + msg.sceneName + " cannot be empty or null");
@@ -153,8 +147,8 @@ namespace Mirror
         internal void OnClientSceneChanged(string sceneName, SceneOperation sceneOperation)
         {
             //set ready after scene change has completed
-            if (!client.Connection.IsReady)
-                SetClientReady();
+            //if (!client.Connection.IsReady)
+            //    SetClientReady();
 
             ClientSceneChanged.Invoke(sceneName, sceneOperation);
         }

--- a/Assets/Mirror/Runtime/NetworkSceneManager.cs
+++ b/Assets/Mirror/Runtime/NetworkSceneManager.cs
@@ -293,11 +293,6 @@ namespace Mirror
             {
                 logger.Log("Finished loading scene in host mode.");
 
-                if (client.Connection != null && sceneOperation == SceneOperation.Normal)
-                {
-                    client.OnAuthenticated(client.Connection);
-                }
-
                 // server scene was loaded. now spawn all the objects
                 server.ActivateHostScene();
 

--- a/Assets/Mirror/Runtime/NetworkSceneManager.cs
+++ b/Assets/Mirror/Runtime/NetworkSceneManager.cs
@@ -249,6 +249,10 @@ namespace Mirror
             switch (sceneOperation)
             {
                 case SceneOperation.Normal:
+                    //Scene is already active.
+                    if (NetworkSceneName.Equals(sceneName))
+                        break;
+
                     asyncOperation = SceneManager.LoadSceneAsync(sceneName);
 
                     //If non host client. Wait for server to finish scene change

--- a/Assets/Mirror/Runtime/NetworkSceneManager.cs
+++ b/Assets/Mirror/Runtime/NetworkSceneManager.cs
@@ -69,8 +69,6 @@ namespace Mirror
             }
         }
 
-        public virtual void LateUpdate() { } //TODO: Remove/move this as its only used in BenchmarkNetworkManager
-
         #region Client
 
         void RegisterClientMessages(INetworkConnection connection)

--- a/Assets/Mirror/Runtime/PlayerSpawner.cs
+++ b/Assets/Mirror/Runtime/PlayerSpawner.cs
@@ -26,7 +26,7 @@ namespace Mirror
             }
             if (client != null)
             {
-                client.Authenticated.AddListener(OnClientAuthenticated);
+                sceneManager.ClientSceneChanged.AddListener(OnClientSceneChanged);
                 client.RegisterPrefab(playerPrefab.gameObject);
             }
             if (server != null)
@@ -42,20 +42,14 @@ namespace Mirror
         }
 
         /// <summary>
-        /// Called on the client when connected to a server.
+        /// Called on the client when a normal scene change happens.
         /// <para>The default implementation of this function sets the client as ready and adds a player. Override the function to dictate what happens when the client connects.</para>
         /// </summary>
         /// <param name="conn">Connection to the server.</param>
-        private void OnClientAuthenticated(INetworkConnection connection)
+        private void OnClientSceneChanged(string sceneName, SceneOperation sceneOperation)
         {
-            // OnClientConnect by default calls AddPlayer but it should not do
-            // that when we have online/offline scenes. so we need the
-            // clientLoadedScene flag to prevent it.
-            // Ready/AddPlayer is usually triggered by a scene load completing. if no scene was loaded, then Ready/AddPlayer it here instead.
-            if (!client.Connection.IsReady)
-                sceneManager.SetClientReady();
-
-            client.Send(new AddPlayerMessage());
+            if(sceneOperation == SceneOperation.Normal)
+                client.Send(new AddPlayerMessage());
         }
 
         void OnServerAddPlayerInternal(INetworkConnection conn, AddPlayerMessage msg)

--- a/Assets/Mirror/Samples~/AdditiveScenes/Scenes/MainScene.unity
+++ b/Assets/Mirror/Samples~/AdditiveScenes/Scenes/MainScene.unity
@@ -1865,7 +1865,7 @@ MonoBehaviour:
   server: {fileID: 1661834283}
   client: {fileID: 1661834282}
   subScenes:
-  - Assets/Mirror/Examples/AdditiveScenes/Scenes/SubScene.unity
+  - Assets/Examples/AdditiveScenes/Scenes/SubScene.unity
 --- !u!4 &1661834279
 Transform:
   m_ObjectHideFlags: 0
@@ -2028,6 +2028,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   Port: 7777
   HashCashBits: 18
+  delayMode: 0
 --- !u!1 &1727677796
 GameObject:
   m_ObjectHideFlags: 0
@@ -3756,7 +3757,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6442dc8070ceb41f094e44de0bf87274, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  NetworkManager: {fileID: 0}
+  NetworkManager: {fileID: 1661834278}
   NetworkAddress: localhost
   NetworkAddressInput: {fileID: 476531300335670375}
   OfflineGO: {fileID: 476531300067055612}

--- a/Assets/Tests/Editor/PlayerSpawnerTest.cs
+++ b/Assets/Tests/Editor/PlayerSpawnerTest.cs
@@ -13,6 +13,7 @@ namespace Mirror.Tests
         private NetworkClient client;
         private NetworkServer server;
         private PlayerSpawner spawner;
+        private NetworkSceneManager sceneManager;
         private GameObject playerPrefab;
 
         private Transform pos1;
@@ -25,6 +26,10 @@ namespace Mirror.Tests
             client = go.AddComponent<NetworkClient>();
             server = go.AddComponent<NetworkServer>();
             spawner = go.AddComponent<PlayerSpawner>();
+            sceneManager = go.AddComponent<NetworkSceneManager>();
+            spawner.sceneManager = sceneManager;
+            sceneManager.client = client;
+            sceneManager.server = server;
             spawner.client = client;
             spawner.server = server;
 

--- a/Assets/Tests/Runtime/LobbyReadyTest.cs
+++ b/Assets/Tests/Runtime/LobbyReadyTest.cs
@@ -77,8 +77,8 @@ namespace Mirror.Tests
             Assert.That(readyComp.IsReady, Is.False);
         }
 
-        [Test]
-        public void ClientReadyTest()
+        [UnityTest]
+        public IEnumerator ClientReadyTest() => UniTask.ToCoroutine(async () =>
         {
             readyPlayer = new GameObject();
             readyPlayer.AddComponent<NetworkIdentity>();
@@ -87,7 +87,7 @@ namespace Mirror.Tests
             server.Spawn(readyPlayer, server.LocalConnection);
             readyComp.Ready();
 
-            Assert.That(readyComp.IsReady, Is.False);
-        }
+            await AsyncUtil.WaitUntilWithTimeout(() => readyComp.IsReady);
+        });
     }
 }

--- a/Assets/Tests/Runtime/NetworkSceneManagerTests.cs
+++ b/Assets/Tests/Runtime/NetworkSceneManagerTests.cs
@@ -74,7 +74,7 @@ namespace Mirror.Tests
 
             sceneManager.ChangeServerScene("testScene");
 
-            await AsyncUtil.WaitUntilWithTimeout(() => invokeClientSceneMessage && invokeNotReadyMessage);
+            await AsyncUtil.WaitUntilWithTimeout(() => sceneManager.asyncOperation.isDone);
 
             func1.Received(1).Invoke(Arg.Any<string>(), Arg.Any<SceneOperation>());
             Assert.That(sceneManager.NetworkSceneName, Is.EqualTo("testScene"));
@@ -216,15 +216,21 @@ namespace Mirror.Tests
             clientSceneManager.ClientChangeScene.AddListener(func1);
             clientSceneManager.ClientSceneMessage(null, new SceneMessage { sceneName = "testScene" });
 
-            await AsyncUtil.WaitUntilWithTimeout(() => clientSceneManager.NetworkSceneName.Equals("testScene"));
+            await AsyncUtil.WaitUntilWithTimeout(() => clientSceneManager.asyncOperation != null);
+
+            clientSceneManager.ClientSceneReadyMessage(connectionToServer, new SceneReadyMessage());
+
+            await AsyncUtil.WaitUntilWithTimeout(() => clientSceneManager.asyncOperation.isDone);
+
+            Assert.That(clientSceneManager.NetworkSceneName, Is.EqualTo("testScene"));
 
             func1.Received(1).Invoke(Arg.Any<string>(), Arg.Any<SceneOperation>());
         });
 
         [Test]
-        public void NetworkSceneNameStringEmptyTest()
+        public void NetworkSceneNameStringValueTest()
         {
-            Assert.That(clientSceneManager.NetworkSceneName.Equals(string.Empty));
+            Assert.That(clientSceneManager.NetworkSceneName.Equals(SceneManager.GetActiveScene().name));
         }
 
         [Test]

--- a/Assets/Tests/Runtime/NetworkSceneManagerTests.cs
+++ b/Assets/Tests/Runtime/NetworkSceneManagerTests.cs
@@ -95,17 +95,6 @@ namespace Mirror.Tests
             Assert.That(client.Connection.IsReady);
         }
 
-        [Test]
-        public void ReadyTwiceTest()
-        {
-            sceneManager.SetClientReady();
-
-            Assert.Throws<InvalidOperationException>(() =>
-            {
-                sceneManager.SetClientReady();
-            });
-        }
-
         int ClientChangeCalled;
         public void ClientChangeScene(string sceneName, SceneOperation sceneOperation)
         {

--- a/Assets/Tests/Runtime/NetworkSceneManagerTests.cs
+++ b/Assets/Tests/Runtime/NetworkSceneManagerTests.cs
@@ -109,15 +109,6 @@ namespace Mirror.Tests
             });
         }
 
-        [Test]
-        public void HostModeClientSceneException()
-        {
-            Assert.Throws<InvalidOperationException>(() =>
-            {
-                sceneManager.ClientSceneMessage(null, new SceneMessage());
-            });
-        }
-
         int ClientChangeCalled;
         public void ClientChangeScene(string sceneName, SceneOperation sceneOperation)
         {

--- a/Assets/Tests/Runtime/NetworkSceneManagerTests.cs
+++ b/Assets/Tests/Runtime/NetworkSceneManagerTests.cs
@@ -27,17 +27,14 @@ namespace Mirror.Tests
         [Test]
         public void FinishLoadSceneHostTest()
         {
-            UnityAction<INetworkConnection> func1 = Substitute.For<UnityAction<INetworkConnection>>();
             UnityAction<string, SceneOperation> func2 = Substitute.For<UnityAction<string, SceneOperation>>();
             UnityAction<string, SceneOperation> func3 = Substitute.For<UnityAction<string, SceneOperation>>();
 
-            client.Authenticated.AddListener(func1);
             sceneManager.ServerSceneChanged.AddListener(func2);
             sceneManager.ClientSceneChanged.AddListener(func3);
 
             sceneManager.FinishLoadScene("test", SceneOperation.Normal);
 
-            func1.Received(1).Invoke(Arg.Any<INetworkConnection>());
             func2.Received(1).Invoke(Arg.Any<string>(), Arg.Any<SceneOperation>());
             func3.Received(1).Invoke(Arg.Any<string>(), Arg.Any<SceneOperation>());
         }
@@ -74,7 +71,7 @@ namespace Mirror.Tests
 
             sceneManager.ChangeServerScene("testScene");
 
-            await AsyncUtil.WaitUntilWithTimeout(() => sceneManager.asyncOperation.isDone);
+            await AsyncUtil.WaitUntilWithTimeout(() => sceneManager.NetworkSceneName.Equals("testScene"));
 
             func1.Received(1).Invoke(Arg.Any<string>(), Arg.Any<SceneOperation>());
             Assert.That(sceneManager.NetworkSceneName, Is.EqualTo("testScene"));
@@ -141,12 +138,6 @@ namespace Mirror.Tests
 
             Assert.That(SceneManager.GetSceneByName("testScene"), Is.Not.Null);
         });
-
-        [Test]
-        public void ClientNoHandlersInHostMode()
-        {
-            Assert.DoesNotThrow(() => { server.SendToAll(new SceneMessage()); }); 
-        }
     }
 
     public class NetworkSceneManagerNonHostTests : ClientServerSetup<MockComponent>
@@ -173,17 +164,12 @@ namespace Mirror.Tests
         }
 
         [Test]
-        public void FinishLoadSceneHostTest()
+        public void FinishLoadSceneTest()
         {
-            UnityAction<INetworkConnection> func1 = Substitute.For<UnityAction<INetworkConnection>>();
             UnityAction<string, SceneOperation> func2 = Substitute.For<UnityAction<string, SceneOperation>>();
-
-            client.Authenticated.AddListener(func1);
             clientSceneManager.ClientSceneChanged.AddListener(func2);
-
             clientSceneManager.FinishLoadScene("test", SceneOperation.Normal);
 
-            func1.Received(1).Invoke(Arg.Any<INetworkConnection>());
             func2.Received(1).Invoke(Arg.Any<string>(), Arg.Any<SceneOperation>());
         }
 
@@ -228,24 +214,6 @@ namespace Mirror.Tests
         public void AsyncOperationInitStateTest()
         {
             Assert.That(clientSceneManager.asyncOperation, Is.Null);
-        }
-
-        [Test]
-        public void AsyncOperationStateTest()
-        {
-            clientSceneManager.ClientSceneMessage(null, new SceneMessage { sceneName = "testScene" });
-
-            Assert.That(clientSceneManager.asyncOperation, Is.Not.Null);
-            Assert.That(clientSceneManager.asyncOperation.allowSceneActivation, Is.False);
-        }
-
-        [Test]
-        public void ClientSceneReadyMessageTest()
-        {
-            clientSceneManager.ClientSceneMessage(null, new SceneMessage { sceneName = "testScene" });
-            clientSceneManager.ClientSceneReadyMessage(null, new SceneReadyMessage());
-
-            Assert.That(clientSceneManager.asyncOperation.allowSceneActivation, Is.True);
         }
     }
 }

--- a/Assets/Tests/Runtime/NetworkSceneManagerTests.cs
+++ b/Assets/Tests/Runtime/NetworkSceneManagerTests.cs
@@ -71,10 +71,10 @@ namespace Mirror.Tests
 
             sceneManager.ChangeServerScene("testScene");
 
-            await AsyncUtil.WaitUntilWithTimeout(() => sceneManager.NetworkSceneName.Equals("testScene"));
+            await AsyncUtil.WaitUntilWithTimeout(() => sceneManager.NetworkSceneName.Equals("Assets/Mirror/Tests/Runtime/testScene.unity"));
 
             func1.Received(1).Invoke(Arg.Any<string>(), Arg.Any<SceneOperation>());
-            Assert.That(sceneManager.NetworkSceneName, Is.EqualTo("testScene"));
+            Assert.That(sceneManager.NetworkSceneName, Is.EqualTo("Assets/Mirror/Tests/Runtime/testScene.unity"));
             Assert.That(invokeClientSceneMessage, Is.True);
             Assert.That(invokeNotReadyMessage, Is.True);
         });
@@ -199,7 +199,7 @@ namespace Mirror.Tests
 
             await AsyncUtil.WaitUntilWithTimeout(() => clientSceneManager.asyncOperation.isDone);
 
-            Assert.That(clientSceneManager.NetworkSceneName, Is.EqualTo("testScene"));
+            Assert.That(clientSceneManager.NetworkSceneName, Is.EqualTo("Assets/Mirror/Tests/Runtime/testScene.unity"));
 
             func1.Received(1).Invoke(Arg.Any<string>(), Arg.Any<SceneOperation>());
         });
@@ -207,7 +207,7 @@ namespace Mirror.Tests
         [Test]
         public void NetworkSceneNameStringValueTest()
         {
-            Assert.That(clientSceneManager.NetworkSceneName.Equals(SceneManager.GetActiveScene().name));
+            Assert.That(clientSceneManager.NetworkSceneName.Equals(SceneManager.GetActiveScene().path));
         }
 
         [Test]


### PR DESCRIPTION
This PR fixes a handful of related timing issues with scene loading. I tried to break this up in other smaller PRs but this chunk is too tangled. The intent is not to change functionality or flow but instead fix bugs or oversights in the existing code.

-----

Before: FinishLoadScene would fire before scene change actually completed
After: hook AsyncOperation.Complete to wait for completion.

Reason for change: this was the original inspiration for the change [Unity Developer Forum Post](https://forum.unity.com/threads/scenemanager-loadscene-additive-and-set-active.380826/#post-2486533). After some testing I confirmed that the UnityEvents for Post scene change were firing before the scene change completed in some scenarios. This was hidden by the IsReady code.

-----

Before: On connect the server will only tell you the NetworkSceneName if the server had changed scene since it started.
After: On connect the server will ALWAYS tell you the NetworkSceneName (returns SceneManager.GetActiveScene().name) every time.

Reason for change: this prevent ambiguous situations where the client and server could start in different scenes.

-----

Before: HostClient would not register any Scene related msg handlers.
After: HostClient registers Scene change msg handler.

Reason for change: this sends all scene changes through the same code paths. Eventually results in less redundant calls and host/client checks.

-----

Before: PlayerSpawner used Authenticated to AddNewPlayerMessage.
After: PlayerSpawner uses ClientSceneChanged (Normal scene change only) to AddNewPlayerMessage.

Reason for change: The player will need to be spawned after a normal scene change happens (as its detroyed in that process since its not DDOL). There is no reason to couple that action to Authenticated as that may have unintended side effects. Also helps remove code from NetworkSceneManager as the existing event can handle this situation instead.