### PR TITLE
feat: Provide mirrorng version at runtime

### DIFF
--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -2,12 +2,15 @@ plugins:
   - '@semantic-release/github'
   - '@semantic-release/release-notes-generator'
   - '@semantic-release/commit-analyzer'
+  - - '@semantic-release/exec'
+    - "prepare": "sed -i .bak -e '/AssemblyVersion/s/\".*\"/\"${nextRelease.version}\"/' Assets/Mirror/Runtime/AssemblyInfo.cs"
   - - '@semantic-release/changelog'
     - changelogFile: 'Assets/Mirror/CHANGELOG.md'
   - - '@semantic-release/npm'
     - npmPublish: false
       pkgRoot: "Assets/Mirror"
   - - '@semantic-release/git'
-    - assets: 
+    - assets:
+        - 'Assets/Mirror/Runtime/AssemblyInfo.cs'
         - 'Assets/Mirror/package.json'
         - 'Assets/Mirror/CHANGELOG.md'

--- a/Assets/Mirror/Runtime/AssemblyInfo.cs
+++ b/Assets/Mirror/Runtime/AssemblyInfo.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using System.Runtime.CompilerServices;
 
 [assembly:AssemblyVersion("1.1.0.0")]

--- a/Assets/Mirror/Runtime/AssemblyInfo.cs
+++ b/Assets/Mirror/Runtime/AssemblyInfo.cs
@@ -1,5 +1,7 @@
 using System.Runtime.CompilerServices;
 
+[assembly:AssemblyVersion("1.1.0.0")]
+
 [assembly: InternalsVisibleTo("Mirror.Tests.Common")]
 [assembly: InternalsVisibleTo("Mirror.Tests")]
 [assembly: InternalsVisibleTo("Mirror.Tests.Generated")]


### PR DESCRIPTION
To access MirrorNG runtime version,  you can use:

```
typeof(NetworkIdentity).Assembly.GetName().Version.ToString()
```
