### PR TITLE
fix: error saving field name SYNC_VAR_COUNT

### DIFF
--- a/Assets/Mirror/Weaver/Extensions.cs
+++ b/Assets/Mirror/Weaver/Extensions.cs
@@ -53,7 +53,7 @@ namespace Mirror.Weaver
 
             if (field == null)
             {
-                field = new FieldDefinition(fieldName, FieldAttributes.Literal, td.Module.ImportReference<T>());
+                field = new FieldDefinition(fieldName, FieldAttributes.Literal| FieldAttributes.NotSerialized | FieldAttributes.Private, td.Module.ImportReference<T>());
                 td.Fields.Add(field);
             }
 


### PR DESCRIPTION
Unity is generating this error
> The same field name is serialized multiple times in the class or it's parent class.
> This is not supported: Base(NetworkTransform) SYNC_VAR_COUNT

when you have a multiple levels of inheritance in network behaviours