### PR TITLE
fix: invalid IL with NI syncvars with hooks

### DIFF
--- a/Assets/Mirror/Weaver/Processors/SyncVarProcessor.cs
+++ b/Assets/Mirror/Weaver/Processors/SyncVarProcessor.cs
@@ -349,7 +349,7 @@ namespace Mirror.Weaver
             GenerateDeSerialization(td);
         }
 
-        static void WriteCallHookMethodUsingArgument(ILProcessor worker, MethodDefinition hookMethod, VariableDefinition oldValue)
+        void WriteCallHookMethodUsingArgument(ILProcessor worker, MethodDefinition hookMethod, VariableDefinition oldValue)
         {
             WriteCallHookMethod(worker, hookMethod, oldValue, null);
         }
@@ -364,7 +364,7 @@ namespace Mirror.Weaver
             WriteCallHookMethod(worker, hookMethod, oldValue, newValue);
         }
 
-        static void WriteCallHookMethod(ILProcessor worker, MethodDefinition hookMethod, VariableDefinition oldValue, FieldDefinition newValue)
+        void WriteCallHookMethod(ILProcessor worker, MethodDefinition hookMethod, VariableDefinition oldValue, FieldDefinition newValue)
         {
             WriteStartFunctionCall();
 
@@ -392,10 +392,7 @@ namespace Mirror.Weaver
                 }
                 else
                 {
-                    // this.
-                    worker.Append(worker.Create(OpCodes.Ldarg_0));
-                    // syncvar.get
-                    worker.Append(worker.Create(OpCodes.Ldfld, newValue));
+                    LoadField(newValue, worker);
                 }
             }
 

--- a/Assets/Tests/Runtime/ClientServer/NetworkIdentitySyncvarTest.cs
+++ b/Assets/Tests/Runtime/ClientServer/NetworkIdentitySyncvarTest.cs
@@ -12,7 +12,7 @@ namespace Mirror.Tests.ClientServer
 
         public void OnTargetChange(NetworkIdentity oldIdentity, NetworkIdentity networkIdentity)
         {
-
+            Assert.That(networkIdentity, Is.SameAs(target));
         }
     }
 

--- a/Assets/Tests/Runtime/ClientServer/NetworkIdentitySyncvarTest.cs
+++ b/Assets/Tests/Runtime/ClientServer/NetworkIdentitySyncvarTest.cs
@@ -10,7 +10,7 @@ namespace Mirror.Tests.ClientServer
         [SyncVar(hook = nameof(OnTargetChange))]
         public NetworkIdentity target;
 
-        public void OnTargetChange(NetworkIdentity oldIdentity, NetworkIdentity networkIdentity)
+        public void OnTargetChange(NetworkIdentity _, NetworkIdentity networkIdentity)
         {
             Assert.That(networkIdentity, Is.SameAs(target));
         }

--- a/Assets/Tests/Runtime/ClientServer/NetworkIdentitySyncvarTest.cs
+++ b/Assets/Tests/Runtime/ClientServer/NetworkIdentitySyncvarTest.cs
@@ -7,8 +7,13 @@ namespace Mirror.Tests.ClientServer
 {
     public class SampleBehaviorWithNI : NetworkBehaviour
     {
-        [SyncVar]
+        [SyncVar(hook = nameof(OnTargetChange))]
         public NetworkIdentity target;
+
+        public void OnTargetChange(NetworkIdentity oldIdentity, NetworkIdentity networkIdentity)
+        {
+
+        }
     }
 
     public class NetworkIdentitySyncvarTest : ClientServerSetup<SampleBehaviorWithNI>


### PR DESCRIPTION
Test and fix this error:
: Closed connection: connection(127.0.0.1:0). Invalid message System.InvalidProgramException:
Invalid IL code in Mirror.Tests.ClientServer.SampleBehaviorWithNI:DeserializeSyncVars (Mirror.NetworkReader,bool): IL_0057: callvirt  0x06000570