### PR TITLE
feat: SyncObjects raise events when initialized

### DIFF
--- a/Assets/Mirror/Runtime/SyncDictionary.cs
+++ b/Assets/Mirror/Runtime/SyncDictionary.cs
@@ -167,18 +167,21 @@ namespace Mirror
 
             objects.Clear();
             changes.Clear();
+            OnClear?.Invoke();
 
             for (int i = 0; i < count; i++)
             {
                 TKey key = reader.Read<TKey>();
                 TValue obj = reader.Read<TValue>();
                 objects.Add(key, obj);
+                OnInsert?.Invoke(key, obj);
             }
 
             // We will need to skip all these changes
             // the next time the list is synchronized
             // because they have already been applied
             changesAhead = (int)reader.ReadPackedUInt32();
+            OnChange?.Invoke();
         }
 
         public void OnDeserializeDelta(NetworkReader reader)

--- a/Assets/Mirror/Runtime/SyncList.cs
+++ b/Assets/Mirror/Runtime/SyncList.cs
@@ -176,18 +176,22 @@ namespace Mirror
             int count = (int)reader.ReadPackedUInt32();
 
             objects.Clear();
+            OnClear?.Invoke();
             changes.Clear();
 
             for (int i = 0; i < count; i++)
             {
                 T obj = reader.Read<T>();
                 objects.Add(obj);
+                OnInsert?.Invoke(i, obj);
             }
 
             // We will need to skip all these changes
             // the next time the list is synchronized
             // because they have already been applied
             changesAhead = (int)reader.ReadPackedUInt32();
+
+            OnChange?.Invoke();
         }
 
         public void OnDeserializeDelta(NetworkReader reader)

--- a/Assets/Mirror/Runtime/SyncSet.cs
+++ b/Assets/Mirror/Runtime/SyncSet.cs
@@ -150,17 +150,20 @@ namespace Mirror
 
             objects.Clear();
             changes.Clear();
+            OnClear?.Invoke();
 
             for (int i = 0; i < count; i++)
             {
                 T obj = reader.Read<T>();
                 objects.Add(obj);
+                OnAdd?.Invoke(obj);
             }
 
             // We will need to skip all these changes
             // the next time the list is synchronized
             // because they have already been applied
             changesAhead = (int)reader.ReadPackedUInt32();
+            OnChange?.Invoke();
         }
 
         public void OnDeserializeDelta(NetworkReader reader)

--- a/Assets/Tests/Editor/SyncDictionaryTest.cs
+++ b/Assets/Tests/Editor/SyncDictionaryTest.cs
@@ -59,6 +59,36 @@ namespace Mirror.Tests
         }
 
         [Test]
+        public void ClearEventOnSyncAll()
+        {
+            Action callback = Substitute.For<Action>();
+            clientSyncDictionary.OnClear += callback;
+            SerializeAllTo(serverSyncDictionary, clientSyncDictionary);
+            callback.Received().Invoke();
+        }
+
+        [Test]
+        public void InsertEventOnSyncAll()
+        {
+            Action<int, string> callback = Substitute.For<Action<int, string>>();
+            clientSyncDictionary.OnInsert += callback;
+            SerializeAllTo(serverSyncDictionary, clientSyncDictionary);
+
+            callback.Received().Invoke(0, "Hello");
+            callback.Received().Invoke(1, "World");
+            callback.Received().Invoke(2, "!");
+        }
+
+        [Test]
+        public void ChangeEventOnSyncAll()
+        {
+            Action callback = Substitute.For<Action>();
+            clientSyncDictionary.OnChange += callback;
+            SerializeAllTo(serverSyncDictionary, clientSyncDictionary);
+            callback.Received().Invoke();
+        }
+
+        [Test]
         public void TestAdd()
         {
             serverSyncDictionary.Add(4, "yay");

--- a/Assets/Tests/Editor/SyncListTest.cs
+++ b/Assets/Tests/Editor/SyncListTest.cs
@@ -57,6 +57,39 @@ namespace Mirror.Tests
         }
 
         [Test]
+        public void ClearEventOnSyncAll()
+        {
+            Action callback = Substitute.For<Action>();
+            clientSyncList.OnClear += callback;
+            SerializeAllTo(serverSyncList, clientSyncList);
+            callback.Received().Invoke();
+        }
+
+        [Test]
+        public void InsertEventOnSyncAll()
+        {
+            Action<int, string> callback = Substitute.For<Action<int, string>>();
+            clientSyncList.OnInsert += callback;
+            SerializeAllTo(serverSyncList, clientSyncList);
+
+            Received.InOrder(() =>
+            {
+                callback.Invoke(0, "Hello");
+                callback.Invoke(1, "World");
+                callback.Invoke(2, "!");
+            });
+        }
+
+        [Test]
+        public void ChangeEventOnSyncAll()
+        {
+            Action callback = Substitute.For<Action>();
+            clientSyncList.OnChange += callback;
+            SerializeAllTo(serverSyncList, clientSyncList);
+            callback.Received().Invoke();
+        }
+
+        [Test]
         public void TestAdd()
         {
             serverSyncList.Add("yay");

--- a/Assets/Tests/Editor/SyncSetTest.cs
+++ b/Assets/Tests/Editor/SyncSetTest.cs
@@ -51,6 +51,37 @@ namespace Mirror.Tests
         }
 
         [Test]
+        public void ClearEventOnSyncAll()
+        {
+            Action callback = Substitute.For<Action>();
+            clientSyncSet.OnClear += callback;
+            SerializeAllTo(serverSyncSet, clientSyncSet);
+            callback.Received().Invoke();
+        }
+
+        [Test]
+        public void InsertEventOnSyncAll()
+        {
+            Action<string> callback = Substitute.For<Action<string>>();
+            clientSyncSet.OnAdd += callback;
+            SerializeAllTo(serverSyncSet, clientSyncSet);
+
+            callback.Received().Invoke("Hello");
+            callback.Received().Invoke("World");
+            callback.Received().Invoke("!");
+        }
+
+        [Test]
+        public void ChangeEventOnSyncAll()
+        {
+            Action callback = Substitute.For<Action>();
+            clientSyncSet.OnChange += callback;
+            SerializeAllTo(serverSyncSet, clientSyncSet);
+            callback.Received().Invoke();
+        }
+
+
+        [Test]
         public void TestAdd()
         {
             serverSyncSet.Add("yay");


### PR DESCRIPTION
Previously, synclists were not raising events when the object was spawned in the client.

This confused a lot of people.  Now they do,  to receive the event, subscribe to it in the Awake() method (before the data is synchronized).