### PR TITLE
fix: prevent DoS attacks with invalid array length

### DIFF
--- a/Assets/Mirror/Runtime/NetworkReader.cs
+++ b/Assets/Mirror/Runtime/NetworkReader.cs
@@ -416,6 +416,8 @@ namespace Mirror
             int length = reader.ReadPackedInt32();
             if (length < 0)
                 return null;
+            if (reader.Position + length > reader.Length)
+                throw new EndOfStreamException("Can't read " + length + " elements because it would read past the end of the stream. ");
             var result = new T[length];
             for (int i = 0; i < length; i++)
             {


### PR DESCRIPTION
Make sure array length is within a reasonable size