### PR TITLE
fix: add missing UniTask.asmdef reference to Mirror.Weaver.asmdef

### DIFF
--- a/Assets/Mirror/Editor/Weaver/Mirror.Weaver.asmdef
+++ b/Assets/Mirror/Editor/Weaver/Mirror.Weaver.asmdef
@@ -1,9 +1,9 @@
 {
     "name": "Mirror.Weaver",
     "references": [
-        "Mirror"
+        "Mirror",
+        "UniTask"
     ],
-    "optionalUnityReferences": [],
     "includePlatforms": [
         "Editor"
     ],


### PR DESCRIPTION
IDE complains about missing assembly reference in ReaderWriterProcessor.GenerateReadersWriters() because three nameof expressions reference async methods that return UniTask.

Unity Editor doesn't seem to care, but added the UniTask asmdef reference to silence the IDE errors.