### PR TITLE
fix: client NRE for objects spawned in .Started in hostmode

### DIFF
--- a/Assets/Mirror/Runtime/ClientObjectManager.cs
+++ b/Assets/Mirror/Runtime/ClientObjectManager.cs
@@ -542,6 +542,7 @@ namespace Mirror
                 if (msg.isLocalPlayer)
                     InternalAddPlayer(localObject);
 
+                localObject.Client = client;
                 localObject.HasAuthority = msg.isOwner;
                 localObject.NotifyAuthority();
                 localObject.StartClient();


### PR DESCRIPTION
This should fix `NetIdentity.Client` being null on networked objects spawned in the `Server.Started` callback in host mode.