### PR TITLE
feat: notify algorithm in connection

### DIFF
--- a/Assets/Mirror/Runtime/INetworkConnection.cs
+++ b/Assets/Mirror/Runtime/INetworkConnection.cs
@@ -25,6 +25,23 @@ namespace Mirror
 
         UniTask ProcessMessagesAsync();
 
+        /// <summary>
+        /// Sends a message, but notify when it is delivered or lost
+        /// </summary>
+        /// <typeparam name="T">type of message to send</typeparam>
+        /// <param name="msg">message to send</param>
+        /// <param name="token">a arbitrary object that the sender will receive with their notification</param>
+        void SendNotify<T>(T msg, object token);
+
+        /// <summary>
+        /// Raised when a message is delivered
+        /// </summary>
+        event Action<INetworkConnection, object> NotifyDelivered;
+
+        /// <summary>
+        /// Raised when a message is lost
+        /// </summary>
+        event Action<INetworkConnection, object> NotifyLost;
     }
 
     /// <summary>

--- a/Assets/Mirror/Runtime/INetworkConnection.cs
+++ b/Assets/Mirror/Runtime/INetworkConnection.cs
@@ -31,7 +31,7 @@ namespace Mirror
         /// <typeparam name="T">type of message to send</typeparam>
         /// <param name="msg">message to send</param>
         /// <param name="token">a arbitrary object that the sender will receive with their notification</param>
-        void SendNotify<T>(T msg, object token);
+        void SendNotify<T>(T msg, object token, int channelId = Channel.Unreliable);
 
         /// <summary>
         /// Raised when a message is delivered

--- a/Assets/Mirror/Runtime/NetworkConnection.cs
+++ b/Assets/Mirror/Runtime/NetworkConnection.cs
@@ -8,6 +8,7 @@ using UnityEngine.Assertions;
 
 namespace Mirror
 {
+
     /// <summary>
     /// A High level network connection. This is used for connections from client-to-server and for connection from server-to-client.
     /// </summary>
@@ -45,7 +46,7 @@ namespace Mirror
         /// General purpose object to hold authentication data, character selection, tokens, etc.
         /// associated with the connection for reference after Authentication completes.
         /// </summary>
-        public object AuthenticationData { get ; set; }
+        public object AuthenticationData { get; set; }
 
         /// <summary>
         /// Flag that tells if the connection has been marked as "ready" by a client calling ClientScene.Ready().
@@ -291,8 +292,17 @@ namespace Mirror
                 {
                     int msgType = MessagePacker.UnpackId(networkReader);
 
-                    // try to invoke the handler for that message
-                    InvokeHandler(msgType, networkReader, channelId);
+                    if (msgType == MessagePacker.GetId<NotifyPacket>())
+                    {
+                        // this is a notify message, send to the notify receive
+                        NotifyPacket notifyPacket = networkReader.ReadNotifyPacket();
+                        ReceiveNotify(notifyPacket, networkReader, channelId);
+                    }
+                    else
+                    {
+                        // try to invoke the handler for that message
+                        InvokeHandler(msgType, networkReader, channelId);
+                    }
                 }
                 catch (InvalidDataException ex)
                 {
@@ -357,5 +367,32 @@ namespace Mirror
                 // connection closed,  normal
             }
         }
+
+        #region Notify
+        /// <summary>
+        /// Sends a message, but notify when it is delivered or lost
+        /// </summary>
+        /// <typeparam name="T">type of message to send</typeparam>
+        /// <param name="msg">message to send</param>
+        /// <param name="token">a arbitrary object that the sender will receive with their notification</param>
+        public void SendNotify<T>(T msg, object token)
+        {
+        }
+
+        internal void ReceiveNotify(NotifyPacket notifyPacket, NetworkReader networkReader, int channelId)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Raised when a message is delivered
+        /// </summary>
+        public event Action<INetworkConnection, object> NotifyDelivered;
+
+        /// <summary>
+        /// Raised when a message is lost
+        /// </summary>
+        public event Action<INetworkConnection, object> NotifyLost;
+        #endregion
     }
 }

--- a/Assets/Mirror/Runtime/NotifyPacket.cs
+++ b/Assets/Mirror/Runtime/NotifyPacket.cs
@@ -1,0 +1,31 @@
+﻿namespace Mirror
+{
+    // header for notify packet
+    public struct NotifyPacket
+    {
+        public ushort Sequence;
+        public ushort ReceiveSequence;
+        public ulong AckMask;
+    }
+
+
+    public static class NotifyPacketSerializer
+    {
+        public static void WriteNotifyPacket(this NetworkWriter writer, NotifyPacket packet)
+        {
+            writer.WriteUInt16(packet.Sequence);
+            writer.WriteUInt16(packet.ReceiveSequence);
+            writer.WriteUInt64(packet.AckMask);
+        }
+
+        public static NotifyPacket ReadNotifyPacket(this NetworkReader reader)
+        {
+            return new NotifyPacket
+            {
+                Sequence = reader.ReadUInt16(),
+                ReceiveSequence = reader.ReadUInt16(),
+                AckMask = reader.ReadUInt64()
+            };
+        }
+    }
+}

--- a/Assets/Mirror/Runtime/NotifyPacket.cs.meta
+++ b/Assets/Mirror/Runtime/NotifyPacket.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9b41f3731b5544382b3d31d16d721219
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/Runtime/Serializers/NetworkConnectionTest.cs
+++ b/Assets/Tests/Runtime/Serializers/NetworkConnectionTest.cs
@@ -122,9 +122,9 @@ namespace Mirror.Tests
         [Test]
         public void RaisePacketDelivered()
         {
-            connection.Send(data, 1);
-            connection.Send(data, 3);
-            connection.Send(data, 5);
+            connection.SendNotify(data, 1);
+            connection.SendNotify(data, 3);
+            connection.SendNotify(data, 5);
 
             delivered.DidNotReceiveWithAnyArgs().Invoke(default, default);
 
@@ -148,9 +148,9 @@ namespace Mirror.Tests
         [Test]
         public void RaisePacketNotDelivered()
         {
-            connection.Send(data, 1);
-            connection.Send(data, 3);
-            connection.Send(data, 5);
+            connection.SendNotify(data, 1);
+            connection.SendNotify(data, 3);
+            connection.SendNotify(data, 5);
 
             delivered.DidNotReceiveWithAnyArgs().Invoke(default, default);
 
@@ -204,11 +204,11 @@ namespace Mirror.Tests
         }
 
         [Test]
-        public void NotAcknoledgedYet()
+        public void NotAcknowledgedYet()
         {
-            connection.Send(data, 1);
-            connection.Send(data, 3);
-            connection.Send(data, 5);
+            connection.SendNotify(data, 1);
+            connection.SendNotify(data, 3);
+            connection.SendNotify(data, 5);
 
             var reply = new NotifyPacket
             {

--- a/Assets/Tests/Runtime/Serializers/NetworkConnectionTest.cs
+++ b/Assets/Tests/Runtime/Serializers/NetworkConnectionTest.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using NSubstitute;
 using NUnit.Framework;
 
@@ -7,11 +8,44 @@ namespace Mirror.Tests
     public class NetworkConnectionTest 
     {
         private NetworkConnection connection;
+        private byte[] serializedMessage;
+        private IConnection mockTransportConnection;
+
+        private SceneMessage data;
+
+        private NotifyPacket lastSent;
+
+        private Action<INetworkConnection, object> delivered;
+
+        private Action<INetworkConnection, object> lost;
 
         [SetUp]
         public void SetUp()
         {
-            connection = new NetworkConnection(Substitute.For<IConnection>());
+            data = new SceneMessage();
+            mockTransportConnection = Substitute.For<IConnection>();
+
+            void parsePacket(ArraySegment<byte> data)
+            {
+                var reader = new NetworkReader(data);
+                int id = MessagePacker.UnpackId(reader);
+                lastSent = reader.ReadNotifyPacket();
+            }
+
+            mockTransportConnection.SendAsync(
+                Arg.Do<ArraySegment<byte>>(parsePacket), Channel.Unreliable);
+
+            connection = new NetworkConnection(mockTransportConnection);
+
+            serializedMessage = MessagePacker.Pack(new ReadyMessage());
+            connection.RegisterHandler<ReadyMessage>(message => { });
+
+            delivered = Substitute.For<Action<INetworkConnection, object>>();
+            lost = Substitute.For<Action<INetworkConnection, object>>();
+
+            connection.NotifyDelivered += delivered;
+            connection.NotifyLost += lost;
+
         }
 
         [Test]
@@ -40,5 +74,165 @@ namespace Mirror.Tests
 
             Assert.That(exception.Message, Does.StartWith("Unexpected message ID 1234 received"));
         }
+
+        #region Notify
+
+
+        [Test]
+        public void SendsNotifyPacket()
+        {
+            connection.SendNotify(data, 1);
+
+            Assert.That(lastSent, Is.EqualTo(new NotifyPacket
+            {
+                Sequence = 1,
+                ReceiveSequence = 0,
+                AckMask = 0
+            }));
+        }
+
+        
+        [Test]
+        public void SendsNotifyPacketWithSequence()
+        {
+            connection.SendNotify(data, 1);
+            Assert.That(lastSent, Is.EqualTo(new NotifyPacket
+            {
+                Sequence = 1,
+                ReceiveSequence = 0,
+                AckMask = 0
+            }));
+
+            connection.SendNotify(data, 1);
+            Assert.That(lastSent, Is.EqualTo(new NotifyPacket
+            {
+                Sequence = 2,
+                ReceiveSequence = 0,
+                AckMask = 0
+            }));
+            connection.SendNotify(data, 1);
+            Assert.That(lastSent, Is.EqualTo(new NotifyPacket
+            {
+                Sequence = 3,
+                ReceiveSequence = 0,
+                AckMask = 0
+            }));
+        }
+
+        [Test]
+        public void RaisePacketDelivered()
+        {
+            connection.Send(data, 1);
+            connection.Send(data, 3);
+            connection.Send(data, 5);
+
+            delivered.DidNotReceiveWithAnyArgs().Invoke(default, default);
+
+            var reply = new NotifyPacket
+            {
+                Sequence = 1,
+                ReceiveSequence = 3,
+                AckMask = 0b111
+            };
+
+            connection.ReceiveNotify(reply, new NetworkReader(serializedMessage), Channel.Unreliable);
+
+            Received.InOrder(() =>
+            {
+                delivered.Invoke(connection, 1);
+                delivered.Invoke(connection, 3);
+                delivered.Invoke(connection, 5);
+            });
+        }
+
+        [Test]
+        public void RaisePacketNotDelivered()
+        {
+            connection.Send(data, 1);
+            connection.Send(data, 3);
+            connection.Send(data, 5);
+
+            delivered.DidNotReceiveWithAnyArgs().Invoke(default, default);
+
+            var reply = new NotifyPacket
+            {
+                Sequence = 1,
+                ReceiveSequence = 3,
+                AckMask = 0b001
+            };
+
+            connection.ReceiveNotify(reply, new NetworkReader(serializedMessage), Channel.Unreliable);
+
+            Received.InOrder(() =>
+            {
+                lost.Invoke(connection, 1);
+                lost.Invoke(connection, 3);
+                delivered.Invoke(connection, 5);
+            });
+        }
+
+
+        [Test]
+        public void LoseOldPackets()
+        {
+            for (int i = 1; i < 10; i++)
+            {
+                var packet = new NotifyPacket
+                {
+                    Sequence = (ushort)i,
+                    ReceiveSequence = 100,
+                    AckMask = ~0b0ul
+                };
+                connection.ReceiveNotify(packet, new NetworkReader(serializedMessage), Channel.Unreliable);
+            }
+
+            var reply = new NotifyPacket
+            {
+                Sequence = 100,
+                ReceiveSequence = 100,
+                AckMask = ~0b0ul
+            };
+            connection.ReceiveNotify(reply, new NetworkReader(serializedMessage), Channel.Unreliable);
+
+            connection.SendNotify(data, 1);
+
+            Assert.That(lastSent, Is.EqualTo(new NotifyPacket {
+                Sequence = 1,
+                ReceiveSequence = 100,
+                AckMask = 1
+            }));
+        }
+
+        [Test]
+        public void NotAcknoledgedYet()
+        {
+            connection.Send(data, 1);
+            connection.Send(data, 3);
+            connection.Send(data, 5);
+
+            var reply = new NotifyPacket
+            {
+                Sequence = 1,
+                ReceiveSequence = 2,
+                AckMask = 0b011
+            };
+
+            connection.ReceiveNotify(reply, new NetworkReader(serializedMessage), Channel.Unreliable);
+
+            delivered.DidNotReceive().Invoke(Arg.Any<INetworkConnection>(), 5);
+
+            reply = new NotifyPacket
+            {
+                Sequence = 2,
+                ReceiveSequence = 3,
+                AckMask = 0b111
+            };
+
+            connection.ReceiveNotify(reply, new NetworkReader(serializedMessage), Channel.Unreliable);
+
+            delivered.Received().Invoke(connection, 5);
+        }
+
+        #endregion
     }
 }


### PR DESCRIPTION
From the receiver it is the same as any other message:
```cs
   connection.RegisterHandler<SomeMessage>( (message) => {
       // I received a message 
   });
```

From the sender, it looks like this:
```cs
  connection.NotifyDelivered += (connection, token) => {
      Debug.Log($"the message with token {token} has been delivered");
  };
  connection.NotifyLost += (connection, token) => {
      Debug.Log($"the message with token {token} has been lost");
  };

  connection.SendNotify(new SomeMessage(...),  "my token");
```

If you send a message,  you will eventually get one of those callbacks.  Messages are always delivered in order.  There is no guarantee that messages are delivered (but you can just resend in the lost callback if you want).  Same latency as raw unreliable.
