### PR TITLE
feat: Add ConnectAsync overload with port.

### DIFF
--- a/Assets/Mirror/Runtime/NetworkClient.cs
+++ b/Assets/Mirror/Runtime/NetworkClient.cs
@@ -116,6 +116,26 @@ namespace Mirror
 
             return ConnectAsync(builder.Uri);
         }
+
+        /// <summary>
+        /// Connect client to a NetworkServer instance.
+        /// </summary>
+        /// <param name="serverIp">Address of the server to connect to</param>
+        /// <param name="port">The port of the server to connect to</param>
+        public UniTask ConnectAsync(string serverIp, ushort port)
+        {
+            if (logger.LogEnabled()) logger.Log("Client address and port:" + serverIp + ":" + port);
+
+            var builder = new UriBuilder
+            {
+                Host = serverIp,
+                Port = port,
+                Scheme = Transport.Scheme.First()
+            };
+
+            return ConnectAsync(builder.Uri);
+        }
+
         /// <summary>
         /// Connect client to a NetworkServer instance.
         /// </summary>


### PR DESCRIPTION
Adds a simple overload to easily allow the user to connect to a server through a different port. Mainly just a method for the lazy, like me, or the ones that really don't know how to use the Uri builder. It makes joining different ports a bit more accessible. 