### PR TITLE
ClientObjectManager now requires NetworkIdentity

### DIFF
--- a/Assets/Mirror/Editor/ClientObjectManagerInspector.cs
+++ b/Assets/Mirror/Editor/ClientObjectManagerInspector.cs
@@ -22,9 +22,9 @@ namespace Mirror
 
         public void RegisterPrefabs(ClientObjectManager gameObject)
         {
-            ISet<GameObject> prefabs = LoadPrefabsContaining<NetworkIdentity>("Assets");
+            ISet<NetworkIdentity> prefabs = LoadPrefabsContaining<NetworkIdentity>("Assets");
 
-            foreach (var existing in gameObject.spawnPrefabs)
+            foreach (NetworkIdentity existing in gameObject.spawnPrefabs)
             {
                 prefabs.Add(existing);
             }
@@ -32,9 +32,9 @@ namespace Mirror
             gameObject.spawnPrefabs.AddRange(prefabs);
         }
 
-        private static ISet<GameObject> LoadPrefabsContaining<T>(string path) where T : UnityEngine.Component
+        private static ISet<T> LoadPrefabsContaining<T>(string path) where T : UnityEngine.Component
         {
-            var result = new HashSet<GameObject>();
+            var result = new HashSet<T>();
 
             var guids = AssetDatabase.FindAssets("t:Object", new[] { path });
 
@@ -45,7 +45,7 @@ namespace Mirror
                 T obj = AssetDatabase.LoadAssetAtPath<T>(assetPath);
 
                 if (obj != null)
-                    result.Add(obj.gameObject);
+                    result.Add(obj);
             }
             return result;
         }

--- a/Assets/Mirror/Runtime/ClientObjectManager.cs
+++ b/Assets/Mirror/Runtime/ClientObjectManager.cs
@@ -32,7 +32,7 @@ namespace Mirror
         /// List of prefabs that will be registered with the spawning system.
         /// <para>For each of these prefabs, ClientManager.RegisterPrefab() will be automatically invoke.</para>
         /// </summary>
-        public List<GameObject> spawnPrefabs = new List<GameObject>();
+        public List<NetworkIdentity> spawnPrefabs = new List<NetworkIdentity>();
 
         /// <summary>
         /// This is dictionary of the disabled NetworkIdentity objects in the scene that could be spawned by messages from the server.
@@ -143,7 +143,7 @@ namespace Mirror
         {
             for (int i = 0; i < spawnPrefabs.Count; i++)
             {
-                GameObject prefab = spawnPrefabs[i];
+                NetworkIdentity prefab = spawnPrefabs[i];
                 if (prefab != null)
                 {
                     RegisterPrefab(prefab);
@@ -178,20 +178,12 @@ namespace Mirror
         /// </summary>
         /// <param name="prefab">A Prefab that will be spawned.</param>
         /// <param name="newAssetId">An assetId to be assigned to this prefab. This allows a dynamically created game object to be registered for an already known asset Id.</param>
-        public void RegisterPrefab(GameObject prefab, Guid newAssetId)
+        public void RegisterPrefab(NetworkIdentity identity, Guid newAssetId)
         {
-            NetworkIdentity identity = prefab.GetComponent<NetworkIdentity>();
-            if (identity)
-            {
                 identity.AssetId = newAssetId;
 
-                if (logger.LogEnabled()) logger.Log("Registering prefab '" + prefab.name + "' as asset:" + identity.AssetId);
-                prefabs[identity.AssetId] = prefab;
-            }
-            else
-            {
-                throw new InvalidOperationException("Could not register '" + prefab.name + "' since it contains no NetworkIdentity component");
-            }
+                if (logger.LogEnabled()) logger.Log("Registering prefab '" + identity.name + "' as asset:" + identity.AssetId);
+                prefabs[identity.AssetId] = identity.gameObject;
         }
 
         /// <summary>
@@ -201,25 +193,10 @@ namespace Mirror
         /// <para>The set of current spawnable object is available in the ClientScene static member variable ClientScene.prefabs, which is a dictionary of NetworkAssetIds and prefab references.</para>
         /// </summary>
         /// <param name="prefab">A Prefab that will be spawned.</param>
-        public void RegisterPrefab(GameObject prefab)
+        public void RegisterPrefab(NetworkIdentity identity)
         {
-            NetworkIdentity identity = prefab.GetComponent<NetworkIdentity>();
-            if (identity)
-            {
-                if (logger.LogEnabled()) logger.Log("Registering prefab '" + prefab.name + "' as asset:" + identity.AssetId);
-                prefabs[identity.AssetId] = prefab;
-
-                NetworkIdentity[] identities = prefab.GetComponentsInChildren<NetworkIdentity>();
-                if (identities.Length > 1)
-                {
-                    logger.LogWarning("The prefab '" + prefab.name +
-                                     "' has multiple NetworkIdentity components. There can only be one NetworkIdentity on a prefab, and it must be on the root object.");
-                }
-            }
-            else
-            {
-                throw new InvalidOperationException("Could not register '" + prefab.name + "' since it contains no NetworkIdentity component");
-            }
+            if (logger.LogEnabled()) logger.Log("Registering prefab '" + identity.name + "' as asset:" + identity.AssetId);
+            prefabs[identity.AssetId] = identity.gameObject;
         }
 
         /// <summary>

--- a/Assets/Mirror/Runtime/INetworkClient.cs
+++ b/Assets/Mirror/Runtime/INetworkClient.cs
@@ -4,19 +4,27 @@ using UnityEngine;
 
 namespace Mirror
 {
+    // Handles requests to spawn objects on the client
+    public delegate NetworkIdentity SpawnDelegate(Vector3 position, Guid assetId);
+
+    public delegate NetworkIdentity SpawnHandlerDelegate(SpawnMessage msg);
+
+    // Handles requests to unspawn objects on the client
+    public delegate void UnSpawnDelegate(NetworkIdentity spawned);
+
     public interface IClientObjectManager
     {
         GameObject GetPrefab(Guid assetId);
 
-        void RegisterPrefab(GameObject prefab);
+        void RegisterPrefab(NetworkIdentity prefab);
 
-        void RegisterPrefab(GameObject prefab, Guid newAssetId);
+        void RegisterPrefab(NetworkIdentity prefab, Guid newAssetId);
 
-        void RegisterPrefab(GameObject prefab, SpawnDelegate spawnHandler, UnSpawnDelegate unspawnHandler);
+        void RegisterPrefab(NetworkIdentity prefab, SpawnDelegate spawnHandler, UnSpawnDelegate unspawnHandler);
 
-        void RegisterPrefab(GameObject prefab, SpawnHandlerDelegate spawnHandler, UnSpawnDelegate unspawnHandler);
+        void RegisterPrefab(NetworkIdentity prefab, SpawnHandlerDelegate spawnHandler, UnSpawnDelegate unspawnHandler);
 
-        void UnregisterPrefab(GameObject prefab);
+        void UnregisterPrefab(NetworkIdentity prefab);
 
         void RegisterSpawnHandler(Guid assetId, SpawnDelegate spawnHandler, UnSpawnDelegate unspawnHandler);
 

--- a/Assets/Mirror/Runtime/PlayerSpawner.cs
+++ b/Assets/Mirror/Runtime/PlayerSpawner.cs
@@ -31,7 +31,7 @@ namespace Mirror
                 sceneManager.ClientSceneChanged.AddListener(OnClientSceneChanged);
                 if(clientObjectManager != null)
                 {
-                    clientObjectManager.RegisterPrefab(playerPrefab.gameObject);
+                    clientObjectManager.RegisterPrefab(playerPrefab);
                 }
                 else
                 {

--- a/Assets/Mirror/Runtime/UNetwork.cs
+++ b/Assets/Mirror/Runtime/UNetwork.cs
@@ -1,6 +1,4 @@
-using System;
 using System.Runtime.InteropServices;
-using UnityEngine;
 
 namespace Mirror
 {

--- a/Assets/Mirror/Runtime/UNetwork.cs
+++ b/Assets/Mirror/Runtime/UNetwork.cs
@@ -4,14 +4,6 @@ using UnityEngine;
 
 namespace Mirror
 {
-    // Handles requests to spawn objects on the client
-    public delegate GameObject SpawnDelegate(Vector3 position, Guid assetId);
-
-    public delegate GameObject SpawnHandlerDelegate(SpawnMessage msg);
-
-    // Handles requests to unspawn objects on the client
-    public delegate void UnSpawnDelegate(GameObject spawned);
-
     // invoke type for Rpc
     public enum MirrorInvokeType
     {

--- a/Assets/Mirror/Samples~/AdditiveScenes/Scenes/MainScene.unity
+++ b/Assets/Mirror/Samples~/AdditiveScenes/Scenes/MainScene.unity
@@ -380,6 +380,7 @@ MonoBehaviour:
   sceneId: 1834901131
   serverOnly: 1
   ServerObjectManager: {fileID: 0}
+  ClientObjectManager: {fileID: 0}
   m_AssetId: 
   OnStartServer:
     m_PersistentCalls:
@@ -1926,12 +1927,12 @@ MonoBehaviour:
   client: {fileID: 1661834282}
   networkSceneManager: {fileID: 1661834284}
   spawnPrefabs:
-  - {fileID: 1076878374699499732, guid: e1971f4a8c7661546bc509b44bd91b80, type: 3}
-  - {fileID: 5623359707189648430, guid: 4ff300cf6bb3c6342a9552c4f18788c8, type: 3}
-  - {fileID: 6852530814182375312, guid: 12a4c14e672c00b4b840f937d824b890, type: 3}
-  - {fileID: 8872462076811691049, guid: a5bdca0a2315d43499be7dcef473fbc7, type: 3}
-  - {fileID: 855244094988030905, guid: f6d08eb9a8e35d84fa30a7e3ae64181a, type: 3}
-  - {fileID: 160176457, guid: ab222ed73ada1ac4ba2f61e843d7627c, type: 3}
+  - {fileID: 2648107611936813301, guid: e1971f4a8c7661546bc509b44bd91b80, type: 3}
+  - {fileID: 5623359707189648404, guid: 4ff300cf6bb3c6342a9552c4f18788c8, type: 3}
+  - {fileID: 6852530814182375318, guid: 12a4c14e672c00b4b840f937d824b890, type: 3}
+  - {fileID: 8537344390966522168, guid: a5bdca0a2315d43499be7dcef473fbc7, type: 3}
+  - {fileID: 855244094988030911, guid: f6d08eb9a8e35d84fa30a7e3ae64181a, type: 3}
+  - {fileID: 160176459, guid: ab222ed73ada1ac4ba2f61e843d7627c, type: 3}
 --- !u!114 &1661834282
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2060,27 +2061,37 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   Levels:
+  - Name: PlayerSpawner
+    level: 2
+  - Name: NetworkSceneManager
+    level: 2
   - Name: NetworkIdentity
     level: 2
-  - Name: ServerObjectManager
+  - Name: NetworkBehaviour
+    level: 2
+  - Name: ClientObjectManager
     level: 2
   - Name: NetworkServer
     level: 2
   - Name: NetworkTime
     level: 2
+  - Name: ServerObjectManager
+    level: 2
   - Name: NetworkClient
-    level: 2
-  - Name: NetworkSceneManager
-    level: 2
-  - Name: PlayerSpawner
-    level: 2
-  - Name: ClientObjectManager
     level: 2
   - Name: EnterPlayModeSettingsCheck
     level: 2
-  - Name: ZoneHandler
+  - Name: NetworkScenePostProcess
     level: 2
-  - Name: NetworkBehaviour
+  - Name: NetworkConnection
+    level: 2
+  - Name: NetworkWriterPool
+    level: 2
+  - Name: NetworkReaderExtensions
+    level: 2
+  - Name: NetworkReaderPool
+    level: 2
+  - Name: ZoneHandler
     level: 2
   - Name: AdditiveNetworkManager
     level: 2

--- a/Assets/Mirror/Samples~/Basic/Scenes/Example.unity
+++ b/Assets/Mirror/Samples~/Basic/Scenes/Example.unity
@@ -316,7 +316,7 @@ MonoBehaviour:
   client: {fileID: 249891958}
   networkSceneManager: {fileID: 249891960}
   spawnPrefabs:
-  - {fileID: 1088833923132447022, guid: 22f1fa3a0aff72b46a371f667bb4fb30, type: 3}
+  - {fileID: 1088833923132447018, guid: 22f1fa3a0aff72b46a371f667bb4fb30, type: 3}
 --- !u!114 &249891962
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -344,37 +344,35 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   Levels:
+  - Name: PlayerSpawner
+    level: 2
+  - Name: NetworkSceneManager
+    level: 2
   - Name: NetworkIdentity
     level: 2
-  - Name: ServerObjectManager
+  - Name: NetworkBehaviour
+    level: 2
+  - Name: ClientObjectManager
     level: 2
   - Name: NetworkServer
     level: 2
   - Name: NetworkTime
     level: 2
+  - Name: ServerObjectManager
+    level: 2
   - Name: NetworkClient
-    level: 2
-  - Name: NetworkSceneManager
-    level: 2
-  - Name: PlayerSpawner
-    level: 2
-  - Name: ClientObjectManager
     level: 2
   - Name: EnterPlayModeSettingsCheck
     level: 2
-  - Name: ZoneHandler
+  - Name: NetworkScenePostProcess
     level: 2
-  - Name: NetworkBehaviour
+  - Name: NetworkConnection
     level: 2
-  - Name: AdditiveNetworkManager
+  - Name: NetworkWriterPool
     level: 2
-  - Name: NetworkProximityChecker
+  - Name: NetworkReaderExtensions
     level: 2
-  - Name: RemoteCallHelper
-    level: 2
-  - Name: NetworkAnimator
-    level: 2
-  - Name: SceneDrawer
+  - Name: NetworkReaderPool
     level: 2
 --- !u!1 &288173824
 GameObject:

--- a/Assets/Mirror/Samples~/ChangeScene/Scenes/Main.unity
+++ b/Assets/Mirror/Samples~/ChangeScene/Scenes/Main.unity
@@ -410,10 +410,10 @@ MonoBehaviour:
   client: {fileID: 450078216}
   networkSceneManager: {fileID: 450078212}
   spawnPrefabs:
-  - {fileID: 6450763840449902378, guid: 4a9f40d34c71ba745b664150c6a4b8b2, type: 3}
-  - {fileID: 486738946543244675, guid: 234985fef22d66a4ca2dba0e688f1743, type: 3}
-  - {fileID: 1818873914431344372, guid: 685b07ee95b6b6b4db30b2440e670157, type: 3}
-  - {fileID: 6727010246441667690, guid: a6be402bdabdcda42927e4593587fefb, type: 3}
+  - {fileID: 6450763840449902381, guid: 4a9f40d34c71ba745b664150c6a4b8b2, type: 3}
+  - {fileID: 3878225662718291898, guid: 234985fef22d66a4ca2dba0e688f1743, type: 3}
+  - {fileID: 1818873914431344371, guid: 685b07ee95b6b6b4db30b2440e670157, type: 3}
+  - {fileID: 6727010246441667693, guid: a6be402bdabdcda42927e4593587fefb, type: 3}
 --- !u!114 &450078221
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -429,25 +429,35 @@ MonoBehaviour:
   Levels:
   - Name: NetworkIdentity
     level: 2
+  - Name: NetworkBehaviour
+    level: 2
   - Name: ServerObjectManager
+    level: 2
+  - Name: ClientObjectManager
     level: 2
   - Name: NetworkServer
     level: 2
   - Name: NetworkTime
     level: 2
-  - Name: NetworkClient
-    level: 2
   - Name: NetworkSceneManager
     level: 2
   - Name: PlayerSpawner
     level: 2
-  - Name: ClientObjectManager
+  - Name: NetworkClient
     level: 2
   - Name: EnterPlayModeSettingsCheck
     level: 2
-  - Name: ZoneHandler
+  - Name: NetworkScenePostProcess
     level: 2
-  - Name: NetworkBehaviour
+  - Name: NetworkConnection
+    level: 2
+  - Name: NetworkWriterPool
+    level: 2
+  - Name: NetworkReaderExtensions
+    level: 2
+  - Name: NetworkReaderPool
+    level: 2
+  - Name: ZoneHandler
     level: 2
   - Name: AdditiveNetworkManager
     level: 2

--- a/Assets/Mirror/Samples~/Chat/Scenes/Main.unity
+++ b/Assets/Mirror/Samples~/Chat/Scenes/Main.unity
@@ -330,6 +330,7 @@ MonoBehaviour:
   sceneId: 1581524575
   serverOnly: 0
   ServerObjectManager: {fileID: 0}
+  ClientObjectManager: {fileID: 0}
   m_AssetId: 
   OnStartServer:
     m_PersistentCalls:
@@ -3134,7 +3135,7 @@ MonoBehaviour:
   client: {fileID: 1783103027}
   networkSceneManager: {fileID: 1783103023}
   spawnPrefabs:
-  - {fileID: 5075528875289742095, guid: e5905ffa27de84009b346b49d518ba03, type: 3}
+  - {fileID: 114398755512196590, guid: e5905ffa27de84009b346b49d518ba03, type: 3}
 --- !u!114 &1783103030
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -3164,25 +3165,35 @@ MonoBehaviour:
   Levels:
   - Name: NetworkIdentity
     level: 2
+  - Name: NetworkBehaviour
+    level: 2
   - Name: ServerObjectManager
+    level: 2
+  - Name: ClientObjectManager
     level: 2
   - Name: NetworkServer
     level: 2
   - Name: NetworkTime
     level: 2
-  - Name: NetworkClient
-    level: 2
   - Name: NetworkSceneManager
     level: 2
   - Name: PlayerSpawner
     level: 2
-  - Name: ClientObjectManager
+  - Name: NetworkClient
     level: 2
   - Name: EnterPlayModeSettingsCheck
     level: 2
-  - Name: ZoneHandler
+  - Name: NetworkScenePostProcess
     level: 2
-  - Name: NetworkBehaviour
+  - Name: NetworkConnection
+    level: 2
+  - Name: NetworkWriterPool
+    level: 2
+  - Name: NetworkReaderExtensions
+    level: 2
+  - Name: NetworkReaderPool
+    level: 2
+  - Name: ZoneHandler
     level: 2
   - Name: AdditiveNetworkManager
     level: 2

--- a/Assets/Mirror/Samples~/Discovery/Scenes/Scene.unity
+++ b/Assets/Mirror/Samples~/Discovery/Scenes/Scene.unity
@@ -389,12 +389,13 @@ GameObject:
   - component: {fileID: 1556883247}
   - component: {fileID: 1556883245}
   - component: {fileID: 1556883248}
-  - component: {fileID: 1556883246}
   - component: {fileID: 1556883250}
   - component: {fileID: 1556883249}
   - component: {fileID: 1556883244}
   - component: {fileID: 1556883251}
   - component: {fileID: 1556883252}
+  - component: {fileID: 1556883253}
+  - component: {fileID: 1556883246}
   m_Layer: 0
   m_Name: NetworkManager
   m_TagString: Untagged
@@ -416,7 +417,9 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   client: {fileID: 1556883249}
   server: {fileID: 1556883250}
-  sceneManager: {fileID: 0}
+  sceneManager: {fileID: 1556883251}
+  clientObjectManager: {fileID: 1556883253}
+  serverObjectManager: {fileID: 1556883246}
   playerPrefab: {fileID: 1410032569926419539, guid: ecd52c53a6ef7496693343d3e32dace1, type: 3}
   startPositionIndex: 0
   startPositions: []
@@ -435,6 +438,9 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   server: {fileID: 1556883250}
   client: {fileID: 1556883249}
+  sceneManager: {fileID: 0}
+  serverObjectManager: {fileID: 0}
+  clientObjectManager: {fileID: 0}
 --- !u!114 &1556883246
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -444,11 +450,11 @@ MonoBehaviour:
   m_GameObject: {fileID: 1556883243}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 88c37d3deca7a834d80cfd8d3cfcc510, type: 3}
+  m_Script: {fileID: 11500000, guid: b750203ddb2d9f84abd799a5c2c32cb6, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  networkDiscovery: {fileID: 1556883248}
-  networkManager: {fileID: 1556883245}
+  server: {fileID: 1556883250}
+  networkSceneManager: {fileID: 1556883251}
 --- !u!4 &1556883247
 Transform:
   m_ObjectHideFlags: 0
@@ -482,7 +488,7 @@ MonoBehaviour:
   OnServerFound:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 1556883246}
+      - m_Target: {fileID: 0}
         m_TargetAssemblyTypeName: 
         m_MethodName: OnDiscoveredServer
         m_Mode: 0
@@ -516,10 +522,6 @@ MonoBehaviour:
   Disconnected:
     m_PersistentCalls:
       m_Calls: []
-  spawnPrefabs:
-  - {fileID: 9081919128954505657, guid: ecd52c53a6ef7496693343d3e32dace1, type: 3}
-  - {fileID: 9081919128954505657, guid: ecd52c53a6ef7496693343d3e32dace1, type: 3}
-  - {fileID: 9081919128954505657, guid: ecd52c53a6ef7496693343d3e32dace1, type: 3}
   Transport: {fileID: 0}
 --- !u!114 &1556883250
 MonoBehaviour:
@@ -598,6 +600,23 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   Port: 7777
   HashCashBits: 18
+  delayMode: 0
+--- !u!114 &1556883253
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1556883243}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a2cbc85c1c2f1c249bbe95ae110bbcde, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  client: {fileID: 1556883249}
+  networkSceneManager: {fileID: 1556883251}
+  spawnPrefabs:
+  - {fileID: 1410032569926419539, guid: ecd52c53a6ef7496693343d3e32dace1, type: 3}
 --- !u!1 &1611696151
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Mirror/Samples~/MultipleAdditiveScenes/Scenes/Main.unity
+++ b/Assets/Mirror/Samples~/MultipleAdditiveScenes/Scenes/Main.unity
@@ -246,9 +246,9 @@ MonoBehaviour:
   client: {fileID: 69965671}
   networkSceneManager: {fileID: 69965674}
   spawnPrefabs:
-  - {fileID: 5513112217680870098, guid: a104de86221e66a48832c222471d4f1e, type: 3}
-  - {fileID: 1480027675339556, guid: 1f4d376d8ca693049abd1744e4c79fad, type: 3}
-  - {fileID: 1139254171913846, guid: 8cec47ed46e0eff45966a5173d3aa0d3, type: 3}
+  - {fileID: -7012348765844800875, guid: a104de86221e66a48832c222471d4f1e, type: 3}
+  - {fileID: 114402732107420660, guid: 1f4d376d8ca693049abd1744e4c79fad, type: 3}
+  - {fileID: 114251241889735402, guid: 8cec47ed46e0eff45966a5173d3aa0d3, type: 3}
 --- !u!114 &69965668
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -441,25 +441,35 @@ MonoBehaviour:
   Levels:
   - Name: NetworkIdentity
     level: 2
+  - Name: NetworkBehaviour
+    level: 2
   - Name: ServerObjectManager
+    level: 2
+  - Name: ClientObjectManager
     level: 2
   - Name: NetworkServer
     level: 2
   - Name: NetworkTime
     level: 2
-  - Name: NetworkClient
-    level: 2
   - Name: NetworkSceneManager
     level: 2
   - Name: PlayerSpawner
     level: 2
-  - Name: ClientObjectManager
+  - Name: NetworkClient
     level: 2
   - Name: EnterPlayModeSettingsCheck
     level: 2
-  - Name: ZoneHandler
+  - Name: NetworkScenePostProcess
     level: 2
-  - Name: NetworkBehaviour
+  - Name: NetworkConnection
+    level: 2
+  - Name: NetworkWriterPool
+    level: 2
+  - Name: NetworkReaderExtensions
+    level: 2
+  - Name: NetworkReaderPool
+    level: 2
+  - Name: ZoneHandler
     level: 2
   - Name: AdditiveNetworkManager
     level: 2
@@ -472,6 +482,10 @@ MonoBehaviour:
   - Name: SceneDrawer
     level: 2
   - Name: ChatWindow
+    level: 2
+  - Name: NetworkDiscovery
+    level: 2
+  - Name: NetworkDiscoveryBase`2
     level: 2
   - Name: NetworkSceneChecker
     level: 2

--- a/Assets/Mirror/Samples~/Pong/Scenes/Scene.unity
+++ b/Assets/Mirror/Samples~/Pong/Scenes/Scene.unity
@@ -882,8 +882,8 @@ MonoBehaviour:
   client: {fileID: 1886246554}
   networkSceneManager: {fileID: 1886246556}
   spawnPrefabs:
-  - {fileID: 1080679924113744, guid: 5f7a7f34494ed40268eff49dbf9168bf, type: 3}
-  - {fileID: 1240244544407914, guid: b1651eaf8c7564a1c86031dfbb8a7b28, type: 3}
+  - {fileID: 114290021321007948, guid: 5f7a7f34494ed40268eff49dbf9168bf, type: 3}
+  - {fileID: 114104497298166850, guid: b1651eaf8c7564a1c86031dfbb8a7b28, type: 3}
 --- !u!114 &1886246552
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1055,25 +1055,35 @@ MonoBehaviour:
   Levels:
   - Name: NetworkIdentity
     level: 2
+  - Name: NetworkBehaviour
+    level: 2
   - Name: ServerObjectManager
+    level: 2
+  - Name: ClientObjectManager
     level: 2
   - Name: NetworkServer
     level: 2
   - Name: NetworkTime
     level: 2
-  - Name: NetworkClient
-    level: 2
   - Name: NetworkSceneManager
     level: 2
   - Name: PlayerSpawner
     level: 2
-  - Name: ClientObjectManager
+  - Name: NetworkClient
     level: 2
   - Name: EnterPlayModeSettingsCheck
     level: 2
-  - Name: ZoneHandler
+  - Name: NetworkScenePostProcess
     level: 2
-  - Name: NetworkBehaviour
+  - Name: NetworkConnection
+    level: 2
+  - Name: NetworkWriterPool
+    level: 2
+  - Name: NetworkReaderExtensions
+    level: 2
+  - Name: NetworkReaderPool
+    level: 2
+  - Name: ZoneHandler
     level: 2
   - Name: AdditiveNetworkManager
     level: 2
@@ -1086,6 +1096,10 @@ MonoBehaviour:
   - Name: SceneDrawer
     level: 2
   - Name: ChatWindow
+    level: 2
+  - Name: NetworkDiscovery
+    level: 2
+  - Name: NetworkDiscoveryBase`2
     level: 2
   - Name: NetworkSceneChecker
     level: 2

--- a/Assets/Mirror/Samples~/RigidbodyPhysics/Scenes/BounceScene.unity
+++ b/Assets/Mirror/Samples~/RigidbodyPhysics/Scenes/BounceScene.unity
@@ -316,7 +316,7 @@ MonoBehaviour:
   client: {fileID: 492096641}
   networkSceneManager: {fileID: 492096634}
   spawnPrefabs:
-  - {fileID: 844717362685181648, guid: 4ab0a427bdc13244499c6e044ad7eb40, type: 3}
+  - {fileID: 1287874831399521600, guid: 4ab0a427bdc13244499c6e044ad7eb40, type: 3}
 --- !u!114 &492096638
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -442,25 +442,35 @@ MonoBehaviour:
   Levels:
   - Name: NetworkIdentity
     level: 2
+  - Name: NetworkBehaviour
+    level: 2
   - Name: ServerObjectManager
+    level: 2
+  - Name: ClientObjectManager
     level: 2
   - Name: NetworkServer
     level: 2
   - Name: NetworkTime
     level: 2
-  - Name: NetworkClient
-    level: 2
   - Name: NetworkSceneManager
     level: 2
   - Name: PlayerSpawner
     level: 2
-  - Name: ClientObjectManager
+  - Name: NetworkClient
     level: 2
   - Name: EnterPlayModeSettingsCheck
     level: 2
-  - Name: ZoneHandler
+  - Name: NetworkScenePostProcess
     level: 2
-  - Name: NetworkBehaviour
+  - Name: NetworkConnection
+    level: 2
+  - Name: NetworkWriterPool
+    level: 2
+  - Name: NetworkReaderExtensions
+    level: 2
+  - Name: NetworkReaderPool
+    level: 2
+  - Name: ZoneHandler
     level: 2
   - Name: AdditiveNetworkManager
     level: 2
@@ -473,6 +483,10 @@ MonoBehaviour:
   - Name: SceneDrawer
     level: 2
   - Name: ChatWindow
+    level: 2
+  - Name: NetworkDiscovery
+    level: 2
+  - Name: NetworkDiscoveryBase`2
     level: 2
   - Name: NetworkSceneChecker
     level: 2
@@ -627,6 +641,7 @@ MonoBehaviour:
   sceneId: 4215798323
   serverOnly: 0
   ServerObjectManager: {fileID: 0}
+  ClientObjectManager: {fileID: 0}
   m_AssetId: 
   OnStartServer:
     m_PersistentCalls:
@@ -928,6 +943,7 @@ MonoBehaviour:
   sceneId: 707906828
   serverOnly: 0
   ServerObjectManager: {fileID: 0}
+  ClientObjectManager: {fileID: 0}
   m_AssetId: 
   OnStartServer:
     m_PersistentCalls:

--- a/Assets/Mirror/Samples~/Tanks/Scenes/Scene.unity
+++ b/Assets/Mirror/Samples~/Tanks/Scenes/Scene.unity
@@ -1584,8 +1584,8 @@ MonoBehaviour:
   client: {fileID: 1282001525}
   networkSceneManager: {fileID: 1282001526}
   spawnPrefabs:
-  - {fileID: 5890560936853567077, guid: b7dd46dbf38c643f09e206f9fa4be008, type: 3}
-  - {fileID: 1916082411674582, guid: 6f43bf5488a7443d19ab2a83c6b91f35, type: 3}
+  - {fileID: 1713098107664522388, guid: b7dd46dbf38c643f09e206f9fa4be008, type: 3}
+  - {fileID: 114118589361100106, guid: 6f43bf5488a7443d19ab2a83c6b91f35, type: 3}
 --- !u!114 &1282001523
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1701,25 +1701,35 @@ MonoBehaviour:
   Levels:
   - Name: NetworkIdentity
     level: 2
+  - Name: NetworkBehaviour
+    level: 2
   - Name: ServerObjectManager
+    level: 2
+  - Name: ClientObjectManager
     level: 2
   - Name: NetworkServer
     level: 2
   - Name: NetworkTime
     level: 2
-  - Name: NetworkClient
-    level: 2
   - Name: NetworkSceneManager
     level: 2
   - Name: PlayerSpawner
     level: 2
-  - Name: ClientObjectManager
+  - Name: NetworkClient
     level: 2
   - Name: EnterPlayModeSettingsCheck
     level: 2
-  - Name: ZoneHandler
+  - Name: NetworkScenePostProcess
     level: 2
-  - Name: NetworkBehaviour
+  - Name: NetworkConnection
+    level: 2
+  - Name: NetworkWriterPool
+    level: 2
+  - Name: NetworkReaderExtensions
+    level: 2
+  - Name: NetworkReaderPool
+    level: 2
+  - Name: ZoneHandler
     level: 2
   - Name: AdditiveNetworkManager
     level: 2
@@ -1732,6 +1742,10 @@ MonoBehaviour:
   - Name: SceneDrawer
     level: 2
   - Name: ChatWindow
+    level: 2
+  - Name: NetworkDiscovery
+    level: 2
+  - Name: NetworkDiscoveryBase`2
     level: 2
   - Name: NetworkSceneChecker
     level: 2

--- a/Assets/Tests/Editor/ClientObjectManagerInspectorTest.cs
+++ b/Assets/Tests/Editor/ClientObjectManagerInspectorTest.cs
@@ -39,7 +39,7 @@ namespace Mirror.Tests
 
             inspector.RegisterPrefabs(client);
 
-            Assert.That(client.spawnPrefabs, Contains.Item(preexisting));
+            Assert.That(client.spawnPrefabs, Contains.Item(preexisting.GetComponent<NetworkIdentity>()));
 
             GameObject.DestroyImmediate(gameObject);
             GameObject.DestroyImmediate(preexisting);

--- a/Assets/Tests/Editor/ClientObjectManagerInspectorTest.cs
+++ b/Assets/Tests/Editor/ClientObjectManagerInspectorTest.cs
@@ -33,7 +33,7 @@ namespace Mirror.Tests
 
             var gameObject = new GameObject("NetworkObjectManager", typeof(ClientObjectManager));
             ClientObjectManager client = gameObject.GetComponent<ClientObjectManager>();
-            client.spawnPrefabs.Add(preexisting);
+            client.spawnPrefabs.Add(preexisting.GetComponent<NetworkIdentity>());
 
             ClientObjectManagerInspector inspector = ScriptableObject.CreateInstance<ClientObjectManagerInspector>();
 

--- a/Assets/Tests/Performance/Runtime/HeadlessBenchmark/Scripts/HeadlessBenchmark.cs
+++ b/Assets/Tests/Performance/Runtime/HeadlessBenchmark/Scripts/HeadlessBenchmark.cs
@@ -98,8 +98,8 @@ namespace Mirror.HeadlessBenchmark
             objectManager.Start();
             client.Transport = transport;
 
-            objectManager.RegisterPrefab(MonsterPrefab);
-            objectManager.RegisterPrefab(PlayerPrefab);
+            objectManager.RegisterPrefab(MonsterPrefab.GetComponent<NetworkIdentity>());
+            objectManager.RegisterPrefab(PlayerPrefab.GetComponent<NetworkIdentity>());
 
             try
             {

--- a/Assets/Tests/Performance/Runtime/MultipleClients/MultipleClients.cs
+++ b/Assets/Tests/Performance/Runtime/MultipleClients/MultipleClients.cs
@@ -70,7 +70,7 @@ namespace Mirror.Tests.Performance.Runtime
             objectManager.Start();
             client.Transport = transport;
 
-            objectManager.RegisterPrefab(monsterPrefab.gameObject);
+            objectManager.RegisterPrefab(monsterPrefab);
             client.ConnectAsync("localhost");
             while (!client.IsConnected)
                 yield return null;

--- a/Assets/Tests/Runtime/ClientObjectManagerTest.cs
+++ b/Assets/Tests/Runtime/ClientObjectManagerTest.cs
@@ -11,31 +11,7 @@ namespace Mirror.Tests
     [TestFixture]
     public class ClientObjectManagerTest : HostSetup<MockComponent>
     {
-        GameObject playerReplacement;
-
-        [Test]
-        public void RegisterPrefabExceptionTest()
-        {
-            var gameObject = new GameObject();
-            Assert.Throws<InvalidOperationException>(() =>
-            {
-                clientObjectManager.RegisterPrefab(gameObject);
-            });
-            Object.Destroy(gameObject);
-        }
-
-        [Test]
-        public void RegisterPrefabGuidExceptionTest()
-        {
-            var guid = Guid.NewGuid();
-            var gameObject = new GameObject();
-
-            Assert.Throws<InvalidOperationException>(() =>
-            {
-                clientObjectManager.RegisterPrefab(gameObject, guid);
-            });
-            Object.Destroy(gameObject);
-        }
+        GameObject playerReplacement;       
 
         [Test]
         public void OnSpawnAssetSceneIDFailureExceptionTest()
@@ -49,42 +25,23 @@ namespace Mirror.Tests
             Assert.That(ex.Message, Is.EqualTo("OnObjSpawn netId: " + msg.netId + " has invalid asset Id"));
         }
 
-        [Test]
-        public void UnregisterPrefabExceptionTest()
-        {
-            var gameObject = new GameObject();
-            Assert.Throws<InvalidOperationException>(() =>
-            {
-                clientObjectManager.UnregisterPrefab(gameObject);
-            });
-            Object.Destroy(gameObject);
-        }
-
         [UnityTest]
         public IEnumerator GetPrefabTest() => UniTask.ToCoroutine(async () =>
         {
             var guid = Guid.NewGuid();
             var prefabObject = new GameObject("prefab", typeof(NetworkIdentity));
+            var identity = prefabObject.GetComponent<NetworkIdentity>();
 
-            clientObjectManager.RegisterPrefab(prefabObject, guid);
+            clientObjectManager.RegisterPrefab(identity, guid);
 
             await UniTask.Delay(1);
 
-            GameObject result = clientObjectManager.GetPrefab(guid);
+            NetworkIdentity result = clientObjectManager.GetPrefab(guid);
 
-            Assert.That(result, Is.SameAs(prefabObject));
+            Assert.That(result, Is.SameAs(identity));
 
             Object.Destroy(prefabObject);
         });
-
-        [Test]
-        public void RegisterPrefabDelegateNoIdentityExceptionTest()
-        {
-            Assert.Throws<InvalidOperationException>(() =>
-            {
-                clientObjectManager.RegisterPrefab(new GameObject(), TestSpawnDelegate, TestUnspawnDelegate);
-            });
-        }
 
         [Test]
         public void RegisterPrefabDelegateEmptyIdentityExceptionTest()
@@ -95,7 +52,7 @@ namespace Mirror.Tests
 
             Assert.Throws<InvalidOperationException>(() =>
             {
-                clientObjectManager.RegisterPrefab(prefabObject, TestSpawnDelegate, TestUnspawnDelegate);
+                clientObjectManager.RegisterPrefab(identity, TestSpawnDelegate, TestUnspawnDelegate);
             });
 
             Object.Destroy(prefabObject);
@@ -108,7 +65,7 @@ namespace Mirror.Tests
             NetworkIdentity identity = prefabObject.GetComponent<NetworkIdentity>();
             identity.AssetId = Guid.NewGuid();
 
-            clientObjectManager.RegisterPrefab(prefabObject, TestSpawnDelegate, TestUnspawnDelegate);
+            clientObjectManager.RegisterPrefab(identity, TestSpawnDelegate, TestUnspawnDelegate);
 
             Assert.That(clientObjectManager.spawnHandlers.ContainsKey(identity.AssetId));
             Assert.That(clientObjectManager.unspawnHandlers.ContainsKey(identity.AssetId));
@@ -123,12 +80,12 @@ namespace Mirror.Tests
             NetworkIdentity identity = prefabObject.GetComponent<NetworkIdentity>();
             identity.AssetId = Guid.NewGuid();
 
-            clientObjectManager.RegisterPrefab(prefabObject, TestSpawnDelegate, TestUnspawnDelegate);
+            clientObjectManager.RegisterPrefab(identity, TestSpawnDelegate, TestUnspawnDelegate);
 
             Assert.That(clientObjectManager.spawnHandlers.ContainsKey(identity.AssetId));
             Assert.That(clientObjectManager.unspawnHandlers.ContainsKey(identity.AssetId));
 
-            clientObjectManager.UnregisterPrefab(prefabObject);
+            clientObjectManager.UnregisterPrefab(identity);
 
             Assert.That(!clientObjectManager.spawnHandlers.ContainsKey(identity.AssetId));
             Assert.That(!clientObjectManager.unspawnHandlers.ContainsKey(identity.AssetId));
@@ -143,7 +100,7 @@ namespace Mirror.Tests
             NetworkIdentity identity = prefabObject.GetComponent<NetworkIdentity>();
             identity.AssetId = Guid.NewGuid();
 
-            clientObjectManager.RegisterPrefab(prefabObject, TestSpawnDelegate, TestUnspawnDelegate);
+            clientObjectManager.RegisterPrefab(identity, TestSpawnDelegate, TestUnspawnDelegate);
 
             Assert.That(clientObjectManager.spawnHandlers.ContainsKey(identity.AssetId));
             Assert.That(clientObjectManager.unspawnHandlers.ContainsKey(identity.AssetId));
@@ -156,20 +113,20 @@ namespace Mirror.Tests
             Object.Destroy(prefabObject);
         }
 
-        GameObject TestSpawnDelegate(Vector3 position, Guid assetId)
+        NetworkIdentity TestSpawnDelegate(Vector3 position, Guid assetId)
         {
-            return new GameObject();
+            return new GameObject("spawned", typeof(NetworkIdentity)).GetComponent<NetworkIdentity>();
         }
 
-        void TestUnspawnDelegate(GameObject gameObject)
+        void TestUnspawnDelegate(NetworkIdentity identity)
         {
-            Debug.Log("Just testing. Nothing to see here");
+            Object.Destroy(identity.gameObject);
         }
 
         [Test]
         public void GetPrefabEmptyNullTest()
         {
-            GameObject result = clientObjectManager.GetPrefab(Guid.Empty);
+            NetworkIdentity result = clientObjectManager.GetPrefab(Guid.Empty);
 
             Assert.That(result, Is.Null);
         }
@@ -177,7 +134,7 @@ namespace Mirror.Tests
         [Test]
         public void GetPrefabNotFoundNullTest()
         {
-            GameObject result = clientObjectManager.GetPrefab(GenerateUniqueGuid());
+            NetworkIdentity result = clientObjectManager.GetPrefab(GenerateUniqueGuid());
 
             Assert.That(result, Is.Null);
         }
@@ -200,7 +157,7 @@ namespace Mirror.Tests
             playerReplacement = new GameObject("replacement", typeof(NetworkIdentity));
             NetworkIdentity replacementIdentity = playerReplacement.GetComponent<NetworkIdentity>();
             replacementIdentity.AssetId = Guid.NewGuid();
-            clientObjectManager.RegisterPrefab(playerReplacement);
+            clientObjectManager.RegisterPrefab(replacementIdentity);
 
             serverObjectManager.ReplacePlayerForConnection(server.LocalConnection, client, playerReplacement, true);
 

--- a/Assets/Tests/Runtime/ClientServerComponentTests.cs
+++ b/Assets/Tests/Runtime/ClientServerComponentTests.cs
@@ -97,7 +97,7 @@ namespace Mirror.Tests
             identity.AssetId = guid;
 
             clientObjectManager.RegisterSpawnHandler(guid, SpawnDelegateTest, go => { });
-            clientObjectManager.RegisterPrefab(gameObject, guid);
+            clientObjectManager.RegisterPrefab(identity, guid);
             serverObjectManager.SendSpawnMessage(identity, connectionToClient);
 
             await AsyncUtil.WaitUntilWithTimeout(() => spawnDelegateTestCalled != 0);
@@ -117,7 +117,7 @@ namespace Mirror.Tests
             var unspawnDelegate = Substitute.For<UnSpawnDelegate>();
 
             clientObjectManager.RegisterSpawnHandler(guid, SpawnDelegateTest, unspawnDelegate);
-            clientObjectManager.RegisterPrefab(gameObject, guid);
+            clientObjectManager.RegisterPrefab(identity, guid);
             serverObjectManager.SendSpawnMessage(identity, connectionToClient);
 
             await AsyncUtil.WaitUntilWithTimeout(() => spawnDelegateTestCalled != 0);
@@ -126,15 +126,15 @@ namespace Mirror.Tests
             {
                 netId = identity.NetId
             });
-            unspawnDelegate.Received().Invoke(Arg.Any<GameObject>());
+            unspawnDelegate.Received().Invoke(Arg.Any<NetworkIdentity>());
         });
 
         int spawnDelegateTestCalled;
-        GameObject SpawnDelegateTest(Vector3 position, Guid assetId)
+        NetworkIdentity SpawnDelegateTest(Vector3 position, Guid assetId)
         {
             spawnDelegateTestCalled++;
 
-            GameObject prefab = clientObjectManager.GetPrefab(assetId);
+            NetworkIdentity prefab = clientObjectManager.GetPrefab(assetId);
             if (!(prefab is null))
             {
                 return Object.Instantiate(prefab);

--- a/Assets/Tests/Runtime/ClientServerSetup.cs
+++ b/Assets/Tests/Runtime/ClientServerSetup.cs
@@ -74,8 +74,9 @@ namespace Mirror.Tests
 
             // create and register a prefab
             playerPrefab = new GameObject("serverPlayer", typeof(NetworkIdentity), typeof(T));
-            playerPrefab.GetComponent<NetworkIdentity>().AssetId = Guid.NewGuid();
-            clientObjectManager.RegisterPrefab(playerPrefab);
+            NetworkIdentity identity = playerPrefab.GetComponent<NetworkIdentity>();
+            identity.AssetId = Guid.NewGuid();
+            clientObjectManager.RegisterPrefab(identity);
 
             // wait for client and server to initialize themselves
             await UniTask.Delay(1);

--- a/Assets/Tests/Runtime/ServerObjectManagerTest.cs
+++ b/Assets/Tests/Runtime/ServerObjectManagerTest.cs
@@ -212,7 +212,7 @@ namespace Mirror.Tests
             playerReplacement = new GameObject("replacement", typeof(NetworkIdentity));
             NetworkIdentity replacementIdentity = playerReplacement.GetComponent<NetworkIdentity>();
             replacementIdentity.AssetId = Guid.NewGuid();
-            clientObjectManager.RegisterPrefab(playerReplacement);
+            clientObjectManager.RegisterPrefab(replacementIdentity);
 
             serverObjectManager.ReplacePlayerForConnection(connectionToClient, client, playerReplacement);
 
@@ -225,7 +225,7 @@ namespace Mirror.Tests
             playerReplacement = new GameObject("replacement", typeof(NetworkIdentity));
             NetworkIdentity replacementIdentity = playerReplacement.GetComponent<NetworkIdentity>();
             replacementIdentity.AssetId = Guid.NewGuid();
-            clientObjectManager.RegisterPrefab(playerReplacement);
+            clientObjectManager.RegisterPrefab(replacementIdentity);
 
             serverObjectManager.ReplacePlayerForConnection(connectionToClient, client, playerReplacement, true);
 
@@ -239,7 +239,7 @@ namespace Mirror.Tests
             playerReplacement = new GameObject("replacement", typeof(NetworkIdentity));
             NetworkIdentity replacementIdentity = playerReplacement.GetComponent<NetworkIdentity>();
             replacementIdentity.AssetId = replacementGuid;
-            clientObjectManager.RegisterPrefab(playerReplacement);
+            clientObjectManager.RegisterPrefab(replacementIdentity);
 
             serverObjectManager.ReplacePlayerForConnection(connectionToClient, client, playerReplacement, replacementGuid);
 
@@ -253,7 +253,7 @@ namespace Mirror.Tests
             playerReplacement = new GameObject("replacement", typeof(NetworkIdentity));
             NetworkIdentity replacementIdentity = playerReplacement.GetComponent<NetworkIdentity>();
             replacementIdentity.AssetId = replacementGuid;
-            clientObjectManager.RegisterPrefab(playerReplacement);
+            clientObjectManager.RegisterPrefab(replacementIdentity);
 
             connectionToClient.Identity = null;
 


### PR DESCRIPTION
BREAKING CHANGE: Now you can only assign prefabs with NetworkIdentity to the ClientObjectManager