### PR TITLE
feat: send NI, NB and GO in RPC

### DIFF
--- a/Assets/Mirror/Runtime/NetworkReader.cs
+++ b/Assets/Mirror/Runtime/NetworkReader.cs
@@ -440,5 +440,32 @@ namespace Mirror
         {
             return new Uri(reader.ReadString());
         }
+
+        public static NetworkBehaviour ReadNetworkBehaviour(this NetworkReader reader)
+        {
+            NetworkIdentity identity = reader.ReadNetworkIdentity();
+            if (identity == null)
+            {
+                return null;
+            }
+
+            byte componentIndex = reader.ReadByte();
+            return identity.NetworkBehaviours[componentIndex];
+        }
+
+        public static T ReadNetworkBehaviour<T>(this NetworkReader reader) where T : NetworkBehaviour
+        {
+            return reader.ReadNetworkBehaviour() as T;
+        }
+
+        public static GameObject ReadGameObject(this NetworkReader reader)
+        {
+            NetworkIdentity identity = reader.ReadNetworkIdentity();
+            if (identity == null)
+            {
+                return null;
+            }
+            return identity.gameObject;
+        }
     }
 }

--- a/Assets/Mirror/Runtime/NetworkWriter.cs
+++ b/Assets/Mirror/Runtime/NetworkWriter.cs
@@ -516,5 +516,29 @@ namespace Mirror
                 writer.Write(segment.Array[segment.Offset + i]);
             }
         }
+
+        public static void WriteNetworkBehaviour(this NetworkWriter writer, NetworkBehaviour value)
+        {
+            if (value == null)
+            {
+                writer.WriteUInt32(0);
+                return;
+            }
+            writer.WriteUInt32(value.NetId);
+            writer.WriteByte((byte)value.ComponentIndex);
+        }
+
+        public static void WriteGameObject(this NetworkWriter writer, GameObject value)
+        {
+            if (value == null)
+            {
+                writer.WriteUInt32(0);
+                return;
+            }
+            NetworkIdentity identity = value.GetComponent<NetworkIdentity>();
+            if (identity == null)
+                throw new InvalidOperationException($"Cannot send GameObject without a NetworkIdentity {value.name}");
+            writer.WriteNetworkIdentity(identity);
+        }
     }
 }

--- a/Assets/Mirror/Weaver/Readers.cs
+++ b/Assets/Mirror/Weaver/Readers.cs
@@ -72,6 +72,10 @@ namespace Mirror.Weaver
             {
                 return GenerateEnumReadFunc(typeReference);
             }
+            if (variableDefinition.IsDerivedFrom<NetworkBehaviour>())
+            {
+                return GetNetworkBehaviourReader(typeReference);
+            }
             if (variableDefinition.IsDerivedFrom<Component>())
             {
                 logger.Error($"Cannot generate reader for component type {typeReference.Name}. Use a supported type or provide a custom reader", typeReference);
@@ -115,6 +119,13 @@ namespace Mirror.Weaver
             }
 
             return GenerateClassOrStructReadFunction(typeReference);
+        }
+
+        private MethodReference GetNetworkBehaviourReader(TypeReference typeReference)
+        {
+            MethodReference readFunc = module.ImportReference<NetworkReader>((reader) => reader.ReadNetworkBehaviour());
+            Register(typeReference, readFunc);
+            return readFunc;
         }
 
         void RegisterReadFunc(TypeReference typeReference, MethodDefinition newReaderFunc)

--- a/Assets/Mirror/Weaver/Readers.cs
+++ b/Assets/Mirror/Weaver/Readers.cs
@@ -91,11 +91,6 @@ namespace Mirror.Weaver
                 logger.Error($"Cannot generate reader for {typeReference.Name}. Use a supported type or provide a custom reader", typeReference);
                 return null;
             }
-            if (typeReference.Is<GameObject>())
-            {
-                logger.Error($"Cannot generate reader for {typeReference.Name}. Use a supported type or provide a custom reader", typeReference);
-                return null;
-            }
             if (typeReference.IsByReference)
             {
                 // error??

--- a/Assets/Mirror/Weaver/Writers.cs
+++ b/Assets/Mirror/Weaver/Writers.cs
@@ -64,7 +64,7 @@ namespace Mirror.Weaver
         }
 
         /// <exception cref="GenerateWriterException">Throws when writer could not be generated for type</exception>
-        MethodDefinition GenerateWriter(TypeReference typeReference)
+        MethodReference GenerateWriter(TypeReference typeReference)
         {
             if (typeReference.IsByReference)
             {
@@ -112,6 +112,10 @@ namespace Mirror.Weaver
             {
                 throw new GenerateWriterException($"{typeReference.Name} is not a supported type. Use a supported type or provide a custom writer", typeReference);
             }
+            if (typeDefinition.IsDerivedFrom<NetworkBehaviour>())
+            {
+                return GetNetworkBehaviourWriter(typeReference);
+            }
             if (typeDefinition.IsDerivedFrom<UnityEngine.Component>())
             {
                 throw new GenerateWriterException($"Cannot generate writer for component type {typeReference.Name}. Use a supported type or provide a custom writer", typeReference);
@@ -143,6 +147,13 @@ namespace Mirror.Weaver
 
             // generate writer for class/struct
             return GenerateClassOrStructWriterFunction(typeReference);
+        }
+
+        private MethodReference GetNetworkBehaviourWriter(TypeReference typeReference)
+        {
+            MethodReference writeFunc = module.ImportReference<NetworkWriter>((nw) => nw.WriteNetworkBehaviour(default));
+            Register(typeReference, writeFunc);
+            return writeFunc;
         }
 
         private MethodDefinition GenerateEnumWriteFunc(TypeReference typeReference)

--- a/Assets/Mirror/Weaver/Writers.cs
+++ b/Assets/Mirror/Weaver/Writers.cs
@@ -128,10 +128,6 @@ namespace Mirror.Weaver
             {
                 throw new GenerateWriterException($"Cannot generate writer for {typeReference.Name}. Use a supported type or provide a custom writer", typeReference);
             }
-            if (typeReference.Is<UnityEngine.GameObject>())
-            {
-                throw new GenerateWriterException($"Cannot generate writer for {typeReference.Name}. Use a supported type or provide a custom writer", typeReference);
-            }
             if (typeDefinition.HasGenericParameters)
             {
                 throw new GenerateWriterException($"Cannot generate writer for generic type {typeReference.Name}. Use a supported type or provide a custom writer", typeReference);

--- a/Assets/Tests/Runtime/ClientServer/NetworkBehaviorRpcTest.cs
+++ b/Assets/Tests/Runtime/ClientServer/NetworkBehaviorRpcTest.cs
@@ -34,7 +34,7 @@ namespace Mirror.Tests
             onSendNetworkBehaviourCalled?.Invoke(value);
         }
 
-        [ServerRpc]
+        [ClientRpc]
         public void SendNetworkBehaviourDerived(SampleBehaviorWithRpc value)
         {
             onSendNetworkBehaviourDerivedCalled?.Invoke(value);
@@ -58,7 +58,7 @@ namespace Mirror.Tests
             onSendNetworkBehaviourCalled?.Invoke(value);
         }
 
-        [ClientRpc]
+        [ServerRpc]
         public void SendNetworkBehaviourDerivedToServer(SampleBehaviorWithRpc value)
         {
             onSendNetworkBehaviourDerivedCalled?.Invoke(value);

--- a/Assets/Tests/Runtime/ClientServer/NetworkBehaviorRpcTest.cs
+++ b/Assets/Tests/Runtime/ClientServer/NetworkBehaviorRpcTest.cs
@@ -1,0 +1,89 @@
+﻿using System;
+using System.Collections;
+using Cysharp.Threading.Tasks;
+using NSubstitute;
+using UnityEngine;
+using UnityEngine.TestTools;
+using System.Linq;
+
+namespace Mirror.Tests
+{
+    public class SampleBehaviorWithRpc : NetworkBehaviour
+    {
+        public event Action<NetworkIdentity> onSendNetworkIdentityCalled;
+        public event Action<GameObject> onSendGameObjectCalled;
+        public event Action<NetworkBehaviour> onSendNetworkBehaviourCalled;
+        public event Action<SampleBehaviorWithRpc> onSendNetworkBehaviourDerivedCalled;
+
+        [ClientRpc]
+        public void SendNetworkIdentity(NetworkIdentity value)
+        {
+            onSendNetworkIdentityCalled?.Invoke(value);
+        }
+
+        [ClientRpc]
+        public void SendGameObject(GameObject value)
+        {
+            onSendGameObjectCalled?.Invoke(value);
+        }
+
+        [ClientRpc]
+        public void SendNetworkBehaviour(NetworkBehaviour value)
+        {
+            onSendNetworkBehaviourCalled?.Invoke(value);
+        }
+
+        [ClientRpc]
+        public void SendNetworkBehaviourDerived(SampleBehaviorWithRpc value)
+        {
+            onSendNetworkBehaviourDerivedCalled?.Invoke(value);
+        }
+    }
+
+    public class NetworkBehaviorRPCTest : ClientServerSetup<SampleBehaviorWithRpc>
+    {
+        [UnityTest]
+        public IEnumerator RpcCanSendNetworkIdentity() => UniTask.ToCoroutine(async () =>
+        {
+            Action<NetworkIdentity> callback = Substitute.For<Action<NetworkIdentity>>();
+            clientComponent.onSendNetworkIdentityCalled += callback;
+
+            serverComponent.SendNetworkIdentity(serverIdentity);
+            await UniTask.WaitUntil(() => callback.ReceivedCalls().Count() > 0);
+            callback.Received().Invoke(clientIdentity);
+        });
+
+        [UnityTest]
+        public IEnumerator RpcCanSendNetworkBehavior() => UniTask.ToCoroutine(async () =>
+        {
+            Action<NetworkBehaviour> callback = Substitute.For<Action<NetworkBehaviour>>();
+            clientComponent.onSendNetworkBehaviourCalled += callback;
+
+            serverComponent.SendNetworkBehaviour(serverComponent);
+            await UniTask.WaitUntil(() => callback.ReceivedCalls().Count() > 0);
+            callback.Received().Invoke(clientComponent);
+        });
+
+        [UnityTest]
+        public IEnumerator RpcCanSendNetworkBehaviorChild() => UniTask.ToCoroutine(async () =>
+        {
+            Action<SampleBehaviorWithRpc> callback = Substitute.For<Action<SampleBehaviorWithRpc>>();
+            clientComponent.onSendNetworkBehaviourDerivedCalled += callback;
+
+            serverComponent.SendNetworkBehaviour(serverComponent);
+            await UniTask.WaitUntil(() => callback.ReceivedCalls().Count() > 0);
+            callback.Received().Invoke(clientComponent);
+        });
+
+        [UnityTest]
+        public IEnumerator RpcCanSendGameObject() => UniTask.ToCoroutine(async () =>
+        {
+            Action<GameObject> callback = Substitute.For<Action<GameObject>>();
+            clientComponent.onSendGameObjectCalled += callback;
+
+            serverComponent.SendGameObject(serverGo);
+            await UniTask.WaitUntil(() => callback.ReceivedCalls().Count() > 0);
+            callback.Received().Invoke(clientGo);
+        });
+    }
+}

--- a/Assets/Tests/Runtime/ClientServer/NetworkBehaviorRpcTest.cs
+++ b/Assets/Tests/Runtime/ClientServer/NetworkBehaviorRpcTest.cs
@@ -5,6 +5,7 @@ using NSubstitute;
 using UnityEngine;
 using UnityEngine.TestTools;
 using System.Linq;
+using NUnit.Framework;
 
 namespace Mirror.Tests
 {
@@ -70,7 +71,7 @@ namespace Mirror.Tests
             Action<SampleBehaviorWithRpc> callback = Substitute.For<Action<SampleBehaviorWithRpc>>();
             clientComponent.onSendNetworkBehaviourDerivedCalled += callback;
 
-            serverComponent.SendNetworkBehaviour(serverComponent);
+            serverComponent.SendNetworkBehaviourDerived(serverComponent);
             await UniTask.WaitUntil(() => callback.ReceivedCalls().Count() > 0);
             callback.Received().Invoke(clientComponent);
         });
@@ -81,9 +82,22 @@ namespace Mirror.Tests
             Action<GameObject> callback = Substitute.For<Action<GameObject>>();
             clientComponent.onSendGameObjectCalled += callback;
 
-            serverComponent.SendGameObject(serverGo);
+            serverComponent.SendGameObject(serverPlayerGO);
             await UniTask.WaitUntil(() => callback.ReceivedCalls().Count() > 0);
-            callback.Received().Invoke(clientGo);
+            callback.Received().Invoke(clientPlayerGO);
         });
+
+        [Test]
+        public void RpcSendInvalidGO()
+        {
+            Action<GameObject> callback = Substitute.For<Action<GameObject>>();
+            clientComponent.onSendGameObjectCalled += callback;
+
+            // this object does not have a NI, so this should error out
+            Assert.Throws<InvalidOperationException>(() =>
+            {
+                serverComponent.SendGameObject(serverGo);
+            });
+        }
     }
 }

--- a/Assets/Tests/Runtime/ClientServer/NetworkBehaviorRpcTest.cs
+++ b/Assets/Tests/Runtime/ClientServer/NetworkBehaviorRpcTest.cs
@@ -50,7 +50,7 @@ namespace Mirror.Tests
             clientComponent.onSendNetworkIdentityCalled += callback;
 
             serverComponent.SendNetworkIdentity(serverIdentity);
-            await UniTask.WaitUntil(() => callback.ReceivedCalls().Count() > 0);
+            await UniTask.WaitUntil(() => callback.ReceivedCalls().Any());
             callback.Received().Invoke(clientIdentity);
         });
 
@@ -61,7 +61,7 @@ namespace Mirror.Tests
             clientComponent.onSendNetworkBehaviourCalled += callback;
 
             serverComponent.SendNetworkBehaviour(serverComponent);
-            await UniTask.WaitUntil(() => callback.ReceivedCalls().Count() > 0);
+            await UniTask.WaitUntil(() => callback.ReceivedCalls().Any());
             callback.Received().Invoke(clientComponent);
         });
 
@@ -72,7 +72,7 @@ namespace Mirror.Tests
             clientComponent.onSendNetworkBehaviourDerivedCalled += callback;
 
             serverComponent.SendNetworkBehaviourDerived(serverComponent);
-            await UniTask.WaitUntil(() => callback.ReceivedCalls().Count() > 0);
+            await UniTask.WaitUntil(() => callback.ReceivedCalls().Any());
             callback.Received().Invoke(clientComponent);
         });
 
@@ -83,7 +83,7 @@ namespace Mirror.Tests
             clientComponent.onSendGameObjectCalled += callback;
 
             serverComponent.SendGameObject(serverPlayerGO);
-            await UniTask.WaitUntil(() => callback.ReceivedCalls().Count() > 0);
+            await UniTask.WaitUntil(() => callback.ReceivedCalls().Any());
             callback.Received().Invoke(clientPlayerGO);
         });
 

--- a/Assets/Tests/Runtime/ClientServer/NetworkBehaviorRpcTest.cs
+++ b/Assets/Tests/Runtime/ClientServer/NetworkBehaviorRpcTest.cs
@@ -127,6 +127,51 @@ namespace Mirror.Tests
         }
 
         [UnityTest]
+        public IEnumerator SendNullNetworkIdentity() => UniTask.ToCoroutine(async () =>
+        {
+            Action<NetworkIdentity> callback = Substitute.For<Action<NetworkIdentity>>();
+            clientComponent.onSendNetworkIdentityCalled += callback;
+
+            serverComponent.SendNetworkIdentity(null);
+            await UniTask.WaitUntil(() => callback.ReceivedCalls().Any());
+            callback.Received().Invoke(null);
+        });
+
+        [UnityTest]
+        public IEnumerator SendNullNetworkBehavior() => UniTask.ToCoroutine(async () =>
+        {
+            Action<NetworkBehaviour> callback = Substitute.For<Action<NetworkBehaviour>>();
+            clientComponent.onSendNetworkBehaviourCalled += callback;
+
+            serverComponent.SendNetworkBehaviour(null);
+            await UniTask.WaitUntil(() => callback.ReceivedCalls().Any());
+            callback.Received().Invoke(null);
+        });
+
+        [UnityTest]
+        public IEnumerator SendNullNetworkBehaviorChild() => UniTask.ToCoroutine(async () =>
+        {
+            Action<SampleBehaviorWithRpc> callback = Substitute.For<Action<SampleBehaviorWithRpc>>();
+            clientComponent.onSendNetworkBehaviourDerivedCalled += callback;
+
+            serverComponent.SendNetworkBehaviourDerived(null);
+            await UniTask.WaitUntil(() => callback.ReceivedCalls().Any());
+            callback.Received().Invoke(null);
+        });
+
+        [UnityTest]
+        public IEnumerator SendNullGameObject() => UniTask.ToCoroutine(async () =>
+        {
+            Action<GameObject> callback = Substitute.For<Action<GameObject>>();
+            clientComponent.onSendGameObjectCalled += callback;
+
+            serverComponent.SendGameObject(null);
+            await UniTask.WaitUntil(() => callback.ReceivedCalls().Any());
+            callback.Received().Invoke(null);
+        });
+
+
+        [UnityTest]
         public IEnumerator SendNetworkIdentityToServer() => UniTask.ToCoroutine(async () =>
         {
             Action<NetworkIdentity> callback = Substitute.For<Action<NetworkIdentity>>();

--- a/Assets/Tests/Runtime/ClientServer/NetworkBehaviorRpcTest.cs.meta
+++ b/Assets/Tests/Runtime/ClientServer/NetworkBehaviorRpcTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d7403bbf156c4406aa234d9b7d48aa1d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Weaver/WeaverNetworkBehaviourTests.cs
+++ b/Assets/Tests/Weaver/WeaverNetworkBehaviourTests.cs
@@ -217,5 +217,11 @@ namespace Mirror.Weaver.Tests
             HasError("Duplicate Rpc name CmdCantHaveSameName",
                 "System.Void WeaverNetworkBehaviourTests.NetworkBehaviourCmdDuplicateName.NetworkBehaviourCmdDuplicateName::CmdCantHaveSameName(System.Int32,System.Int32)");
         }
+
+        [Test]
+        public void NetworkBehaviourChild()
+        {
+            IsSuccess();
+        }
     }
 }

--- a/Assets/Tests/Weaver/WeaverNetworkBehaviourTests.cs
+++ b/Assets/Tests/Weaver/WeaverNetworkBehaviourTests.cs
@@ -208,14 +208,7 @@ namespace Mirror.Weaver.Tests
         [Test]
         public void NetworkBehaviourCmdParamGameObject()
         {
-            HasError("Cannot generate writer for GameObject. Use a supported type or provide a custom writer",
-                "UnityEngine.GameObject");
-            HasError("CmdCantHaveGameObjectComponent has invalid parameter monkeyComp",
-                "System.Void WeaverNetworkBehaviourTests.NetworkBehaviourCmdParamGameObject.NetworkBehaviourCmdParamGameObject::CmdCantHaveGameObjectComponent(UnityEngine.GameObject)");
-            HasError("Cannot generate reader for GameObject. Use a supported type or provide a custom reader",
-                "UnityEngine.GameObject");
-            HasError("CmdCantHaveGameObjectComponent has invalid parameter monkeyComp.  Unsupported type UnityEngine.GameObject,  use a supported MirrorNG type instead",
-                "System.Void WeaverNetworkBehaviourTests.NetworkBehaviourCmdParamGameObject.NetworkBehaviourCmdParamGameObject::CmdCantHaveGameObjectComponent(UnityEngine.GameObject)");
+            IsSuccess();
         }
 
         [Test]

--- a/Assets/Tests/Weaver/WeaverNetworkBehaviourTests~/NetworkBehaviourChild.cs
+++ b/Assets/Tests/Weaver/WeaverNetworkBehaviourTests~/NetworkBehaviourChild.cs
@@ -1,0 +1,12 @@
+using Mirror;
+
+namespace WeaverNetworkBehaviourTests.NetworkBehaviourChild
+{
+    class NetworkBehaviourChild : NetworkBehaviour
+    {
+        
+        [ServerRpc]
+        public void SendNBChild(NetworkBehaviourChild nb) {
+        }
+    }
+}


### PR DESCRIPTION
It is now valid to send NetworkIdentity, NetworkBehaviors and GameObjects as RPC parameters.
NG will serialize the gameobject id and component index where appropriate and do the lookup in the other side.