### PR TITLE
Transport now has connected and started events.

### DIFF
--- a/Assets/Mirror/Runtime/Transport/MultiplexTransport.cs
+++ b/Assets/Mirror/Runtime/Transport/MultiplexTransport.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Cysharp.Threading.Tasks;
-using UnityEngine;
 
 namespace Mirror
 {
@@ -44,13 +43,17 @@ namespace Mirror
                 transport.Disconnect();
         }
 
-        public override UniTask ListenAsync()
+        public void Start()
         {
             foreach (Transport t in transports)
             {
                 t.Connected.AddListener(c => Connected.Invoke(c));
                 t.Started.AddListener(() => Started.Invoke());
             }
+        }
+        
+        public override UniTask ListenAsync()
+        {
 
             return UniTask.WhenAll(transports.Select(t => t.ListenAsync()));
         }

--- a/Assets/Mirror/Runtime/Transport/Transport.cs
+++ b/Assets/Mirror/Runtime/Transport/Transport.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using UnityEngine;
 using Cysharp.Threading.Tasks;
+using UnityEngine.Events;
 
 namespace Mirror
 {
@@ -11,11 +12,24 @@ namespace Mirror
     /// </summary>
     public abstract class Transport : MonoBehaviour
     {
+        public class ConnectEvent : UnityEvent<IConnection> { }
+
         public abstract IEnumerable<string> Scheme { get; }
+
+        /// <summary>
+        /// Event that gets fired when a client is accepted by the transport
+        /// </summary>
+        public ConnectEvent Connected = new ConnectEvent();
+
+        /// <summary>
+        /// Raised when the transport starts
+        /// </summary>
+        public UnityEvent Started = new UnityEvent();
 
         /// <summary>
         /// Open up the port and listen for connections
         /// Use in servers.
+        /// Note the task ends when we stop listening
         /// </summary>
         /// <exception>If we cannot start the transport</exception>
         /// <returns></returns>
@@ -39,14 +53,6 @@ namespace Mirror
         /// <returns>The connection to the server</returns>
         /// <exception>If connection cannot be established</exception>
         public abstract UniTask<IConnection> ConnectAsync(Uri uri);
-
-        /// <summary>
-        /// Accepts a connection from a client. 
-        /// After ListenAsync completes,  clients will queue up until you call AcceptAsync
-        /// then you get the connection to the client
-        /// </summary>
-        /// <returns>The connection to a client</returns>
-        public abstract UniTask<IConnection> AcceptAsync();
 
         /// <summary>
         /// Retrieves the address of this server.

--- a/Assets/Tests/Common/MockTransport.cs
+++ b/Assets/Tests/Common/MockTransport.cs
@@ -16,14 +16,19 @@ namespace Mirror.Tests
             return UniTask.FromResult<IConnection>(default);
         }
 
+        UniTaskCompletionSource completionSource;
+
         public override void Disconnect()
         {
+            completionSource.TrySetResult();
         }
 
         public override UniTask ListenAsync()
         {
             Started.Invoke();
-            return UniTask.CompletedTask;
+
+            completionSource = new UniTaskCompletionSource();
+            return completionSource.Task;
         }
 
         public override IEnumerable<Uri> ServerUri()

--- a/Assets/Tests/Common/MockTransport.cs
+++ b/Assets/Tests/Common/MockTransport.cs
@@ -7,31 +7,22 @@ namespace Mirror.Tests
 
     public class MockTransport : Transport
     {
-        public readonly Channel<IConnection> AcceptConnections = Cysharp.Threading.Tasks.Channel.CreateSingleConsumerUnbounded<IConnection>();
-
-        public override UniTask<IConnection> AcceptAsync()
-        {
-            return AcceptConnections.Reader.ReadAsync();
-        }
-
-        public readonly Channel<IConnection> ConnectConnections = Cysharp.Threading.Tasks.Channel.CreateSingleConsumerUnbounded<IConnection>();
-
         public override IEnumerable<string> Scheme => new []{"kcp"};
 
         public override bool Supported => true;
 
         public override UniTask<IConnection> ConnectAsync(Uri uri)
         {
-            return ConnectConnections.Reader.ReadAsync();
+            return UniTask.FromResult<IConnection>(default);
         }
 
         public override void Disconnect()
         {
-            AcceptConnections.Writer.TryWrite(null);
         }
 
         public override UniTask ListenAsync()
         {
+            Started.Invoke();
             return UniTask.CompletedTask;
         }
 

--- a/Assets/Tests/Performance/Runtime/10K/BenchmarkPerformance.cs
+++ b/Assets/Tests/Performance/Runtime/10K/BenchmarkPerformance.cs
@@ -31,7 +31,7 @@ namespace Mirror.Tests.Performance.Runtime
             // load host
             benchmarker = Object.FindObjectOfType<NetworkManager>();
 
-            await benchmarker.server.StartHost(benchmarker.client);
+            benchmarker.server.StartHost(benchmarker.client).Forget();
 
         });
 

--- a/Assets/Tests/Performance/Runtime/10KL/BenchmarkPerformanceLight.cs
+++ b/Assets/Tests/Performance/Runtime/10KL/BenchmarkPerformanceLight.cs
@@ -28,7 +28,7 @@ namespace Mirror.Tests.Performance.Runtime
             // load host
             benchmarker = Object.FindObjectOfType<NetworkManager>();
 
-            await benchmarker.server.StartHost(benchmarker.client);
+            benchmarker.server.StartHost(benchmarker.client).Forget();
 
         });
 

--- a/Assets/Tests/Performance/Runtime/MultipleClients/MultipleClients.cs
+++ b/Assets/Tests/Performance/Runtime/MultipleClients/MultipleClients.cs
@@ -45,7 +45,11 @@ namespace Mirror.Tests.Performance.Runtime
 
             server.Authenticated.AddListener(conn => serverObjectManager.SetClientReady(conn));
 
-            await server.ListenAsync();
+            var started = new UniTaskCompletionSource();
+            server.Started.AddListener(()=> started.TrySetResult());
+            server.ListenAsync().Forget();
+
+            await started.Task;
 
             transport = Object.FindObjectOfType<Transport>();
 

--- a/Assets/Tests/Runtime/ClientServerSetup.cs
+++ b/Assets/Tests/Runtime/ClientServerSetup.cs
@@ -82,9 +82,11 @@ namespace Mirror.Tests
             await UniTask.Delay(1);
 
             // start the server
-            await server.ListenAsync();
+            var started = new UniTaskCompletionSource();
+            server.Started.AddListener(() => started.TrySetResult());
+            server.ListenAsync().Forget();
 
-            await UniTask.Delay(1);
+            await started.Task;
 
             var builder = new UriBuilder
             {

--- a/Assets/Tests/Runtime/HostComponentTests.cs
+++ b/Assets/Tests/Runtime/HostComponentTests.cs
@@ -115,10 +115,9 @@ namespace Mirror.Tests
 
             var mockListener = Substitute.For<UnityAction<string, SceneOperation>>();
             sceneManager.ClientChangeScene.AddListener(mockListener);
-            await server.StartHost(client);
+            await StartHost(); ;
 
             client.Update();
-
             mockListener.Received().Invoke(Arg.Any<string>(), Arg.Any<SceneOperation>());
         });
     }

--- a/Assets/Tests/Runtime/HostComponentTests.cs
+++ b/Assets/Tests/Runtime/HostComponentTests.cs
@@ -115,7 +115,7 @@ namespace Mirror.Tests
 
             var mockListener = Substitute.For<UnityAction<string, SceneOperation>>();
             sceneManager.ClientChangeScene.AddListener(mockListener);
-            await StartHost(); ;
+            await StartHost();
 
             client.Update();
             mockListener.Received().Invoke(Arg.Any<string>(), Arg.Any<SceneOperation>());

--- a/Assets/Tests/Runtime/HostSetup.cs
+++ b/Assets/Tests/Runtime/HostSetup.cs
@@ -41,17 +41,15 @@ namespace Mirror.Tests
             sceneManager.server = server;
             serverObjectManager.server = server;
             serverObjectManager.networkSceneManager = sceneManager;
-            serverObjectManager.Start();
             clientObjectManager.client = client;
             clientObjectManager.networkSceneManager = sceneManager;
 
             ExtraSetup();
 
-            // wait for client and server to initialize themselves
-            await UniTask.Delay(1);
+            // wait for all Start() methods to get invoked
+            await UniTask.DelayFrame(1);
 
-            // now start the host
-            manager.server.StartHost(client).Forget();
+            await StartHost();
 
             playerGO = new GameObject("playerGO", typeof(Rigidbody));
             identity = playerGO.AddComponent<NetworkIdentity>();
@@ -61,6 +59,24 @@ namespace Mirror.Tests
 
             client.Update();
         });
+
+
+        protected async UniTask StartHost()
+        {
+            var completionSource = new UniTaskCompletionSource();
+
+            void Started()
+            {
+                completionSource.TrySetResult();
+            }
+
+            server.Started.AddListener(Started);
+            // now start the host
+            manager.server.StartHost(client).Forget();
+
+            await completionSource.Task;
+            server.Started.RemoveListener(Started);
+        }
 
         public virtual void ExtraTearDown() { }
 

--- a/Assets/Tests/Runtime/HostSetup.cs
+++ b/Assets/Tests/Runtime/HostSetup.cs
@@ -51,7 +51,7 @@ namespace Mirror.Tests
             await UniTask.Delay(1);
 
             // now start the host
-            await manager.server.StartHost(client);
+            manager.server.StartHost(client).Forget();
 
             playerGO = new GameObject("playerGO", typeof(Rigidbody));
             identity = playerGO.AddComponent<NetworkIdentity>();

--- a/Assets/Tests/Runtime/Transport/MultiplexTransportTest.cs
+++ b/Assets/Tests/Runtime/Transport/MultiplexTransportTest.cs
@@ -24,8 +24,6 @@ namespace Mirror.Tests
         IConnection conn1;
         IConnection conn2;
 
-        UniTask transportListen;
-
         [SetUp]
         public void Setup()
         {

--- a/Assets/Tests/Runtime/Transport/MultiplexTransportTest.cs
+++ b/Assets/Tests/Runtime/Transport/MultiplexTransportTest.cs
@@ -4,6 +4,7 @@ using Cysharp.Threading.Tasks;
 using NSubstitute;
 using NUnit.Framework;
 using UnityEngine;
+using UnityEngine.Events;
 using UnityEngine.TestTools;
 using Object = UnityEngine.Object;
 
@@ -50,47 +51,54 @@ namespace Mirror.Tests
         }
         #endregion
 
-        [UnityTest]
-        public IEnumerator AcceptTransport1() => UniTask.ToCoroutine(async () =>
+        [Test]
+        public void AcceptTransport1()
         {
-            transport1.AcceptAsync().Returns(UniTask.FromResult(conn1));
+            var connectedDelegate = Substitute.For<UnityAction<IConnection>>();
 
-            Assert.That(await transport.AcceptAsync(), Is.SameAs(conn1));
-        });
+            transport.Connected.AddListener(connectedDelegate);
+            transport1.Connected.Invoke(conn1);
 
-        [UnityTest]
-        public IEnumerator AcceptTransport2() => UniTask.ToCoroutine(async () =>
+            connectedDelegate.Received().Invoke(conn1);
+        }
+
+        [Test]
+        public void AcceptTransport2()
         {
-            transport2.AcceptAsync().Returns(UniTask.FromResult(conn1));
-            // transport1 task never ends
-            transport1.AcceptAsync().Returns(new UniTaskCompletionSource<IConnection>().Task);
-            Assert.That(await transport.AcceptAsync(), Is.SameAs(conn1));
-        });
+            var connectedDelegate = Substitute.For<UnityAction<IConnection>>();
+            transport.Connected.AddListener(connectedDelegate);
 
-        [UnityTest]
-        public IEnumerator AcceptMultiple() => UniTask.ToCoroutine(async () =>
+            transport2.Connected.Invoke(conn1);
+
+            connectedDelegate.Received().Invoke(conn1);
+        }
+
+        [Test]
+        public void AcceptMultiple()
         {
-            transport1.AcceptAsync().Returns(UniTask.FromResult(conn1), UniTask.FromResult(conn2));
-            // transport2 task never ends
-            transport2.AcceptAsync().Returns(new UniTaskCompletionSource<IConnection>().Task);
-            Assert.That(await transport.AcceptAsync(), Is.SameAs(conn1));
-            Assert.That(await transport.AcceptAsync(), Is.SameAs(conn2));
-        });
+            var connectedDelegate = Substitute.For<UnityAction<IConnection>>();
+            transport.Connected.AddListener(connectedDelegate);
 
-        [UnityTest]
-        public IEnumerator AcceptUntilAllGone() => UniTask.ToCoroutine(async () =>
+            transport1.Connected.Invoke(conn1);
+            transport2.Connected.Invoke(conn2);
+
+            connectedDelegate.Received().Invoke(conn1);
+            connectedDelegate.Received().Invoke(conn2);
+        }
+
+        [Test]
+        public void AcceptUntilAllGone()
         {
-            transport1.AcceptAsync().Returns(x => UniTask.FromResult(conn1), x => UniTask.FromResult<IConnection>(null));
-            // transport2 task never ends
-            transport2.AcceptAsync().Returns(x => UniTask.FromResult(conn2), x => UniTask.FromResult<IConnection>(null));
+            var connectedDelegate = Substitute.For<UnityAction<IConnection>>();
+            transport.Connected.AddListener(connectedDelegate);
 
-            IConnection accepted1 = await transport.AcceptAsync();
-            IConnection accepted2 = await transport.AcceptAsync();
+            transport1.Connected.Invoke(conn1);
+            transport1.Disconnect();
+            transport2.Connected.Invoke(conn2);
 
-            Assert.That(new[] { accepted1, accepted2 }, Is.EquivalentTo(new[] { conn1, conn2 }));
-
-            Assert.That(await transport.AcceptAsync(), Is.Null);
-        });
+            connectedDelegate.Received().Invoke(conn1);
+            connectedDelegate.Received().Invoke(conn2);
+        }
 
         [UnityTest]
         public IEnumerator Listen() => UniTask.ToCoroutine(async () =>

--- a/Assets/Tests/Runtime/Transport/MultiplexTransportTest.cs
+++ b/Assets/Tests/Runtime/Transport/MultiplexTransportTest.cs
@@ -24,6 +24,8 @@ namespace Mirror.Tests
         IConnection conn1;
         IConnection conn2;
 
+        UniTask transportListen;
+
         [SetUp]
         public void Setup()
         {
@@ -42,6 +44,7 @@ namespace Mirror.Tests
             conn1 = Substitute.For<IConnection>();
             conn2 = Substitute.For<IConnection>();
 
+            transport.Start();
         }
 
         [TearDown]


### PR DESCRIPTION
These changes are designed so that transports can be stacked on top of each other
and each middleware transport can implement their own handshake.

BREAKING CHANGE: Add Connected event to Transport API
BREAKING CHANGE: Add Started event to Transport API
BREAKING CHANGE: ListenAsync returns a task that completes when the transport stops
BREAKING CHANGE: Remove AcceptAsync from transports