### PR TITLE
fix: better transport checks on NS and NC

### DIFF
--- a/Assets/Mirror/Runtime/NetworkClient.cs
+++ b/Assets/Mirror/Runtime/NetworkClient.cs
@@ -127,6 +127,8 @@ namespace Mirror
 
             if (Transport == null)
                 Transport = GetComponent<Transport>();
+            if (Transport == null)
+                throw new InvalidOperationException("Trasnport could not be found for NetworkClient");
 
             connectState = ConnectState.Connecting;
 

--- a/Assets/Mirror/Runtime/NetworkClient.cs
+++ b/Assets/Mirror/Runtime/NetworkClient.cs
@@ -125,15 +125,14 @@ namespace Mirror
         {
             if (logger.LogEnabled()) logger.Log("Client Connect: " + uri);
 
-            Transport transport = Transport;
-            if (transport == null)
-                transport = GetComponent<Transport>();
+            if (Transport == null)
+                Transport = GetComponent<Transport>();
 
             connectState = ConnectState.Connecting;
 
             try
             {
-                IConnection transportConnection = await transport.ConnectAsync(uri);
+                IConnection transportConnection = await Transport.ConnectAsync(uri);
 
                 InitializeAuthEvents();
 

--- a/Assets/Mirror/Runtime/NetworkClient.cs
+++ b/Assets/Mirror/Runtime/NetworkClient.cs
@@ -128,7 +128,7 @@ namespace Mirror
             if (Transport == null)
                 Transport = GetComponent<Transport>();
             if (Transport == null)
-                throw new InvalidOperationException("Trasnport could not be found for NetworkClient");
+                throw new InvalidOperationException("Transport could not be found for NetworkClient");
 
             connectState = ConnectState.Connecting;
 

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -153,7 +153,7 @@ namespace Mirror
             if (transport is null)
                 transport = GetComponent<Transport>();
             if (transport == null)
-                throw new InvalidOperationException("Trasnport could not be found for NetworkServer");
+                throw new InvalidOperationException("Transport could not be found for NetworkServer");
 
             if (authenticator != null)
             {

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -152,6 +152,8 @@ namespace Mirror
 
             if (transport is null)
                 transport = GetComponent<Transport>();
+            if (transport == null)
+                throw new InvalidOperationException("Trasnport could not be found for NetworkServer");
 
             if (authenticator != null)
             {


### PR DESCRIPTION
On NC it was not actually setting the value of the comp found via GetComponent. That would cause the following try to throw an NRE when you tried to connect. Now it throws for the same reason but gives a specific line and reason in the debug message. Much easier to debug. The same logic was applied to the server side.