### PR TITLE
fix: null reference destroying objects

### DIFF
--- a/Assets/Mirror/Runtime/ClientObjectManager.cs
+++ b/Assets/Mirror/Runtime/ClientObjectManager.cs
@@ -99,15 +99,6 @@ namespace Mirror
             client.Connection.RegisterHandler<RpcMessage>(OnRpcMessage);
         }
 
-        void OnDestroy()
-        {
-            client.Connected.RemoveListener(OnClientConnected);
-            client.Disconnected.RemoveListener(OnClientDisconnected);
-
-            if (networkSceneManager != null)
-                networkSceneManager.ClientSceneChanged.RemoveListener(OnClientSceneChanged);
-        }
-
         static bool ConsiderForSpawning(NetworkIdentity identity)
         {
             // not spawned yet, not hidden, etc.?

--- a/Assets/Mirror/Runtime/ServerObjectManager.cs
+++ b/Assets/Mirror/Runtime/ServerObjectManager.cs
@@ -70,14 +70,6 @@ namespace Mirror
             connection.RegisterHandler<ServerRpcMessage>(OnServerRpcMessage);
         }
 
-        void OnDestroy()
-        {
-            server.Started.RemoveListener(SpawnOrActivate);
-            server.Authenticated.RemoveListener(OnAuthenticated);
-            networkSceneManager.ServerChangeScene.RemoveListener(OnServerChangeScene);
-            networkSceneManager.ServerSceneChanged.RemoveListener(OnServerSceneChanged);
-        }
-
         void OnAuthenticated(INetworkConnection connection)
         {
             RegisterMessageHandlers(connection);


### PR DESCRIPTION
These are giving NullReferenceException,  they should not be
necesary because unityevents automatically removes subscribers
when they are destroyed.