### PR TITLE
feat: recommend Fast3 as default for performance

### DIFF
--- a/Assets/Mirror/Runtime/Transport/Kcp/KcpTransport.cs
+++ b/Assets/Mirror/Runtime/Transport/Kcp/KcpTransport.cs
@@ -23,7 +23,7 @@ namespace Mirror.KCP
         [Tooltip("How many messages can be received")]
         public int ReceiveWindowSize = 8192;
 
-        public KcpDelayMode delayMode = KcpDelayMode.Normal;
+        public KcpDelayMode delayMode = KcpDelayMode.Fast3;
         internal readonly Dictionary<IPEndPoint, KcpServerConnection> connectedClients = new Dictionary<IPEndPoint, KcpServerConnection>(new IPEndpointComparer());
 
         public override IEnumerable<string> Scheme => new[] { "kcp" };


### PR DESCRIPTION
normal delay mode has proven to cause issues in bench tests and user games. After more testing and feedback a default of Fast3 seems to be much more stable and performant stopping all choke warnings.