### PR TITLE
breaking: remove serverOnly

### DIFF
--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -113,7 +113,7 @@ namespace Mirror
         /// <summary>
         /// Returns true if running as a client and this object was spawned by a server.
         /// </summary>
-        public bool IsClient => Client != null && Client.Active && NetId != 0 && !serverOnly;
+        public bool IsClient => Client != null && Client.Active && NetId != 0;
 
         /// <summary>
         /// Returns true if NetworkServer.active and server is not stopped.
@@ -156,12 +156,6 @@ namespace Mirror
         // persistent scene id <sceneHash/32,sceneId/32> (see AssignSceneID comments)
         [FormerlySerializedAs("m_SceneId"), HideInInspector]
         public ulong sceneId;
-
-        /// <summary>
-        /// Flag to make this object only exist when the game is running as a server (or host).
-        /// </summary>
-        [FormerlySerializedAs("m_ServerOnly")]
-        public bool serverOnly;
 
         /// <summary>
         /// The NetworkServer associated with this NetworkIdentity.

--- a/Assets/Mirror/Runtime/ServerObjectManager.cs
+++ b/Assets/Mirror/Runtime/ServerObjectManager.cs
@@ -410,9 +410,6 @@ namespace Mirror
 
         internal void SendSpawnMessage(NetworkIdentity identity, INetworkConnection conn)
         {
-            if (identity.serverOnly)
-                return;
-
             // for easier debugging
             if (logger.LogEnabled()) logger.Log("Server SendSpawnMessage: name=" + identity.name + " sceneId=" + identity.sceneId.ToString("X") + " netid=" + identity.NetId);
 


### PR DESCRIPTION
As discussed in discord,  removing this flag.
Changing this flag at runtime does not work at all.
and it is also bugged,  see #389

The use case this addresses is to have an object that only lives in the server
but you can easily achieve this by setting an object as active
in the Started and Stopped events in NetworkServer.
![Screen Shot 2020-11-23 at 10 23 25 AM](https://user-images.githubusercontent.com/466007/99989862-be7b2900-2d78-11eb-94d7-6d75e2a18dba.png)

In the future, we may reintroduce this if there is a good case for it
with an AOI rewrite

closes #389

BREAKING CHANGE: Remove serverOnly option in NetworkIdentity