### PR TITLE
fix(weaver): NRE with basic authenticator

### DIFF
--- a/Assets/Mirror/Editor/Weaver/Processors/CodePass.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/CodePass.cs
@@ -60,7 +60,7 @@ namespace Mirror.Weaver
                 return;
             }
 
-            if (selector(md))
+            if (md.Body.CodeSize> 0 && selector(md))
             {
                 Instruction instr = md.Body.Instructions[0];
 

--- a/Assets/Mirror/Editor/Weaver/Processors/PropertySiteProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/PropertySiteProcessor.cs
@@ -13,11 +13,6 @@ namespace Mirror.Weaver
             // replace all field access with property access for syncvars
             CodePass.ForEachInstruction(moduleDef, WeavedMethods, ProcessInstruction);
 
-            if (Weaver.WeaveLists.generateContainerClass != null)
-            {
-                moduleDef.Types.Add(Weaver.WeaveLists.generateContainerClass);
-            }
-
             Console.WriteLine("  ProcessSitesModule " + moduleDef.Name + " elapsed time:" + (DateTime.Now - startTime));
         }
 

--- a/Assets/Mirror/Editor/Weaver/Readers.cs
+++ b/Assets/Mirror/Editor/Weaver/Readers.cs
@@ -10,6 +10,8 @@ namespace Mirror.Weaver
     {
         static Dictionary<string, MethodReference> readFuncs;
 
+        public static int Count => readFuncs.Count;
+
         public static void Init()
         {
             readFuncs = new Dictionary<string, MethodReference>();
@@ -109,8 +111,7 @@ namespace Mirror.Weaver
         {
             readFuncs[typeReference.FullName] = newReaderFunc;
 
-            Weaver.WeaveLists.ConfirmGeneratedCodeClass();
-            Weaver.WeaveLists.generateContainerClass.Methods.Add(newReaderFunc);
+            Weaver.WeaveLists.GeneratedCode().Methods.Add(newReaderFunc);
         }
 
         static MethodDefinition GenerateEnumReadFunc(TypeReference variable)

--- a/Assets/Mirror/Editor/Weaver/Weaver.cs
+++ b/Assets/Mirror/Editor/Weaver/Weaver.cs
@@ -14,7 +14,7 @@ namespace Mirror.Weaver
         // getter functions that replace [SyncVar] member variable references. dict<field, replacement>
         public Dictionary<FieldDefinition, MethodDefinition> replacementGetterProperties = new Dictionary<FieldDefinition, MethodDefinition>();
 
-        public TypeDefinition generateContainerClass;
+        private TypeDefinition generateContainerClass ;
 
         // amount of SyncVars per class. dict<className, amount>
         public Dictionary<string, int> numSyncVars = new Dictionary<string, int>();
@@ -31,14 +31,16 @@ namespace Mirror.Weaver
             numSyncVars[className] = num;
         }
 
-        public void ConfirmGeneratedCodeClass()
+        public TypeDefinition GeneratedCode()
         {
             if (generateContainerClass == null)
             {
                 generateContainerClass = new TypeDefinition("Mirror", "GeneratedNetworkCode",
                         TypeAttributes.BeforeFieldInit | TypeAttributes.Class | TypeAttributes.AnsiClass | TypeAttributes.Public | TypeAttributes.AutoClass | TypeAttributes.Abstract | TypeAttributes.Sealed,
                         WeaverTypes.Import<object>());
+                Weaver.CurrentAssembly.MainModule.Types.Add(generateContainerClass);
             }
+            return generateContainerClass;
         }
     }
 
@@ -166,14 +168,14 @@ namespace Mirror.Weaver
 
                 WeaverTypes.SetupTargetTypes(CurrentAssembly);
                 var rwstopwatch = System.Diagnostics.Stopwatch.StartNew();
-                ReaderWriterProcessor.Process(CurrentAssembly, unityAssembly);
+                bool modified = ReaderWriterProcessor.Process(CurrentAssembly, unityAssembly);
                 rwstopwatch.Stop();
                 Console.WriteLine($"Find all reader and writers took {rwstopwatch.ElapsedMilliseconds} milliseconds");
 
                 ModuleDefinition moduleDefinition = CurrentAssembly.MainModule;
                 Console.WriteLine($"Script Module: {moduleDefinition.Name}");
 
-                bool modified = WeaveModule(moduleDefinition);
+                modified |= WeaveModule(moduleDefinition);
 
                 if (WeavingFailed)
                 {

--- a/Assets/Mirror/Editor/Weaver/Writers.cs
+++ b/Assets/Mirror/Editor/Weaver/Writers.cs
@@ -10,6 +10,8 @@ namespace Mirror.Weaver
     {
         static Dictionary<string, MethodReference> writeFuncs;
 
+        public static int Count => writeFuncs.Count;
+
         public static void Init()
         {
             writeFuncs = new Dictionary<string, MethodReference>();
@@ -24,8 +26,7 @@ namespace Mirror.Weaver
         {
             writeFuncs[typeReference.FullName] = newWriterFunc;
 
-            Weaver.WeaveLists.ConfirmGeneratedCodeClass();
-            Weaver.WeaveLists.generateContainerClass.Methods.Add(newWriterFunc);
+            Weaver.WeaveLists.GeneratedCode().Methods.Add(newWriterFunc);
         }
 
         /// <summary>

--- a/Assets/Tests/Runtime/BasicAuthenticatorTest.cs
+++ b/Assets/Tests/Runtime/BasicAuthenticatorTest.cs
@@ -1,0 +1,29 @@
+﻿using Mirror.Authenticators;
+using NUnit.Framework;
+
+namespace Mirror.Tests
+{
+    public class BasicAuthenticatorTest : ClientServerSetup<MockComponent>
+    {
+
+        BasicAuthenticator authenticator;
+
+        [Test]
+        public void CheckConnected()
+        {
+            // Should have connected
+            Assert.That(connectionToServer, Is.Not.Null);
+            Assert.That(connectionToClient, Is.Not.Null);
+        }
+
+        public override void ExtraSetup()
+        {
+            authenticator = server.gameObject.AddComponent<BasicAuthenticator>();
+
+            server.authenticator = authenticator;
+            client.authenticator = authenticator;
+
+            base.ExtraSetup();
+        }
+    }
+}

--- a/Assets/Tests/Runtime/BasicAuthenticatorTest.cs.meta
+++ b/Assets/Tests/Runtime/BasicAuthenticatorTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 189fb30f76e664f4cb7fb17d97609b1e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Basic authenticator was failing because the weaver did not save the generated reader/writer.

fixes #441 