### PR TITLE
fix: DoS vector in kcp accept

### DIFF
--- a/Assets/Mirror/Runtime/Transport/Kcp/KcpTransport.cs
+++ b/Assets/Mirror/Runtime/Transport/Kcp/KcpTransport.cs
@@ -76,10 +76,11 @@ namespace Mirror.KCP
                 // that way if the client does not cooperate
                 // we can continue with other clients
                 ServerHandshake(endpoint, data, msgLength).Forget();
-                return;
             }
-
-            connection.RawInput(data, msgLength);
+            else
+            {
+                connection.RawInput(data, msgLength);
+            }
         }
 
         private async UniTaskVoid ServerHandshake(EndPoint endpoint, byte[] data, int msgLength)

--- a/Assets/Mirror/Runtime/Transport/Kcp/KcpTransport.cs
+++ b/Assets/Mirror/Runtime/Transport/Kcp/KcpTransport.cs
@@ -72,17 +72,32 @@ namespace Mirror.KCP
                 if (channel != Channel.Reliable)
                     return;
 
-                // add it to a queue
-                connection = new KcpServerConnection(socket, endpoint, delayMode);
-                acceptedConnections.Writer.TryWrite(connection);
-                connectedClients.Add(endpoint as IPEndPoint, connection);
-                connection.Disconnected += () =>
-                {
-                    connectedClients.Remove(endpoint as IPEndPoint);
-                };
+                // fire a separate task for handshake
+                // that way if the client does not cooperate
+                // we can continue with other clients
+                ServerHandshake(endpoint, data, msgLength).Forget();
+                return;
             }
 
             connection.RawInput(data, msgLength);
+        }
+
+        private async UniTaskVoid ServerHandshake(EndPoint endpoint, byte[] data, int msgLength)
+        {
+            var connection = new KcpServerConnection(socket, endpoint, delayMode);
+            connectedClients.Add(endpoint as IPEndPoint, connection);
+
+            connection.Disconnected += () =>
+            {
+                connectedClients.Remove(endpoint as IPEndPoint);
+            };
+
+            connection.RawInput(data, msgLength);
+
+            await connection.HandshakeAsync();
+
+            // once handshake is completed,  then the connection has been accepted
+            acceptedConnections.Writer.TryWrite(connection);
         }
 
         private readonly HashSet<HashCash> used = new HashSet<HashCash>();
@@ -153,11 +168,7 @@ namespace Mirror.KCP
 
             try
             {
-                KcpServerConnection connection = await acceptedConnections.Reader.ReadAsync();
-
-                await connection.HandshakeAsync();
-
-                return connection;
+                return await acceptedConnections.Reader.ReadAsync();
             }
             catch (ChannelClosedException)
             {


### PR DESCRIPTION
Previously,  if a client sends a valid hello and nothing else,
the server waits to complete the handshake before accepting other connections.
This opens a very easy to exploit DoS vector, because a single client can prevent the server from accepting other connections.

Now,  the server fires a separate task for completing the handshake for each client. It does not consider the connection accepted until the handshake is completed.
This way, if a client does not cooperate with the handshake, other clients can still be accepted