### PR TITLE
perf: simplify NetworkWriter/Reader dispose

### DIFF
--- a/Assets/Mirror/Runtime/NetworkReaderPool.cs
+++ b/Assets/Mirror/Runtime/NetworkReaderPool.cs
@@ -6,19 +6,13 @@ namespace Mirror
     /// <summary>
     /// NetworkReader to be used with <see cref="NetworkReaderPool">NetworkReaderPool</see>
     /// </summary>
-    public class PooledNetworkReader : NetworkReader, IDisposable
+    public sealed class PooledNetworkReader : NetworkReader, IDisposable
     {
         internal PooledNetworkReader(byte[] bytes) : base(bytes) { }
 
         internal PooledNetworkReader(ArraySegment<byte> segment) : base(segment) { }
 
         public void Dispose()
-        {
-            Dispose(true);
-            GC.SuppressFinalize(this);
-        }
-
-        public virtual void Dispose(bool disposing)
         {
             NetworkReaderPool.Recycle(this);
         }

--- a/Assets/Mirror/Runtime/NetworkWriterPool.cs
+++ b/Assets/Mirror/Runtime/NetworkWriterPool.cs
@@ -6,15 +6,9 @@ namespace Mirror
     /// <summary>
     /// NetworkWriter to be used with <see cref="NetworkWriterPool">NetworkWriterPool</see>
     /// </summary>
-    public class PooledNetworkWriter : NetworkWriter, IDisposable
+    public sealed class PooledNetworkWriter : NetworkWriter, IDisposable
     {
         public void Dispose() {
-            Dispose(true);
-            GC.SuppressFinalize(this);
-        }
-
-        public virtual void Dispose(bool disposing)
-        {
             NetworkWriterPool.Recycle(this);
         }
     }


### PR DESCRIPTION
Sealed classes don't need the complicated disposable pattern