### PR TITLE
ReceiveAsync now throws EndOfStreamException

### DIFF
--- a/Assets/Mirror/Runtime/NetworkConnection.cs
+++ b/Assets/Mirror/Runtime/NetworkConnection.cs
@@ -347,13 +347,24 @@ namespace Mirror
         {
             var buffer = new MemoryStream();
 
-            (bool next, int channel) = await connection.ReceiveAsync(buffer);
+            try
+            {
+                while (true)
+                {
 
-            while (next) { 
-                buffer.TryGetBuffer(out ArraySegment<byte> data);
-                TransportReceive(data, channel);
+                    int channel = await connection.ReceiveAsync(buffer);
 
-                (next, channel) = await connection.ReceiveAsync(buffer);
+                    buffer.TryGetBuffer(out ArraySegment<byte> data);
+                    TransportReceive(data, channel);
+                }
+            }
+            catch (EndOfStreamException)
+            {
+                // connection closed,  normal
+            }
+            catch (Exception ex)
+            {
+                logger.LogException(ex);
             }
         }
     }

--- a/Assets/Mirror/Runtime/Transport/IConnection.cs
+++ b/Assets/Mirror/Runtime/Transport/IConnection.cs
@@ -23,8 +23,9 @@ namespace Mirror
         /// reads a message from connection
         /// </summary>
         /// <param name="buffer">buffer where the message will be written</param>
-        /// <returns>true if we got a message, false if we got disconnected</returns>
-        UniTask<(bool next, int channel)> ReceiveAsync(MemoryStream buffer);
+        /// <returns>The channel where we got the message</returns>
+        /// <exception cref="EndOfStreamException">If the connetion has been closed</exception>
+        UniTask<int> ReceiveAsync(MemoryStream buffer);
 
         /// <summary>
         /// Disconnect this connection

--- a/Assets/Mirror/Runtime/Transport/IConnection.cs
+++ b/Assets/Mirror/Runtime/Transport/IConnection.cs
@@ -24,7 +24,7 @@ namespace Mirror
         /// </summary>
         /// <param name="buffer">buffer where the message will be written</param>
         /// <returns>The channel where we got the message</returns>
-        /// <exception cref="EndOfStreamException">If the connetion has been closed</exception>
+        /// <remark> throws System.IO.EndOfStreamException if the connetion has been closed</remark>
         UniTask<int> ReceiveAsync(MemoryStream buffer);
 
         /// <summary>

--- a/Assets/Mirror/Runtime/Transport/IConnection.cs
+++ b/Assets/Mirror/Runtime/Transport/IConnection.cs
@@ -24,7 +24,7 @@ namespace Mirror
         /// </summary>
         /// <param name="buffer">buffer where the message will be written</param>
         /// <returns>The channel where we got the message</returns>
-        /// <exception cref="System.IO.EndOfStreamException">if the connetion has been closed</exception>
+        /// <remark> throws System.IO.EndOfStreamException if the connetion has been closed</remark>
         UniTask<int> ReceiveAsync(MemoryStream buffer);
 
         /// <summary>

--- a/Assets/Mirror/Runtime/Transport/IConnection.cs
+++ b/Assets/Mirror/Runtime/Transport/IConnection.cs
@@ -24,7 +24,7 @@ namespace Mirror
         /// </summary>
         /// <param name="buffer">buffer where the message will be written</param>
         /// <returns>The channel where we got the message</returns>
-        /// <remark> throws System.IO.EndOfStreamException if the connetion has been closed</remark>
+        /// <exception cref="System.IO.EndOfStreamException">if the connetion has been closed</exception>
         UniTask<int> ReceiveAsync(MemoryStream buffer);
 
         /// <summary>

--- a/Assets/Mirror/Runtime/Transport/Kcp/Kcp.cs
+++ b/Assets/Mirror/Runtime/Transport/Kcp/Kcp.cs
@@ -81,7 +81,7 @@ namespace Mirror.KCP
         private uint current;                 // current time (milliseconds). set by Update.
 
         private int fastresend;
-        private int fastlimit = 5; // max times to trigger fastack
+        private readonly int fastlimit = 5; // max times to trigger fastack
         private bool nocwnd;
         private readonly Queue<Segment> snd_queue = new Queue<Segment>(16); // send queue
         private readonly Queue<Segment> rcv_queue = new Queue<Segment>(16); // receive queue

--- a/Assets/Mirror/Runtime/Transport/Kcp/KcpClientConnection.cs
+++ b/Assets/Mirror/Runtime/Transport/Kcp/KcpClientConnection.cs
@@ -88,9 +88,13 @@ namespace Mirror.KCP
             await SendAsync(data);
 
             var stream = new MemoryStream();
-            if (!(await ReceiveAsync(stream)).next)
+            try
             {
-                throw new OperationCanceledException("Unable to establish connection, no Handshake message received.");
+                await ReceiveAsync(stream);
+            }
+            catch (Exception e)
+            {
+                throw new InvalidDataException("Unable to establish connection, no Handshake message received.", e);
             }
         }
     }

--- a/Assets/Mirror/Runtime/Transport/Kcp/KcpConnection.cs
+++ b/Assets/Mirror/Runtime/Transport/Kcp/KcpConnection.cs
@@ -197,7 +197,7 @@ namespace Mirror.KCP
         /// </summary>
         /// <param name="buffer">buffer where the message will be written</param>
         /// <returns>true if we got a message, false if we got disconnected</returns>
-        public async UniTask<(bool next, int channel)> ReceiveAsync(MemoryStream buffer)
+        public async UniTask<int> ReceiveAsync(MemoryStream buffer)
         {
             while (kcp.PeekSize() < 0 && unreliable.PeekSize() < 0 && open) { 
                 isWaiting = true;
@@ -209,7 +209,7 @@ namespace Mirror.KCP
             if (!open)
             {
                 Disconnected?.Invoke();
-                return (false, Channel.Reliable);
+                throw new EndOfStreamException();
             }
 
             if (unreliable.PeekSize() >= 0)
@@ -219,7 +219,7 @@ namespace Mirror.KCP
                 buffer.SetLength(msgSize);
                 unreliable.Receive(buffer.GetBuffer(), (int)buffer.Length);
                 buffer.Position = msgSize;
-                return (true, Channel.Unreliable);
+                return Channel.Unreliable;
             }
             else
             {
@@ -236,9 +236,9 @@ namespace Mirror.KCP
                 {
                     open = false;
                     Disconnected?.Invoke();
-                    return (false, Channel.Reliable);
+                    throw new EndOfStreamException();
                 }
-                return (true, Channel.Reliable);
+                return Channel.Reliable;
             }
         }
 

--- a/Assets/Mirror/Runtime/Transport/Kcp/KcpServerConnection.cs
+++ b/Assets/Mirror/Runtime/Transport/Kcp/KcpServerConnection.cs
@@ -21,16 +21,19 @@ namespace Mirror.KCP
             await SendAsync(Hello);
             var stream = new MemoryStream();
 
-            // receive our first message and just throw it away
-            // this first message is the one that contains the Hashcash,
-            // but we don't care,  we already validated it before creating
-            // the connection
-            if (!(await ReceiveAsync(stream)).next)
+            try
             {
-                throw new OperationCanceledException("Unable to establish connection, no Handshake message received.");
+                // receive our first message and just throw it away
+                // this first message is the one that contains the Hashcash,
+                // but we don't care,  we already validated it before creating
+                // the connection
+                await ReceiveAsync(stream);
+            }
+            catch (Exception ex)
+            {
+                throw new InvalidDataException("No handshake received", ex);
             }
         }
-
         protected override void RawSend(byte[] data, int length)
         {
             socket.SendTo(data, 0, length, SocketFlags.None, remoteEndpoint);

--- a/Assets/Mirror/Runtime/Transport/PipeConnection.cs
+++ b/Assets/Mirror/Runtime/Transport/PipeConnection.cs
@@ -53,7 +53,7 @@ namespace Mirror
         // technically not an IPEndpoint,  will fix later
         public EndPoint GetEndPointAddress() => new IPEndPoint(IPAddress.Loopback, 0);
         
-        public async UniTask<(bool next, int channel)> ReceiveAsync(MemoryStream buffer)
+        public async UniTask<int> ReceiveAsync(MemoryStream buffer)
         {
             // wait for a message
             await MessageCount.WaitAsync();
@@ -64,7 +64,7 @@ namespace Mirror
             ArraySegment<byte> data = reader.ReadBytesAndSizeSegment();
 
             if (data.Count == 0)
-                return (false, 0);
+                throw new EndOfStreamException();
 
             buffer.SetLength(0);
             buffer.Write(data.Array, data.Offset, data.Count);
@@ -76,7 +76,7 @@ namespace Mirror
                 reader.Position = 0;
             }
 
-            return (true, 0);
+            return 0;
         }
 
         public UniTask SendAsync(ArraySegment<byte> data, int channel = Channel.Reliable)

--- a/Assets/Tests/Editor/PipeConnectionTest.cs
+++ b/Assets/Tests/Editor/PipeConnectionTest.cs
@@ -32,7 +32,7 @@ namespace Mirror.Tests
         private static async Task ExpectData(IConnection c, byte[] expected)
         {
             var memoryStream = new MemoryStream();
-            Assert.That((await c.ReceiveAsync(memoryStream)).next);
+            await c.ReceiveAsync(memoryStream);
 
             memoryStream.TryGetBuffer(out ArraySegment<byte> receivedData);
             Assert.That(receivedData, Is.EqualTo(new ArraySegment<byte>(expected)));
@@ -63,8 +63,25 @@ namespace Mirror.Tests
             c1.Disconnect();
 
             var memoryStream = new MemoryStream();
-            Assert.That((await c1.ReceiveAsync(memoryStream)).next, Is.False);
-            Assert.That((await c2.ReceiveAsync(memoryStream)).next, Is.False);
+            try
+            {
+                await c1.ReceiveAsync(memoryStream);
+                Assert.Fail("Recive Async should have thrown EndOfStreamException");
+            }
+            catch (EndOfStreamException)
+            {
+                // good to go
+            }
+
+            try
+            {
+                await c2.ReceiveAsync(memoryStream);
+                Assert.Fail("Recive Async should have thrown EndOfStreamException");
+            }
+            catch (EndOfStreamException)
+            {
+                // good to go
+            }
         });
 
         [UnityTest]
@@ -74,8 +91,25 @@ namespace Mirror.Tests
             c2.Disconnect();
 
             var memoryStream = new MemoryStream();
-            Assert.That((await c1.ReceiveAsync(memoryStream)).next, Is.False);
-            Assert.That((await c2.ReceiveAsync(memoryStream)).next, Is.False);
+            try
+            {
+                await c1.ReceiveAsync(memoryStream);
+                Assert.Fail("Recive Async should have thrown EndOfStreamException");
+            }
+            catch (EndOfStreamException)
+            {
+                // good to go
+            }
+
+            try
+            {
+                await c2.ReceiveAsync(memoryStream);
+                Assert.Fail("Recive Async should have thrown EndOfStreamException");
+            }
+            catch (EndOfStreamException)
+            {
+                // good to go
+            }
         });
 
         [Test]

--- a/Assets/Tests/Runtime/Transport/TransportTests.cs
+++ b/Assets/Tests/Runtime/Transport/TransportTests.cs
@@ -71,7 +71,7 @@ namespace Mirror.Tests
 
             var stream = new MemoryStream();
 
-            Assert.That((await serverConnection.ReceiveAsync(stream)).next, Is.True);
+            await serverConnection.ReceiveAsync(stream);
             byte[] received = stream.ToArray();
             Assert.That(received, Is.EqualTo(data));
         });
@@ -110,12 +110,12 @@ namespace Mirror.Tests
 
             var stream = new MemoryStream();
 
-            Assert.That((await serverConnection.ReceiveAsync(stream)).next, Is.True);
+            await serverConnection.ReceiveAsync(stream);
             byte[] received = stream.ToArray();
             Assert.That(received, Is.EqualTo(data));
 
             stream.SetLength(0);
-            Assert.That((await serverConnection.ReceiveAsync(stream)).next, Is.True);
+            await serverConnection.ReceiveAsync(stream);
             byte[] received2 = stream.ToArray();
             Assert.That(received2, Is.EqualTo(data2));
         });
@@ -130,7 +130,7 @@ namespace Mirror.Tests
 
             var stream = new MemoryStream();
 
-            Assert.That((await clientConnection.ReceiveAsync(stream)).next, Is.True);
+            await clientConnection.ReceiveAsync(stream);
             byte[] received = stream.ToArray();
             Assert.That(received, Is.EqualTo(data));
         });
@@ -141,7 +141,15 @@ namespace Mirror.Tests
             serverConnection.Disconnect();
 
             var stream = new MemoryStream();
-            Assert.That((await clientConnection.ReceiveAsync(stream)).next, Is.False);
+            try
+            {
+                await clientConnection.ReceiveAsync(stream);
+                Assert.Fail("ReceiveAsync should have thrown EndOfStreamException");
+            }
+            catch (EndOfStreamException)
+            {
+                // good to go
+            }
         });
 
         [UnityTest]
@@ -150,7 +158,15 @@ namespace Mirror.Tests
             clientConnection.Disconnect();
 
             var stream = new MemoryStream();
-            Assert.That((await serverConnection.ReceiveAsync(stream)).next, Is.False);
+            try
+            {
+                await serverConnection.ReceiveAsync(stream);
+                Assert.Fail("ReceiveAsync should have thrown EndOfStreamException");
+            }
+            catch (EndOfStreamException)
+            {
+                // good to go
+            }
         });
 
         [UnityTest]
@@ -159,7 +175,15 @@ namespace Mirror.Tests
             clientConnection.Disconnect();
 
             var stream = new MemoryStream();
-            Assert.That((await clientConnection.ReceiveAsync(stream)).next, Is.False);
+            try
+            {
+                await clientConnection.ReceiveAsync(stream);
+                Assert.Fail("ReceiveAsync should have thrown EndOfStreamException");
+            }
+            catch (EndOfStreamException)
+            {
+                // good to go
+            }
         });
 
         [Test]


### PR DESCRIPTION
before ReceiveAsync returned both a boolean and a channel.
This was very awkard to use and implement,  now ReceiveAsync throws EndOfStreamException
when the connection is disconnected

BREAKING CHANGE: External transports will need update