### PR TITLE
fix: don't consume so much memory registering prefabs

### DIFF
--- a/Assets/Mirror/Editor/ClientObjectManagerInspector.cs
+++ b/Assets/Mirror/Editor/ClientObjectManagerInspector.cs
@@ -36,7 +36,7 @@ namespace Mirror
         {
             var result = new HashSet<T>();
 
-            var guids = AssetDatabase.FindAssets("t:Object", new[] { path });
+            var guids = AssetDatabase.FindAssets("t:GameObject", new[] { path });
 
             int index = 0;
 

--- a/Assets/Mirror/Editor/ClientObjectManagerInspector.cs
+++ b/Assets/Mirror/Editor/ClientObjectManagerInspector.cs
@@ -32,15 +32,15 @@ namespace Mirror
             gameObject.spawnPrefabs.AddRange(prefabs);
         }
 
-        private static ISet<T> LoadPrefabsContaining<T>(string path) where T : UnityEngine.Component
+        private static ISet<T> LoadPrefabsContaining<T>(string path) where T : Component
         {
             var result = new HashSet<T>();
 
-            var guids = AssetDatabase.FindAssets("t:GameObject", new[] { path });
+            string[] guids = AssetDatabase.FindAssets("t:GameObject", new[] { path });
 
             for (int i = 0; i< guids.Length; i++)
             {
-                var assetPath = AssetDatabase.GUIDToAssetPath(guids[i]);
+                string assetPath = AssetDatabase.GUIDToAssetPath(guids[i]);
 
                 T obj = AssetDatabase.LoadAssetAtPath<T>(assetPath);
 

--- a/Assets/Mirror/Editor/ClientObjectManagerInspector.cs
+++ b/Assets/Mirror/Editor/ClientObjectManagerInspector.cs
@@ -38,11 +38,9 @@ namespace Mirror
 
             var guids = AssetDatabase.FindAssets("t:GameObject", new[] { path });
 
-            int index = 0;
-
-            foreach (string guid in guids)
+            for (int i = 0; i< guids.Length; i++)
             {
-                var assetPath = AssetDatabase.GUIDToAssetPath(guid);
+                var assetPath = AssetDatabase.GUIDToAssetPath(guids[i]);
 
                 T obj = AssetDatabase.LoadAssetAtPath<T>(assetPath);
 
@@ -51,10 +49,9 @@ namespace Mirror
                     result.Add(obj);
                 }
 
-                if (index++ > 100)
+                if (i % 100 == 99)
                 {
                     EditorUtility.UnloadUnusedAssetsImmediate();
-                    index = 0;
                 }
             }
             EditorUtility.UnloadUnusedAssetsImmediate();

--- a/Assets/Mirror/Editor/ClientObjectManagerInspector.cs
+++ b/Assets/Mirror/Editor/ClientObjectManagerInspector.cs
@@ -38,15 +38,26 @@ namespace Mirror
 
             var guids = AssetDatabase.FindAssets("t:Object", new[] { path });
 
-            foreach (var guid in guids)
+            int index = 0;
+
+            foreach (string guid in guids)
             {
                 var assetPath = AssetDatabase.GUIDToAssetPath(guid);
 
                 T obj = AssetDatabase.LoadAssetAtPath<T>(assetPath);
 
                 if (obj != null)
+                {
                     result.Add(obj);
+                }
+
+                if (index++ > 100)
+                {
+                    EditorUtility.UnloadUnusedAssetsImmediate();
+                    index = 0;
+                }
             }
+            EditorUtility.UnloadUnusedAssetsImmediate();
             return result;
         }
     }


### PR DESCRIPTION
In dragon's game,  this can consume upwards of 30 GB of RAM