### PR TITLE
Allow for generic behaviours.

### DIFF
--- a/Assets/Mirror/Editor/Weaver/Processors/NetworkBehaviourProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/NetworkBehaviourProcessor.cs
@@ -39,13 +39,6 @@ namespace Mirror.Weaver
             }
             Weaver.DLog(netBehaviourSubclass, "Found NetworkBehaviour " + netBehaviourSubclass.FullName);
 
-            if (netBehaviourSubclass.HasGenericParameters)
-            {
-                Weaver.Error($"{netBehaviourSubclass.Name} cannot have generic parameters", netBehaviourSubclass);
-                // originally Process returned true in every case, except if already processed.
-                // maybe return false here in the future.
-                return true;
-            }
             Weaver.DLog(netBehaviourSubclass, "Process Start");
             MarkAsProcessed(netBehaviourSubclass);
 

--- a/Assets/Mirror/Editor/Weaver/Processors/RpcProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/RpcProcessor.cs
@@ -176,6 +176,12 @@ namespace Mirror.Weaver
                 return false;
             }
 
+            if (param.ParameterType.IsGenericParameter)
+            {
+                Weaver.Error($"{method.Name} cannot have generic parameters", method);
+                return false;
+            }
+
             if (IsNetworkConnection(param.ParameterType))
             {
                 if (callType == RemoteCallType.ClientRpc && firstParam)

--- a/Assets/Mirror/Editor/Weaver/Processors/SyncObjectProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/SyncObjectProcessor.cs
@@ -18,6 +18,11 @@ namespace Mirror.Weaver
         {
             foreach (FieldDefinition fd in td.Fields)
             {
+                if (fd.FieldType.IsGenericParameter) // Just ignore all generic objects.
+                {
+                    continue;
+                }
+
                 if (fd.FieldType.Resolve().ImplementsInterface<ISyncObject>())
                 {
                     if (fd.IsStatic)

--- a/Assets/Mirror/Editor/Weaver/Processors/SyncVarProcessor.cs
+++ b/Assets/Mirror/Editor/Weaver/Processors/SyncVarProcessor.cs
@@ -294,6 +294,12 @@ namespace Mirror.Weaver
                     continue;
                 }
 
+                if (fd.FieldType.IsGenericParameter)
+                {
+                    Weaver.Error($"{fd.Name} cannot be synced since it's a generic parameter", fd);
+                    continue;
+                }
+
                 if ((fd.Attributes & FieldAttributes.Static) != 0)
                 {
                     Weaver.Error($"{fd.Name} cannot be static", fd);

--- a/Assets/Tests/Editor/Weaver/WeaverNetworkBehaviourTests.cs
+++ b/Assets/Tests/Editor/Weaver/WeaverNetworkBehaviourTests.cs
@@ -17,13 +17,6 @@ namespace Mirror.Weaver.Tests
         }
 
         [Test]
-        public void NetworkBehaviourGeneric()
-        {
-            HasError("NetworkBehaviourGeneric`1 cannot have generic parameters",
-                "WeaverNetworkBehaviourTests.NetworkBehaviourGeneric.NetworkBehaviourGeneric`1");
-        }
-
-        [Test]
         public void NetworkBehaviourCmdGenericParam()
         {
             HasError("CmdCantHaveGeneric cannot have generic parameters",


### PR DESCRIPTION
This would allow network behaviours to be used together with generics. 
It doesn't allow for the generic to be used in a syncvar or RPC methods. Also removed Test that checks if generic behaviours are blocked.