### PR TITLE
Add empty skeleton method instead of null

### DIFF
--- a/Assets/Mirror/Editor/Weaver/Processors/RpcProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/RpcProcessor.cs
@@ -43,6 +43,9 @@ namespace Mirror.Weaver
                 MethodAttributes.Family | MethodAttributes.Static | MethodAttributes.HideBySig,
                 WeaverTypes.Import(typeof(void)));
 
+            NetworkBehaviourProcessor.AddInvokeParameters(rpc.Parameters);
+            md.DeclaringType.Methods.Add(rpc);
+
             ILProcessor worker = rpc.Body.GetILProcessor();
 
             // setup for reader
@@ -61,14 +64,12 @@ namespace Mirror.Weaver
             }
             
             if (!NetworkBehaviourProcessor.ReadArguments(md, worker, hasNetworkConnection))
-                return null;
+                return rpc;
 
             // invoke actual ServerRpc function
             worker.Append(worker.Create(OpCodes.Callvirt, userCodeFunc));
             worker.Append(worker.Create(OpCodes.Ret));
 
-            NetworkBehaviourProcessor.AddInvokeParameters(rpc.Parameters);
-            md.DeclaringType.Methods.Add(rpc);
             return rpc;
         }
 

--- a/Assets/Mirror/Editor/Weaver/Processors/ServerRpcProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/ServerRpcProcessor.cs
@@ -102,6 +102,9 @@ namespace Mirror.Weaver
                 MethodAttributes.Family | MethodAttributes.Static | MethodAttributes.HideBySig,
                 WeaverTypes.Import(typeof(void)));
 
+            NetworkBehaviourProcessor.AddInvokeParameters(cmd.Parameters);
+            method.DeclaringType.Methods.Add(cmd);
+
             ILProcessor worker = cmd.Body.GetILProcessor();
 
             // setup for reader
@@ -109,7 +112,7 @@ namespace Mirror.Weaver
             worker.Append(worker.Create(OpCodes.Castclass, method.DeclaringType));
 
             if (!NetworkBehaviourProcessor.ReadArguments(method, worker, false))
-                return null;
+                return cmd;
 
             AddSenderConnection(method, worker);
 
@@ -117,9 +120,6 @@ namespace Mirror.Weaver
             worker.Append(worker.Create(OpCodes.Callvirt, userCodeFunc));
             worker.Append(worker.Create(OpCodes.Ret));
 
-            NetworkBehaviourProcessor.AddInvokeParameters(cmd.Parameters);
-
-            method.DeclaringType.Methods.Add(cmd);
             return cmd;
         }
 


### PR DESCRIPTION
Makes it safer because we don't end up with null methods in
unexpected places.