### PR TITLE
feat: TCPTransport is obsolete, use KCPTransport instead

### DIFF
--- a/Assets/Mirror/Runtime/Transport/Tcp/TcpConnection.cs
+++ b/Assets/Mirror/Runtime/Transport/Tcp/TcpConnection.cs
@@ -6,6 +6,7 @@ using Cysharp.Threading.Tasks;
 
 namespace Mirror.Tcp
 {
+    [Obsolete("Use KcpConnection instead")]
     internal class TcpConnection : IConnection
     {
         private readonly TcpClient client;

--- a/Assets/Mirror/Runtime/Transport/Tcp/TcpTransport.cs
+++ b/Assets/Mirror/Runtime/Transport/Tcp/TcpTransport.cs
@@ -7,7 +7,8 @@ using Cysharp.Threading.Tasks;
 using UnityEngine;
 
 namespace Mirror.Tcp
-{ 
+{
+    [Obsolete("Use KcpTransport instead")]
     public class TcpTransport : Transport
     {
         private TcpListener listener;

--- a/Assets/Tests/Performance/Runtime/HeadlessBenchmark/Scripts/HeadlessBenchmark.cs
+++ b/Assets/Tests/Performance/Runtime/HeadlessBenchmark/Scripts/HeadlessBenchmark.cs
@@ -180,7 +180,9 @@ namespace Mirror.HeadlessBenchmark
             {
                 if (transport.Equals("tcp"))
                 {
+#pragma warning disable CS0618 // Type or member is obsolete
                     TcpTransport newTransport = networkManager.gameObject.AddComponent<TcpTransport>();
+#pragma warning restore CS0618 // Type or member is obsolete
 
                     //Try to apply port if exists and needed by transport.
                     if (!string.IsNullOrEmpty(port))

--- a/Assets/Tests/Runtime/Transport/TransportTests.cs
+++ b/Assets/Tests/Runtime/Transport/TransportTests.cs
@@ -14,7 +14,9 @@ using Mirror.KCP;
 
 namespace Mirror.Tests
 {
+#pragma warning disable CS0618 // Type or member is obsolete
     [TestFixture(typeof(TcpTransport), new[] { "tcp4" }, "tcp4://localhost", 7777)]
+#pragma warning restore CS0618 // Type or member is obsolete
     [TestFixture(typeof(KcpTransport), new[] { "kcp" }, "kcp://localhost", 7777)]
     public class AsyncTransportTests<T> where T : Transport
     {


### PR DESCRIPTION
KCP transport is better than TCP transport in every way as far as I know.  
There is no reason to use TCP transport anymore.

Let's mark it obsolete so people know to migrate.