### PR TITLE
fix: using mathematics in commands and rpcs

### DIFF
--- a/Assets/Mirror/Editor/Weaver/Readers.cs
+++ b/Assets/Mirror/Editor/Weaver/Readers.cs
@@ -276,7 +276,8 @@ namespace Mirror.Weaver
                 OpCode opcode = variable.IsValueType ? OpCodes.Ldloca : OpCodes.Ldloc;
                 worker.Append(worker.Create(opcode, 0));
 
-                MethodReference readFunc = GetReadFunc(field.FieldType);
+                TypeReference fieldTypeRef = worker.Body.Method.Module.ImportReference(field.FieldType);
+                MethodReference readFunc = GetReadFunc(fieldTypeRef);
                 if (readFunc != null)
                 {
                     worker.Append(worker.Create(OpCodes.Ldarg_0));

--- a/Assets/Mirror/Editor/Weaver/Writers.cs
+++ b/Assets/Mirror/Editor/Weaver/Writers.cs
@@ -221,7 +221,8 @@ namespace Mirror.Weaver
             uint fields = 0;
             foreach (FieldDefinition field in variable.FindAllPublicFields())
             {
-                MethodReference writeFunc = GetWriteFunc(field.FieldType);
+                TypeReference fieldTypeRef = worker.Body.Method.Module.ImportReference(field.FieldType);
+                MethodReference writeFunc = GetWriteFunc(fieldTypeRef);
                 // need this null check till later PR when GetWriteFunc throws exception instead
                 if (writeFunc == null) { return false; }
 


### PR DESCRIPTION
Generating readers and writers for structs in other assemblies
could sometimes cause a
```
System.ArgumentException: Member 'xxx' is declared in another module and needs to be imported
```

This in particular affected unity mathematics.