### PR TITLE
perf: NetId is now 2 bytes instead of 4

### DIFF
--- a/Assets/Mirror/Runtime/ClientObjectManager.cs
+++ b/Assets/Mirror/Runtime/ClientObjectManager.cs
@@ -373,7 +373,7 @@ namespace Mirror
             ApplySpawnPayload(identity, msg);
         }
 
-        NetworkIdentity GetExistingObject(uint netid)
+        NetworkIdentity GetExistingObject(ushort netid)
         {
             client.Spawned.TryGetValue(netid, out NetworkIdentity localObject);
             return localObject;
@@ -446,7 +446,7 @@ namespace Mirror
             DestroyObject(msg.netId);
         }
 
-        void DestroyObject(uint netId)
+        void DestroyObject(ushort netId)
         {
             if (logger.LogEnabled()) logger.Log("ClientScene.OnObjDestroy netId:" + netId);
 

--- a/Assets/Mirror/Runtime/GameObjectSyncvar.cs
+++ b/Assets/Mirror/Runtime/GameObjectSyncvar.cs
@@ -14,11 +14,11 @@ namespace Mirror
         /// used to lookup the identity if it exists
         /// </summary>
         internal NetworkClient client;
-        internal uint netId;
+        internal ushort netId;
 
         internal GameObject gameObject;
 
-        internal uint NetId => gameObject != null ? gameObject.GetComponent<NetworkIdentity>().NetId : netId;
+        internal ushort NetId => gameObject != null ? gameObject.GetComponent<NetworkIdentity>().NetId : netId;
 
         public GameObject Value
         {
@@ -51,12 +51,12 @@ namespace Mirror
     {
         public static void WriteGameObjectSyncVar(this NetworkWriter writer, GameObjectSyncvar id)
         {
-            writer.WritePackedUInt32(id.NetId);
+            writer.WriteUInt16(id.NetId);
         }
 
         public static GameObjectSyncvar ReadGameObjectSyncVar(this NetworkReader reader)
         {
-            uint netId = reader.ReadPackedUInt32();
+            ushort netId = reader.ReadUInt16();
 
             NetworkIdentity identity = null;
             if (!(reader.Client is null))

--- a/Assets/Mirror/Runtime/Messages.cs
+++ b/Assets/Mirror/Runtime/Messages.cs
@@ -34,7 +34,7 @@ namespace Mirror
     #region System Messages requried for code gen path
     public struct ServerRpcMessage
     {
-        public uint netId;
+        public ushort netId;
         public int componentIndex;
         public int functionHash;
 
@@ -54,7 +54,7 @@ namespace Mirror
 
     public struct RpcMessage
     {
-        public uint netId;
+        public ushort netId;
         public int componentIndex;
         public int functionHash;
         // the parameters for the Cmd function
@@ -69,7 +69,7 @@ namespace Mirror
         /// <summary>
         /// netId of new or existing object
         /// </summary>
-        public uint netId;
+        public ushort netId;
         /// <summary>
         /// Is the spawning object the local player. Sets ClientScene.localPlayer
         /// </summary>
@@ -108,17 +108,17 @@ namespace Mirror
 
     public struct ObjectDestroyMessage
     {
-        public uint netId;
+        public ushort netId;
     }
 
     public struct ObjectHideMessage
     {
-        public uint netId;
+        public ushort netId;
     }
 
     public struct UpdateVarsMessage
     {
-        public uint netId;
+        public ushort netId;
         // the serialized component data
         // -> ArraySegment to avoid unnecessary allocations
         public ArraySegment<byte> payload;

--- a/Assets/Mirror/Runtime/NetworkBehaviorSyncvar.cs
+++ b/Assets/Mirror/Runtime/NetworkBehaviorSyncvar.cs
@@ -12,12 +12,12 @@
         /// used to lookup the identity if it exists
         /// </summary>
         internal NetworkClient client;
-        internal uint netId;
+        internal ushort netId;
         internal int componentId;
 
         internal NetworkBehaviour component;
 
-        internal uint NetId => component != null ? component.NetId : netId;
+        internal ushort NetId => component != null ? component.NetId : netId;
         internal int ComponentId => component != null ? component.ComponentIndex : componentId;
 
         public NetworkBehaviour Value
@@ -54,13 +54,13 @@
     {
         public static void WriteNetworkBehaviorSyncVar(this NetworkWriter writer, NetworkBehaviorSyncvar id)
         {
-            writer.WritePackedUInt32(id.NetId);
+            writer.WriteUInt16(id.NetId);
             writer.WritePackedInt32(id.ComponentId);
         }
 
         public static NetworkBehaviorSyncvar ReadNetworkBehaviourSyncVar(this NetworkReader reader)
         {
-            uint netId = reader.ReadPackedUInt32();
+            ushort netId = reader.ReadUInt16();
             int componentId = reader.ReadPackedInt32();
 
             NetworkIdentity identity = null;

--- a/Assets/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirror/Runtime/NetworkBehaviour.cs
@@ -85,7 +85,7 @@ namespace Mirror
         /// The unique network Id of this object.
         /// <para>This is assigned at runtime by the network server and will be unique for all objects for that network session.</para>
         /// </summary>
-        public uint NetId => NetIdentity.NetId;
+        public ushort NetId => NetIdentity.NetId;
 
         /// <summary>
         /// The <see cref="NetworkServer">NetworkClient</see> associated to this object.

--- a/Assets/Mirror/Runtime/NetworkClient.cs
+++ b/Assets/Mirror/Runtime/NetworkClient.cs
@@ -31,7 +31,7 @@ namespace Mirror
         [Tooltip("Authentication component attached to this object")]
         public NetworkAuthenticator authenticator;
 
-        internal readonly Dictionary<uint, NetworkIdentity> spawned = new Dictionary<uint, NetworkIdentity>();
+        internal readonly Dictionary<ushort, NetworkIdentity> spawned = new Dictionary<ushort, NetworkIdentity>();
 
         /// <summary>
         /// Event fires once the Client has connected its Server.
@@ -78,7 +78,7 @@ namespace Mirror
         /// <summary>
         /// List of all objects spawned in this client
         /// </summary>
-        public Dictionary<uint, NetworkIdentity> Spawned
+        public Dictionary<ushort, NetworkIdentity> Spawned
         {
             get
             {

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -147,7 +147,7 @@ namespace Mirror
         /// Unique identifier for this particular object instance, used for tracking objects between networked clients and the server.
         /// <para>This is a unique identifier for this particular GameObject instance. Use it to track GameObjects between networked clients and the server.</para>
         /// </summary>
-        public uint NetId { get; internal set; }
+        public ushort NetId { get; internal set; }
 
         /// <summary>
         /// A unique identifier for NetworkIdentity objects within a scene.

--- a/Assets/Mirror/Runtime/NetworkIdentitySyncvar.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentitySyncvar.cs
@@ -12,11 +12,11 @@
         /// used to lookup the identity if it exists
         /// </summary>
         internal NetworkClient client;
-        internal uint netId;
+        internal ushort netId;
 
         internal NetworkIdentity identity;
 
-        internal uint NetId => identity != null ? identity.NetId : netId;
+        internal ushort NetId => identity != null ? identity.NetId : netId;
 
         public NetworkIdentity Value
         {
@@ -48,12 +48,12 @@
     {
         public static void WriteNetworkIdentitySyncVar(this NetworkWriter writer, NetworkIdentitySyncvar id)
         {
-            writer.WritePackedUInt32(id.NetId);
+            writer.WriteUInt16(id.NetId);
         }
 
         public static NetworkIdentitySyncvar ReadNetworkIdentitySyncVar(this NetworkReader reader)
         {
-            uint netId = reader.ReadPackedUInt32();
+            ushort netId = reader.ReadUInt16();
 
             NetworkIdentity identity = null;
             if (!(reader.Client is null))

--- a/Assets/Mirror/Runtime/NetworkReader.cs
+++ b/Assets/Mirror/Runtime/NetworkReader.cs
@@ -389,7 +389,7 @@ namespace Mirror
 
         public static NetworkIdentity ReadNetworkIdentity(this NetworkReader reader)
         {
-            uint netId = reader.ReadPackedUInt32();
+            ushort netId = reader.ReadUInt16();
             if (netId == 0)
                 return null;
 

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -106,7 +106,7 @@ namespace Mirror
         /// </summary>
         public bool Active { get; private set; }
 
-        public readonly Dictionary<uint, NetworkIdentity> Spawned = new Dictionary<uint, NetworkIdentity>();
+        public readonly Dictionary<ushort, NetworkIdentity> Spawned = new Dictionary<ushort, NetworkIdentity>();
 
         // Time kept in this server
         public readonly NetworkTime Time = new NetworkTime();

--- a/Assets/Mirror/Runtime/NetworkWriter.cs
+++ b/Assets/Mirror/Runtime/NetworkWriter.cs
@@ -472,10 +472,10 @@ namespace Mirror
         {
             if (value == null)
             {
-                writer.WritePackedUInt32(0);
+                writer.WriteUInt16(0);
                 return;
             }
-            writer.WritePackedUInt32(value.NetId);
+            writer.WriteUInt16(value.NetId);
         }
 
         public static void WriteUri(this NetworkWriter writer, Uri uri)

--- a/Assets/Mirror/Runtime/ServerObjectManager.cs
+++ b/Assets/Mirror/Runtime/ServerObjectManager.cs
@@ -24,9 +24,16 @@ namespace Mirror
         public NetworkServer server;
         public NetworkSceneManager networkSceneManager;
 
-        uint nextNetworkId = 1;
-        uint GetNextNetworkId() => nextNetworkId++;
-
+        ushort nextNetworkId = 1;
+        ushort GetNextNetworkId()
+        {
+            ushort next;
+            do
+            {
+                next = nextNetworkId++;
+            } while (next == 0 || server.Spawned.ContainsKey(next));
+            return next;
+        }
 
         public readonly HashSet<NetworkIdentity> DirtyObjects = new HashSet<NetworkIdentity>();
         private readonly List<NetworkIdentity> DirtyObjectsTmp = new List<NetworkIdentity>();

--- a/Assets/Mirror/Runtime/ServerObjectManager.cs
+++ b/Assets/Mirror/Runtime/ServerObjectManager.cs
@@ -27,12 +27,18 @@ namespace Mirror
         ushort nextNetworkId = 1;
         ushort GetNextNetworkId()
         {
-            ushort next;
-            do
+            // After a while,  the ids will wrap around,  it is possible
+            // that there might be an object already using the next id
+            // so we need to find a valid id that is not used
+            unchecked
             {
-                next = nextNetworkId++;
-            } while (next == 0 || server.Spawned.ContainsKey(next));
-            return next;
+                ushort next;
+                do
+                {
+                    next = nextNetworkId++;
+                } while (next == 0 || server.Spawned.ContainsKey(next));
+                return next;
+            }
         }
 
         public readonly HashSet<NetworkIdentity> DirtyObjects = new HashSet<NetworkIdentity>();

--- a/Assets/Mirror/Samples~/Tanks/Scripts/TankGameManager.cs
+++ b/Assets/Mirror/Samples~/Tanks/Scripts/TankGameManager.cs
@@ -84,7 +84,7 @@ namespace Mirror.Examples.Tanks
 
         void CheckPlayersNotInList()
         {
-            foreach (KeyValuePair<uint, NetworkIdentity> kvp in NetworkManager.client.Spawned)
+            foreach (KeyValuePair<ushort, NetworkIdentity> kvp in NetworkManager.client.Spawned)
             {
                 Tank comp = kvp.Value.GetComponent<Tank>();
                 if (comp != null && !players.Contains(comp))

--- a/Assets/Tests/Runtime/ClientServer/GameObjectSyncvarTest.cs
+++ b/Assets/Tests/Runtime/ClientServer/GameObjectSyncvarTest.cs
@@ -62,7 +62,7 @@ namespace Mirror.Tests
             serverObjectManager.Spawn(newObject);
 
             // wait until the client spawns it
-            uint newObjectId = newBehavior.NetId;
+            ushort newObjectId = newBehavior.NetId;
             await UniTask.WaitUntil(() => client.Spawned.ContainsKey(newObjectId));
 
             // check if the target was set correctly in the client

--- a/Assets/Tests/Runtime/ClientServer/NetworkBehaviorSyncvarTest.cs
+++ b/Assets/Tests/Runtime/ClientServer/NetworkBehaviorSyncvarTest.cs
@@ -61,7 +61,7 @@ namespace Mirror.Tests
             serverObjectManager.Spawn(newObject);
 
             // wait until the client spawns it
-            uint newObjectId = newBehavior.NetId;
+            ushort newObjectId = newBehavior.NetId;
             await UniTask.WaitUntil(() => client.Spawned.ContainsKey(newObjectId));
 
             // check if the target was set correctly in the client

--- a/Assets/Tests/Runtime/ClientServer/NetworkIdentitySyncvarTest.cs
+++ b/Assets/Tests/Runtime/ClientServer/NetworkIdentitySyncvarTest.cs
@@ -61,7 +61,7 @@ namespace Mirror.Tests
             serverObjectManager.Spawn(newObject);
 
             // wait until the client spawns it
-            uint newObjectId = newBehavior.NetId;
+            ushort newObjectId = newBehavior.NetId;
             await UniTask.WaitUntil(() => client.Spawned.ContainsKey(newObjectId));
 
             // check if the target was set correctly in the client


### PR DESCRIPTION
NetId is now a ushort instead of uint.
That means the max amount of networked objects is 65K
Note NetId can now be recycled after a while.
Tx to MrGadget for the idea.

BREAKING CHANGE: NetId is now a ushort instead of uint