### PR TITLE
feat: transports can report bandwidth

### DIFF
--- a/Assets/Mirror/Runtime/Transport/Kcp/KcpServerConnection.cs
+++ b/Assets/Mirror/Runtime/Transport/Kcp/KcpServerConnection.cs
@@ -8,6 +8,8 @@ namespace Mirror.KCP
 {
     public class KcpServerConnection : KcpConnection
     {
+        internal event Action<int> DataSent;
+
         public KcpServerConnection(Socket socket, EndPoint remoteEndpoint, KcpDelayMode delayMode, int sendWindowSize, int receiveWindowSize) : base(delayMode, sendWindowSize, receiveWindowSize)
         {
             this.socket = socket;
@@ -34,8 +36,10 @@ namespace Mirror.KCP
                 throw new InvalidDataException("No handshake received", ex);
             }
         }
+
         protected override void RawSend(byte[] data, int length)
         {
+            DataSent?.Invoke(length);
             socket.SendTo(data, 0, length, SocketFlags.None, remoteEndpoint);
         }
     }

--- a/Assets/Mirror/Runtime/Transport/Kcp/KcpTransport.cs
+++ b/Assets/Mirror/Runtime/Transport/Kcp/KcpTransport.cs
@@ -32,8 +32,8 @@ namespace Mirror.KCP
 
         public long ReceivedMessageCount { get; private set; }
 
-        private long receivedBytes = 0;
-        private long sentBytes = 0;
+        private long receivedBytes;
+        private long sentBytes;
 
         private AutoResetUniTaskCompletionSource ListenCompletionSource;
 

--- a/Assets/Mirror/Runtime/Transport/Kcp/KcpTransport.cs
+++ b/Assets/Mirror/Runtime/Transport/Kcp/KcpTransport.cs
@@ -32,6 +32,9 @@ namespace Mirror.KCP
 
         public long ReceivedMessageCount { get; private set; }
 
+        private long receivedBytes = 0;
+        private long sentBytes = 0;
+
         private AutoResetUniTaskCompletionSource ListenCompletionSource;
 
         /// <summary>
@@ -89,6 +92,7 @@ namespace Mirror.KCP
                 if (channel != Channel.Reliable)
                     return;
 
+                receivedBytes += msgLength;
                 // fire a separate task for handshake
                 // that way if the client does not cooperate
                 // we can continue with other clients
@@ -96,6 +100,7 @@ namespace Mirror.KCP
             }
             else
             {
+                receivedBytes += msgLength;
                 connection.RawInput(data, msgLength);
             }
         }
@@ -108,6 +113,11 @@ namespace Mirror.KCP
             connection.Disconnected += () =>
             {
                 connectedClients.Remove(endpoint as IPEndPoint);
+            };
+
+            connection.DataSent += (length) =>
+            {
+                sentBytes += length;
             };
 
             connection.RawInput(data, msgLength);
@@ -213,5 +223,9 @@ namespace Mirror.KCP
             await client.ConnectAsync(uri.Host, port);
             return client;
         }
+
+        public override long ReceivedBytes => receivedBytes;
+
+        public override long SentBytes => sentBytes;
     }
 }

--- a/Assets/Mirror/Runtime/Transport/Transport.cs
+++ b/Assets/Mirror/Runtime/Transport/Transport.cs
@@ -60,5 +60,15 @@ namespace Mirror
         /// </summary>
         /// <returns>the url at which this server can be reached</returns>
         public abstract IEnumerable<Uri> ServerUri();
+
+        /// <summary>
+        /// Gets the total amount of received data
+        /// </summary>
+        public virtual long ReceivedBytes => 0;
+
+        /// <summary>
+        /// Gets the total amount of sent data
+        /// </summary>
+        public virtual long SentBytes => 0;
     }
 }

--- a/Assets/Tests/Runtime/Transport/KcpTransportTest.cs
+++ b/Assets/Tests/Runtime/Transport/KcpTransportTest.cs
@@ -116,13 +116,12 @@ namespace Mirror.Tests
             long received = transport.ReceivedBytes;
             Assert.That(received, Is.GreaterThan(0), "Must have received some bytes to establish the connection");
 
-            byte[] data = { (byte)Random.Range(1, 255) };
             await clientConnection.SendAsync(new ArraySegment<byte>(data));
 
             var buffer = new MemoryStream();
             await serverConnection.ReceiveAsync(buffer);
 
-            Assert.That(transport.ReceivedBytes, Is.GreaterThan(received), "Client sent data,  we should have received");
+            Assert.That(transport.ReceivedBytes, Is.GreaterThan(received + data.Length), "Client sent data,  we should have received");
 
         });
 
@@ -132,13 +131,12 @@ namespace Mirror.Tests
             long sent = transport.SentBytes;
             Assert.That(sent, Is.GreaterThan(0), "Must have received some bytes to establish the connection");
 
-            byte[] data = { (byte)Random.Range(1, 255) };
             await serverConnection.SendAsync(new ArraySegment<byte>(data));
 
             var buffer = new MemoryStream();
             await clientConnection.ReceiveAsync(buffer);
 
-            Assert.That(transport.SentBytes, Is.GreaterThan(sent), "Client sent data,  we should have received");
+            Assert.That(transport.SentBytes, Is.GreaterThan(sent + data.Length), "Client sent data,  we should have received");
 
         });
 

--- a/Assets/Tests/Runtime/Transport/KcpTransportTest.cs
+++ b/Assets/Tests/Runtime/Transport/KcpTransportTest.cs
@@ -108,6 +108,38 @@ namespace Mirror.Tests
         });
 
         [UnityTest]
+        public IEnumerator ReceivedBytes() => UniTask.ToCoroutine(async () =>
+        {
+            long received = transport.ReceivedBytes;
+            Assert.That(received, Is.GreaterThan(0), "Must have received some bytes to establish the connection");
+
+            byte[] data = { (byte)Random.Range(1, 255) };
+            await clientConnection.SendAsync(new ArraySegment<byte>(data));
+
+            var buffer = new MemoryStream();
+            await serverConnection.ReceiveAsync(buffer);
+
+            Assert.That(transport.ReceivedBytes, Is.GreaterThan(received), "Client sent data,  we should have received");
+
+        });
+
+        [UnityTest]
+        public IEnumerator SentBytes() => UniTask.ToCoroutine(async () =>
+        {
+            long sent = transport.SentBytes;
+            Assert.That(sent, Is.GreaterThan(0), "Must have received some bytes to establish the connection");
+
+            byte[] data = { (byte)Random.Range(1, 255) };
+            await serverConnection.SendAsync(new ArraySegment<byte>(data));
+
+            var buffer = new MemoryStream();
+            await clientConnection.ReceiveAsync(buffer);
+
+            Assert.That(transport.SentBytes, Is.GreaterThan(sent), "Client sent data,  we should have received");
+
+        });
+
+        [UnityTest]
         public IEnumerator SendUnreliableDataFromServer() => UniTask.ToCoroutine(async () =>
         {
             byte[] data = { (byte)Random.Range(1, 255) };


### PR DESCRIPTION
KCP transport reports how many bytes were sent and received.
This can be used to report bandwidth.

Other transports can override these properties to report bandwidth too.