### PR TITLE
feat: Quaternion compression

### DIFF
--- a/Assets/Mirror/Runtime/Compression.cs
+++ b/Assets/Mirror/Runtime/Compression.cs
@@ -20,57 +20,57 @@ namespace Mirror
         private const float Minimum = -1.0f / 1.414214f; // note: 1.0f / sqrt(2)
         private const float Maximum = +1.0f / 1.414214f;
 
-        internal static uint Compress(Quaternion expected)
+        internal static uint Compress(Quaternion quaternion)
         {
-            float absX = Mathf.Abs(expected.x),
-                      absY = Mathf.Abs(expected.y),
-                      absZ = Mathf.Abs(expected.z),
-                      absW = Mathf.Abs(expected.w);
+            float absX = Mathf.Abs(quaternion.x),
+                      absY = Mathf.Abs(quaternion.y),
+                      absZ = Mathf.Abs(quaternion.z),
+                      absW = Mathf.Abs(quaternion.w);
 
             ComponentType largestComponent = ComponentType.X;
-            float largestValue = absX;
-            float largestSign = Mathf.Sign(expected.x);
+            float largestAbs = absX;
+            float largest = quaternion.x;
 
-            if (absY > largestValue)
+            if (absY > largestAbs)
             {
-                largestValue = absY;
+                largestAbs = absY;
                 largestComponent = ComponentType.Y;
-                largestSign = Mathf.Sign(expected.y);
+                largest = quaternion.y;
             }
-            if (absZ > largestValue)
+            if (absZ > largestAbs)
             {
-                largestValue = absZ;
+                largestAbs = absZ;
                 largestComponent = ComponentType.Z;
-                largestSign = Mathf.Sign(expected.z);
+                largest =quaternion.z;
             }
-            if (absW > largestValue)
+            if (absW > largestAbs)
             {
                 largestComponent = ComponentType.W;
-                largestSign = Mathf.Sign(expected.w);
+                largest = quaternion.w;
             }
 
             float a, b, c;
             switch (largestComponent)
             {
                 case ComponentType.X:
-                    a = expected.y;
-                    b = expected.z;
-                    c = expected.w;
+                    a = quaternion.y;
+                    b = quaternion.z;
+                    c = quaternion.w;
                     break;
                 case ComponentType.Y:
-                    a = expected.x;
-                    b = expected.z;
-                    c = expected.w;
+                    a = quaternion.x;
+                    b = quaternion.z;
+                    c = quaternion.w;
                     break;
                 case ComponentType.Z:
-                    a = expected.x;
-                    b = expected.y;
-                    c = expected.w;
+                    a = quaternion.x;
+                    b = quaternion.y;
+                    c = quaternion.w;
                     break;
                 case ComponentType.W:
-                    a = expected.x;
-                    b = expected.y;
-                    c = expected.z;
+                    a = quaternion.x;
+                    b = quaternion.y;
+                    c = quaternion.z;
                     break;
                 default:
                     // Should never happen!
@@ -78,7 +78,7 @@ namespace Mirror
                                                           largestComponent);
             }
 
-            if (largestSign < 0)
+            if (largest < 0)
             {
                 a = -a;
                 b = -b;

--- a/Assets/Mirror/Runtime/Compression.cs
+++ b/Assets/Mirror/Runtime/Compression.cs
@@ -11,19 +11,6 @@ namespace Mirror
         W = 3
     }
 
-    struct LargestComponent
-    {
-        public ComponentType ComponentType;
-        public float Value;
-
-        public LargestComponent(ComponentType componentType, float value)
-        {
-            ComponentType = componentType;
-            Value = value;
-
-        }
-    }
-
     /// <summary>
     ///     Credit to this man for converting gaffer games c code to c#
     ///     https://gist.github.com/fversnel/0497ad7ab3b81e0dc1dd
@@ -40,25 +27,25 @@ namespace Mirror
                       absZ = Mathf.Abs(expected.z),
                       absW = Mathf.Abs(expected.w);
 
-            var largestComponent = new LargestComponent(ComponentType.X, absX);
-            if (absY > largestComponent.Value)
+            ComponentType largestComponent = ComponentType.X;
+            float largestValue = absX;
+            if (absY > largestValue)
             {
-                largestComponent.Value = absY;
-                largestComponent.ComponentType = ComponentType.Y;
+                largestValue = absY;
+                largestComponent = ComponentType.Y;
             }
-            if (absZ > largestComponent.Value)
+            if (absZ > largestValue)
             {
-                largestComponent.Value = absZ;
-                largestComponent.ComponentType = ComponentType.Z;
+                largestValue = absZ;
+                largestComponent = ComponentType.Z;
             }
-            if (absW > largestComponent.Value)
+            if (absW > largestValue)
             {
-                largestComponent.Value = absW;
-                largestComponent.ComponentType = ComponentType.W;
+                largestComponent = ComponentType.W;
             }
 
             float a, b, c;
-            switch (largestComponent.ComponentType)
+            switch (largestComponent)
             {
                 case ComponentType.X when expected.x >= 0:
                     a = expected.y;
@@ -76,11 +63,9 @@ namespace Mirror
                     c = expected.w;
                     break;
                 case ComponentType.Y when expected.y < 0:
-
                     a = -expected.x;
                     b = -expected.z;
                     c = -expected.w;
-
                     break;
                 case ComponentType.Z when expected.z >= 0:
                     a = expected.x;
@@ -106,7 +91,7 @@ namespace Mirror
                 default:
                     // Should never happen!
                     throw new ArgumentOutOfRangeException("Unknown rotation component type: " +
-                                                          largestComponent.ComponentType);
+                                                          largestComponent);
             }
 
             float normalizedA = (a - Minimum) / (Maximum - Minimum),
@@ -117,7 +102,7 @@ namespace Mirror
                 integerB = (uint)Mathf.FloorToInt(normalizedB * 1024.0f + 0.5f),
                 integerC = (uint)Mathf.FloorToInt(normalizedC * 1024.0f + 0.5f);
 
-            return (((uint)largestComponent.ComponentType) << 30) | (integerA << 20) | (integerB << 10) | integerC;
+            return (((uint)largestComponent) << 30) | (integerA << 20) | (integerB << 10) | integerC;
         }
 
         internal static Quaternion Decompress(uint compressed)

--- a/Assets/Mirror/Runtime/Compression.cs
+++ b/Assets/Mirror/Runtime/Compression.cs
@@ -60,61 +60,48 @@ namespace Mirror
             float a, b, c;
             switch (largestComponent.ComponentType)
             {
-                case ComponentType.X:
-                    if (expected.x >= 0)
-                    {
-                        a = expected.y;
-                        b = expected.z;
-                        c = expected.w;
-                    }
-                    else
-                    {
-                        a = -expected.y;
-                        b = -expected.z;
-                        c = -expected.w;
-                    }
+                case ComponentType.X when expected.x >= 0:
+                    a = expected.y;
+                    b = expected.z;
+                    c = expected.w;
                     break;
-                case ComponentType.Y:
-                    if (expected.y >= 0)
-                    {
-                        a = expected.x;
-                        b = expected.z;
-                        c = expected.w;
-                    }
-                    else
-                    {
-                        a = -expected.x;
-                        b = -expected.z;
-                        c = -expected.w;
-                    }
+                case ComponentType.X when expected.x < 0:
+                    a = -expected.y;
+                    b = -expected.z;
+                    c = -expected.w;
                     break;
-                case ComponentType.Z:
-                    if (expected.z >= 0)
-                    {
-                        a = expected.x;
-                        b = expected.y;
-                        c = expected.w;
-                    }
-                    else
-                    {
-                        a = -expected.x;
-                        b = -expected.y;
-                        c = -expected.w;
-                    }
+                case ComponentType.Y when expected.y >= 0:
+                    a = expected.x;
+                    b = expected.z;
+                    c = expected.w;
                     break;
-                case ComponentType.W:
-                    if (expected.w >= 0)
-                    {
-                        a = expected.x;
-                        b = expected.y;
-                        c = expected.z;
-                    }
-                    else
-                    {
-                        a = -expected.x;
-                        b = -expected.y;
-                        c = -expected.z;
-                    }
+                case ComponentType.Y when expected.y < 0:
+
+                    a = -expected.x;
+                    b = -expected.z;
+                    c = -expected.w;
+
+                    break;
+                case ComponentType.Z when expected.z >= 0:
+                    a = expected.x;
+                    b = expected.y;
+                    c = expected.w;
+                    break;
+                case ComponentType.Z when expected.z < 0:
+                    a = -expected.x;
+                    b = -expected.y;
+                    c = -expected.w;
+
+                    break;
+                case ComponentType.W when expected.w >= 0:
+                    a = expected.x;
+                    b = expected.y;
+                    c = expected.z;
+                    break;
+                case ComponentType.W when expected.w < 0:
+                    a = -expected.x;
+                    b = -expected.y;
+                    c = -expected.z;
                     break;
                 default:
                     // Should never happen!

--- a/Assets/Mirror/Runtime/Compression.cs
+++ b/Assets/Mirror/Runtime/Compression.cs
@@ -72,10 +72,6 @@ namespace Mirror
                     b = quaternion.y;
                     c = quaternion.z;
                     break;
-                default:
-                    // Should never happen!
-                    throw new ArgumentOutOfRangeException("Unknown rotation component type: " +
-                                                          largestComponent);
             }
 
             if (largest < 0)

--- a/Assets/Mirror/Runtime/Compression.cs
+++ b/Assets/Mirror/Runtime/Compression.cs
@@ -29,69 +29,60 @@ namespace Mirror
 
             ComponentType largestComponent = ComponentType.X;
             float largestValue = absX;
+            float largestSign = Mathf.Sign(expected.x);
+
             if (absY > largestValue)
             {
                 largestValue = absY;
                 largestComponent = ComponentType.Y;
+                largestSign = Mathf.Sign(expected.y);
             }
             if (absZ > largestValue)
             {
                 largestValue = absZ;
                 largestComponent = ComponentType.Z;
+                largestSign = Mathf.Sign(expected.z);
             }
             if (absW > largestValue)
             {
                 largestComponent = ComponentType.W;
+                largestSign = Mathf.Sign(expected.w);
             }
 
             float a, b, c;
             switch (largestComponent)
             {
-                case ComponentType.X when expected.x >= 0:
+                case ComponentType.X:
                     a = expected.y;
                     b = expected.z;
                     c = expected.w;
                     break;
-                case ComponentType.X when expected.x < 0:
-                    a = -expected.y;
-                    b = -expected.z;
-                    c = -expected.w;
-                    break;
-                case ComponentType.Y when expected.y >= 0:
+                case ComponentType.Y:
                     a = expected.x;
                     b = expected.z;
                     c = expected.w;
                     break;
-                case ComponentType.Y when expected.y < 0:
-                    a = -expected.x;
-                    b = -expected.z;
-                    c = -expected.w;
-                    break;
-                case ComponentType.Z when expected.z >= 0:
+                case ComponentType.Z:
                     a = expected.x;
                     b = expected.y;
                     c = expected.w;
                     break;
-                case ComponentType.Z when expected.z < 0:
-                    a = -expected.x;
-                    b = -expected.y;
-                    c = -expected.w;
-
-                    break;
-                case ComponentType.W when expected.w >= 0:
+                case ComponentType.W:
                     a = expected.x;
                     b = expected.y;
                     c = expected.z;
-                    break;
-                case ComponentType.W when expected.w < 0:
-                    a = -expected.x;
-                    b = -expected.y;
-                    c = -expected.z;
                     break;
                 default:
                     // Should never happen!
                     throw new ArgumentOutOfRangeException("Unknown rotation component type: " +
                                                           largestComponent);
+            }
+
+            if (largestSign < 0)
+            {
+                a = -a;
+                b = -b;
+                c = -c;
             }
 
             float normalizedA = (a - Minimum) / (Maximum - Minimum),

--- a/Assets/Mirror/Runtime/Compression.cs
+++ b/Assets/Mirror/Runtime/Compression.cs
@@ -49,7 +49,9 @@ namespace Mirror
                 largest = quaternion.w;
             }
 
-            float a, b, c;
+            float a = 0;
+            float b = 0;
+            float c = 0;
             switch (largestComponent)
             {
                 case ComponentType.X:

--- a/Assets/Mirror/Runtime/Compression.cs
+++ b/Assets/Mirror/Runtime/Compression.cs
@@ -1,20 +1,195 @@
-﻿using System;
-using System.Collections;
-using System.Collections.Generic;
+using System;
 using UnityEngine;
 
 namespace Mirror
 {
+    enum ComponentType : uint
+    {
+        X = 0,
+        Y = 1,
+        Z = 2,
+        W = 3
+    }
+
+    struct LargestComponent
+    {
+        public ComponentType ComponentType;
+        public float Value;
+
+        public LargestComponent(ComponentType componentType, float value)
+        {
+            ComponentType = componentType;
+            Value = value;
+
+        }
+    }
+
+    /// <summary>
+    ///     Credit to this man for converting gaffer games c code to c#
+    ///     https://gist.github.com/fversnel/0497ad7ab3b81e0dc1dd
+    /// </summary>
     public static class Compression
     {
+        private const float Minimum = -1.0f / 1.414214f; // note: 1.0f / sqrt(2)
+        private const float Maximum = +1.0f / 1.414214f;
+
         internal static uint Compress(Quaternion expected)
         {
-            throw new NotImplementedException();
+            float absX = Mathf.Abs(expected.x),
+                      absY = Mathf.Abs(expected.y),
+                      absZ = Mathf.Abs(expected.z),
+                      absW = Mathf.Abs(expected.w);
+
+            var largestComponent = new LargestComponent(ComponentType.X, absX);
+            if (absY > largestComponent.Value)
+            {
+                largestComponent.Value = absY;
+                largestComponent.ComponentType = ComponentType.Y;
+            }
+            if (absZ > largestComponent.Value)
+            {
+                largestComponent.Value = absZ;
+                largestComponent.ComponentType = ComponentType.Z;
+            }
+            if (absW > largestComponent.Value)
+            {
+                largestComponent.Value = absW;
+                largestComponent.ComponentType = ComponentType.W;
+            }
+
+            float a, b, c;
+            switch (largestComponent.ComponentType)
+            {
+                case ComponentType.X:
+                    if (expected.x >= 0)
+                    {
+                        a = expected.y;
+                        b = expected.z;
+                        c = expected.w;
+                    }
+                    else
+                    {
+                        a = -expected.y;
+                        b = -expected.z;
+                        c = -expected.w;
+                    }
+                    break;
+                case ComponentType.Y:
+                    if (expected.y >= 0)
+                    {
+                        a = expected.x;
+                        b = expected.z;
+                        c = expected.w;
+                    }
+                    else
+                    {
+                        a = -expected.x;
+                        b = -expected.z;
+                        c = -expected.w;
+                    }
+                    break;
+                case ComponentType.Z:
+                    if (expected.z >= 0)
+                    {
+                        a = expected.x;
+                        b = expected.y;
+                        c = expected.w;
+                    }
+                    else
+                    {
+                        a = -expected.x;
+                        b = -expected.y;
+                        c = -expected.w;
+                    }
+                    break;
+                case ComponentType.W:
+                    if (expected.w >= 0)
+                    {
+                        a = expected.x;
+                        b = expected.y;
+                        c = expected.z;
+                    }
+                    else
+                    {
+                        a = -expected.x;
+                        b = -expected.y;
+                        c = -expected.z;
+                    }
+                    break;
+                default:
+                    // Should never happen!
+                    throw new ArgumentOutOfRangeException("Unknown rotation component type: " +
+                                                          largestComponent.ComponentType);
+            }
+
+            float normalizedA = (a - Minimum) / (Maximum - Minimum),
+                normalizedB = (b - Minimum) / (Maximum - Minimum),
+                normalizedC = (c - Minimum) / (Maximum - Minimum);
+
+            uint integerA = (uint)Mathf.FloorToInt(normalizedA * 1024.0f + 0.5f),
+                integerB = (uint)Mathf.FloorToInt(normalizedB * 1024.0f + 0.5f),
+                integerC = (uint)Mathf.FloorToInt(normalizedC * 1024.0f + 0.5f);
+
+            return (((uint)largestComponent.ComponentType) << 30) | (integerA << 20) | (integerB << 10) | integerC;
         }
 
         internal static Quaternion Decompress(uint compressed)
         {
-            throw new NotImplementedException();
+            var largestComponentType = (ComponentType)(compressed >> 30);
+            uint integerA = (compressed >> 20) & ((1 << 10) - 1),
+                integerB = (compressed >> 10) & ((1 << 10) - 1),
+                integerC = compressed & ((1 << 10) - 1);
+
+            float a = integerA / 1024.0f * (Maximum - Minimum) + Minimum,
+                b = integerB / 1024.0f * (Maximum - Minimum) + Minimum,
+                c = integerC / 1024.0f * (Maximum - Minimum) + Minimum;
+
+            Quaternion rotation;
+            switch (largestComponentType)
+            {
+                case ComponentType.X:
+                    // (?) y z w
+                    rotation.y = a;
+                    rotation.z = b;
+                    rotation.w = c;
+                    rotation.x = Mathf.Sqrt(1 - rotation.y * rotation.y
+                                               - rotation.z * rotation.z
+                                               - rotation.w * rotation.w);
+                    break;
+                case ComponentType.Y:
+                    // x (?) z w
+                    rotation.x = a;
+                    rotation.z = b;
+                    rotation.w = c;
+                    rotation.y = Mathf.Sqrt(1 - rotation.x * rotation.x
+                                               - rotation.z * rotation.z
+                                               - rotation.w * rotation.w);
+                    break;
+                case ComponentType.Z:
+                    // x y (?) w
+                    rotation.x = a;
+                    rotation.y = b;
+                    rotation.w = c;
+                    rotation.z = Mathf.Sqrt(1 - rotation.x * rotation.x
+                                               - rotation.y * rotation.y
+                                               - rotation.w * rotation.w);
+                    break;
+                case ComponentType.W:
+                    // x y z (?)
+                    rotation.x = a;
+                    rotation.y = b;
+                    rotation.z = c;
+                    rotation.w = Mathf.Sqrt(1 - rotation.x * rotation.x
+                                               - rotation.y * rotation.y
+                                               - rotation.z * rotation.z);
+                    break;
+                default:
+                    // Should never happen!
+                    throw new ArgumentOutOfRangeException("Unknown rotation component type: " +
+                                                          largestComponentType);
+            }
+
+            return rotation;
         }
     }
 }

--- a/Assets/Mirror/Runtime/Compression.cs
+++ b/Assets/Mirror/Runtime/Compression.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Mirror
+{
+    public static class Compression
+    {
+        internal static uint Compress(Quaternion expected)
+        {
+            throw new NotImplementedException();
+        }
+
+        internal static Quaternion Decompress(uint compressed)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/Assets/Mirror/Runtime/Compression.cs
+++ b/Assets/Mirror/Runtime/Compression.cs
@@ -1,28 +1,195 @@
-﻿using System;
+using System;
 using UnityEngine;
 
 namespace Mirror
 {
+    enum ComponentType : uint
+    {
+        X = 0,
+        Y = 1,
+        Z = 2,
+        W = 3
+    }
+
+    struct LargestComponent
+    {
+        public ComponentType ComponentType;
+        public float Value;
+
+        public LargestComponent(ComponentType componentType, float value)
+        {
+            ComponentType = componentType;
+            Value = value;
+
+        }
+    }
+
+    /// <summary>
+    ///     Credit to this man for converting gaffer games c code to c#
+    ///     https://gist.github.com/fversnel/0497ad7ab3b81e0dc1dd
+    /// </summary>
     public static class Compression
     {
-        /// <summary>
-        /// Lossy compression of normalized quaternion into 29 bits
-        /// </summary>
-        /// <param name="quaternion">The quaternion to compress</param>
-        /// <returns>29 bits of compressed quaternion</returns>
-        internal static uint Compress(Quaternion quaternion)
+        private const float Minimum = -1.0f / 1.414214f; // note: 1.0f / sqrt(2)
+        private const float Maximum = +1.0f / 1.414214f;
+
+        internal static uint Compress(Quaternion expected)
         {
-            throw new NotImplementedException();
+            float absX = Mathf.Abs(expected.x),
+                      absY = Mathf.Abs(expected.y),
+                      absZ = Mathf.Abs(expected.z),
+                      absW = Mathf.Abs(expected.w);
+
+            var largestComponent = new LargestComponent(ComponentType.X, absX);
+            if (absY > largestComponent.Value)
+            {
+                largestComponent.Value = absY;
+                largestComponent.ComponentType = ComponentType.Y;
+            }
+            if (absZ > largestComponent.Value)
+            {
+                largestComponent.Value = absZ;
+                largestComponent.ComponentType = ComponentType.Z;
+            }
+            if (absW > largestComponent.Value)
+            {
+                largestComponent.Value = absW;
+                largestComponent.ComponentType = ComponentType.W;
+            }
+
+            float a, b, c;
+            switch (largestComponent.ComponentType)
+            {
+                case ComponentType.X:
+                    if (expected.x >= 0)
+                    {
+                        a = expected.y;
+                        b = expected.z;
+                        c = expected.w;
+                    }
+                    else
+                    {
+                        a = -expected.y;
+                        b = -expected.z;
+                        c = -expected.w;
+                    }
+                    break;
+                case ComponentType.Y:
+                    if (expected.y >= 0)
+                    {
+                        a = expected.x;
+                        b = expected.z;
+                        c = expected.w;
+                    }
+                    else
+                    {
+                        a = -expected.x;
+                        b = -expected.z;
+                        c = -expected.w;
+                    }
+                    break;
+                case ComponentType.Z:
+                    if (expected.z >= 0)
+                    {
+                        a = expected.x;
+                        b = expected.y;
+                        c = expected.w;
+                    }
+                    else
+                    {
+                        a = -expected.x;
+                        b = -expected.y;
+                        c = -expected.w;
+                    }
+                    break;
+                case ComponentType.W:
+                    if (expected.w >= 0)
+                    {
+                        a = expected.x;
+                        b = expected.y;
+                        c = expected.z;
+                    }
+                    else
+                    {
+                        a = -expected.x;
+                        b = -expected.y;
+                        c = -expected.z;
+                    }
+                    break;
+                default:
+                    // Should never happen!
+                    throw new ArgumentOutOfRangeException("Unknown rotation component type: " +
+                                                          largestComponent.ComponentType);
+            }
+
+            float normalizedA = (a - Minimum) / (Maximum - Minimum),
+                normalizedB = (b - Minimum) / (Maximum - Minimum),
+                normalizedC = (c - Minimum) / (Maximum - Minimum);
+
+            uint integerA = (uint)Mathf.FloorToInt(normalizedA * 1024.0f + 0.5f),
+                integerB = (uint)Mathf.FloorToInt(normalizedB * 1024.0f + 0.5f),
+                integerC = (uint)Mathf.FloorToInt(normalizedC * 1024.0f + 0.5f);
+
+            return (((uint)largestComponent.ComponentType) << 30) | (integerA << 20) | (integerB << 10) | integerC;
         }
 
-        /// <summary>
-        /// Decompress quaternions
-        /// </summary>
-        /// <param name="compressed">29 bits contained a compressed quaternion</param>
-        /// <returns>The normalized quaternion</returns>
         internal static Quaternion Decompress(uint compressed)
         {
-            throw new NotImplementedException();
+            var largestComponentType = (ComponentType)(compressed >> 30);
+            uint integerA = (compressed >> 20) & ((1 << 10) - 1),
+                integerB = (compressed >> 10) & ((1 << 10) - 1),
+                integerC = compressed & ((1 << 10) - 1);
+
+            float a = integerA / 1024.0f * (Maximum - Minimum) + Minimum,
+                b = integerB / 1024.0f * (Maximum - Minimum) + Minimum,
+                c = integerC / 1024.0f * (Maximum - Minimum) + Minimum;
+
+            Quaternion rotation;
+            switch (largestComponentType)
+            {
+                case ComponentType.X:
+                    // (?) y z w
+                    rotation.y = a;
+                    rotation.z = b;
+                    rotation.w = c;
+                    rotation.x = Mathf.Sqrt(1 - rotation.y * rotation.y
+                                               - rotation.z * rotation.z
+                                               - rotation.w * rotation.w);
+                    break;
+                case ComponentType.Y:
+                    // x (?) z w
+                    rotation.x = a;
+                    rotation.z = b;
+                    rotation.w = c;
+                    rotation.y = Mathf.Sqrt(1 - rotation.x * rotation.x
+                                               - rotation.z * rotation.z
+                                               - rotation.w * rotation.w);
+                    break;
+                case ComponentType.Z:
+                    // x y (?) w
+                    rotation.x = a;
+                    rotation.y = b;
+                    rotation.w = c;
+                    rotation.z = Mathf.Sqrt(1 - rotation.x * rotation.x
+                                               - rotation.y * rotation.y
+                                               - rotation.w * rotation.w);
+                    break;
+                case ComponentType.W:
+                    // x y z (?)
+                    rotation.x = a;
+                    rotation.y = b;
+                    rotation.z = c;
+                    rotation.w = Mathf.Sqrt(1 - rotation.x * rotation.x
+                                               - rotation.y * rotation.y
+                                               - rotation.z * rotation.z);
+                    break;
+                default:
+                    // Should never happen!
+                    throw new ArgumentOutOfRangeException("Unknown rotation component type: " +
+                                                          largestComponentType);
+            }
+
+            return rotation;
         }
     }
 }

--- a/Assets/Mirror/Runtime/Compression.cs
+++ b/Assets/Mirror/Runtime/Compression.cs
@@ -87,9 +87,9 @@ namespace Mirror
                 normalizedB = (b - Minimum) / (Maximum - Minimum),
                 normalizedC = (c - Minimum) / (Maximum - Minimum);
 
-            uint integerA = (uint)Mathf.FloorToInt(normalizedA * 1024.0f + 0.5f),
-                integerB = (uint)Mathf.FloorToInt(normalizedB * 1024.0f + 0.5f),
-                integerC = (uint)Mathf.FloorToInt(normalizedC * 1024.0f + 0.5f);
+            uint integerA = (uint)Mathf.RoundToInt(normalizedA * 1024.0f),
+                integerB = (uint)Mathf.RoundToInt(normalizedB * 1024.0f),
+                integerC = (uint)Mathf.RoundToInt(normalizedC * 1024.0f);
 
             return (((uint)largestComponent) << 30) | (integerA << 20) | (integerB << 10) | integerC;
         }

--- a/Assets/Mirror/Runtime/Compression.cs.meta
+++ b/Assets/Mirror/Runtime/Compression.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9aa04482b3d27456e97b974b18752f32
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Editor/Compression.cs
+++ b/Assets/Tests/Editor/Compression.cs
@@ -1,0 +1,27 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using Mirror;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace Tests
+{
+    public class CompressionTests
+    {
+
+        [Test]
+        [Repeat(100)]
+        public void QuaternionCompression()
+        {
+            Quaternion expected = Random.rotation;
+
+            uint compressed = Compression.Compress(expected);
+
+            Quaternion decompressed = Compression.Decompress(compressed);
+
+            // decompressed should be almost the same
+            Assert.That(Quaternion.Dot(expected, decompressed), Is.GreaterThan(1 - 0.001));
+        }
+    }
+}

--- a/Assets/Tests/Editor/Compression.cs.meta
+++ b/Assets/Tests/Editor/Compression.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4220775e22e344aa2a78bac42cbcbadf
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
as described by
https://gafferongames.com/post/snapshot_compression/

Assuming quaternions are normalized, this algorithm gets a 29-bit lossy compression of quaternions suitable for networking rotations.  Note that a full-blown quaternion takes 32 * 4 = 128 bits