### PR TITLE
Remove static NC.Current and NS.Current

### DIFF
--- a/Assets/Mirror/Runtime/NetworkClient.cs
+++ b/Assets/Mirror/Runtime/NetworkClient.cs
@@ -193,13 +193,6 @@ namespace Mirror
             }
         }
 
-        /// <summary>
-        /// client that received the message
-        /// </summary>
-        /// <remarks>This is a hack, but it is needed to deserialize
-        /// gameobjects when processing the message</remarks>
-        internal static NetworkClient Current { get; set; }
-
         async UniTaskVoid OnConnected()
         {
             // reset network time stats

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -901,8 +901,8 @@ namespace Mirror
 
         internal void OnDeserializeAllSafely(NetworkReader reader, bool initialState)
         {
-            // hack needed so that we can deserialize gameobjects and NI
-            NetworkClient.Current = Client;
+            // needed so that we can deserialize gameobjects and NI
+            reader.Client = Client;
             // deserialize all components that were received
             NetworkBehaviour[] components = NetworkBehaviours;
             while (reader.Position < reader.Length)
@@ -928,10 +928,10 @@ namespace Mirror
         /// <param name="senderConnection"></param>
         internal void HandleRemoteCall(Skeleton skeleton, int componentIndex, NetworkReader reader, INetworkConnection senderConnection = null, int replyId = 0)
         {
-            // hack sets the current client and server so that we can deserialize
-            // gameobjects and network identities in the reader
-            NetworkClient.Current = Client;
-            NetworkServer.Current = Server;
+            // Set the client and server for this remote call.
+            // this can be used by custom deserializers to lookup objects
+            reader.Client = Client;
+            reader.Server = Server;
 
             // find the right component to invoke the function on
             if (componentIndex >= 0 && componentIndex < NetworkBehaviours.Length)

--- a/Assets/Mirror/Runtime/NetworkReader.cs
+++ b/Assets/Mirror/Runtime/NetworkReader.cs
@@ -45,6 +45,16 @@ namespace Mirror
         public int Position;
         public int Length => buffer.Count;
 
+        /// <summary>
+        /// The network client that created this reader. May be null
+        /// </summary>
+        public NetworkClient Client { get; internal set; }
+
+        /// <summary>
+        /// The Network Server that created this reader. May be null
+        /// </summary>
+        public NetworkServer Server { get; internal set; }
+
         public NetworkReader(byte[] bytes)
         {
             buffer = new ArraySegment<byte>(bytes);
@@ -383,14 +393,14 @@ namespace Mirror
             if (netId == 0)
                 return null;
 
-            if (NetworkClient.Current != null)
+            if (reader.Client != null)
             {
-                NetworkClient.Current.Spawned.TryGetValue(netId, out NetworkIdentity identity);
+                reader.Client.Spawned.TryGetValue(netId, out NetworkIdentity identity);
                 return identity;
             }
-            else if (NetworkServer.Current != null)
+            else if (reader.Server != null)
             {
-                NetworkServer.Current.Spawned.TryGetValue(netId, out NetworkIdentity identity);
+                reader.Server.Spawned.TryGetValue(netId, out NetworkIdentity identity);
                 return identity;
             }
 

--- a/Assets/Mirror/Runtime/NetworkReaderPool.cs
+++ b/Assets/Mirror/Runtime/NetworkReaderPool.cs
@@ -79,6 +79,8 @@ namespace Mirror
 
             // reset buffer
             SetBuffer(reader, bytes);
+            reader.Client = null;
+            reader.Server = null;
             return reader;
         }
 
@@ -99,6 +101,8 @@ namespace Mirror
 
             // reset buffer
             SetBuffer(reader, segment);
+            reader.Client = null;
+            reader.Server = null;
             return reader;
         }
 

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -429,14 +429,6 @@ namespace Mirror
         }
 
         /// <summary>
-        /// server that received the message
-        /// </summary>
-        /// <remarks>This is a hack, but it is needed to deserialize
-        /// gameobjects when processing the message</remarks>
-        /// 
-        internal static NetworkServer Current { get; set; }
-
-        /// <summary>
         /// send this message to the player only
         /// </summary>
         /// <typeparam name="T">Message type</typeparam>

--- a/Assets/Tests/Runtime/NetworkClientTest.cs
+++ b/Assets/Tests/Runtime/NetworkClientTest.cs
@@ -22,12 +22,6 @@ namespace Mirror.Tests
         }
 
         [Test]
-        public void CurrentTest()
-        {
-            Assert.That(NetworkClient.Current == null);
-        }
-
-        [Test]
         public void GetNewConnectionTest()
         {
             Assert.That(client.GetNewConnection(Substitute.For<IConnection>()), Is.Not.Null);


### PR DESCRIPTION
As far as I know,  this is the last piece of static state we have.

Instead of having it as a static, which could cause trouble with
multiple tasks,  when we receive a message, we attach the current
NetworkClient and NetworkServer to NetworkReader.

A custom deserializer,  can ask the reader for the NC or NS and use
it to lookup NetworkIdentities.