### PR TITLE
fix: Restarting host does not start player

### DIFF
--- a/Assets/Mirror/Runtime/NetworkSceneManager.cs
+++ b/Assets/Mirror/Runtime/NetworkSceneManager.cs
@@ -66,7 +66,6 @@ namespace Mirror
             if (client != null)
             {
                 client.Authenticated.AddListener(OnClientAuthenticated);
-                client.Disconnected.AddListener(OnClientDisconnected);
             }
             if (server != null)
             {
@@ -94,10 +93,9 @@ namespace Mirror
             RegisterClientMessages(conn);
         }
 
-        void OnClientDisconnected()
+        void OnDestroy()
         {
-            client.Authenticated.RemoveListener(OnClientAuthenticated);
-            client.Disconnected.RemoveListener(OnClientDisconnected);
+            client?.Authenticated?.RemoveListener(OnClientAuthenticated);
         }
 
         internal void ClientSceneMessage(INetworkConnection conn, SceneMessage msg)


### PR DESCRIPTION
To reproduce:
1) open the basic example
2) start host mode
3) stop network
4) start host mode

I expect the player to be spawned the second time too.
but no player is spawned.

Here is a unit test that I believe reproduces the root cause