### PR TITLE
perf: avoid weaving editor scripts

### DIFF
--- a/Assets/Mirror/Weaver/MirrorILPostProcessor.cs
+++ b/Assets/Mirror/Weaver/MirrorILPostProcessor.cs
@@ -3,8 +3,6 @@ using System.Linq;
 using System.IO;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
-using System;
-using UnityEditor.Compilation;
 
 namespace Mirror.Weaver
 {

--- a/Assets/Mirror/Weaver/MirrorILPostProcessor.cs
+++ b/Assets/Mirror/Weaver/MirrorILPostProcessor.cs
@@ -4,12 +4,14 @@ using System.IO;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
 using System;
+using UnityEditor.Compilation;
 
 namespace Mirror.Weaver
 {
     public class MirrorILPostProcessor : ILPostProcessor
     {
         public const string RuntimeAssemblyName = "Mirror";
+        public const string EditorAssemblyName = "Mirror.Editor";
 
         public override ILPostProcessor GetInstance() => this;
 
@@ -41,13 +43,14 @@ namespace Mirror.Weaver
 
         public override bool WillProcess(ICompiledAssembly compiledAssembly)
         {
-            bool result = 
-            compiledAssembly.Name == RuntimeAssemblyName ||
-            compiledAssembly.References.Any(filePath => Path.GetFileNameWithoutExtension(filePath) == RuntimeAssemblyName);
+            bool usesMirror = 
+                compiledAssembly.Name == RuntimeAssemblyName ||
+                compiledAssembly.References.Any(filePath => Path.GetFileNameWithoutExtension(filePath) == RuntimeAssemblyName);
 
-            Console.WriteLine($"checking Assembly {compiledAssembly.Name}, weaving: {result}");
-            return result;
+            bool usesMirrorEditor =
+                compiledAssembly.References.Any(filePath => Path.GetFileNameWithoutExtension(filePath) == EditorAssemblyName);
 
+            return usesMirror && !usesMirrorEditor;
         }
     }
 }

--- a/Assets/Mirror/Weaver/MirrorILPostProcessor.cs
+++ b/Assets/Mirror/Weaver/MirrorILPostProcessor.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.IO;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
+using System;
 
 namespace Mirror.Weaver
 {

--- a/Assets/Mirror/Weaver/MirrorILPostProcessor.cs
+++ b/Assets/Mirror/Weaver/MirrorILPostProcessor.cs
@@ -38,8 +38,15 @@ namespace Mirror.Weaver
             return new ILPostProcessResult(new InMemoryAssembly(pe.ToArray(), pdb.ToArray()), logger.Diagnostics);
         }
 
-        public override bool WillProcess(ICompiledAssembly compiledAssembly) =>
-                compiledAssembly.Name == RuntimeAssemblyName ||
-                compiledAssembly.References.Any(filePath => Path.GetFileNameWithoutExtension(filePath) == RuntimeAssemblyName);
+        public override bool WillProcess(ICompiledAssembly compiledAssembly)
+        {
+            bool result = 
+            compiledAssembly.Name == RuntimeAssemblyName ||
+            compiledAssembly.References.Any(filePath => Path.GetFileNameWithoutExtension(filePath) == RuntimeAssemblyName);
+
+            Console.WriteLine($"checking Assembly {compiledAssembly.Name}, weaving: {result}");
+            return result;
+
+        }
     }
 }


### PR DESCRIPTION
Avoid weaving editor scripts including Assembly-CSharp-Editor.dll

We were already not expecting editor scripts to be weaved,  but this actively prevents it. 
Speeds up weaving a few seconds