### PR TITLE
refactor(weaver): mirror runtime no longer needs weaver

### DIFF
--- a/Assets/Mirror/Cloud/Core/Events.cs
+++ b/Assets/Mirror/Cloud/Core/Events.cs
@@ -4,9 +4,9 @@ using UnityEngine.Events;
 
 namespace Mirror.Cloud
 {
-    [Serializable]
+    [System.Serializable]
     public class ServerListEvent : UnityEvent<ServerCollectionJson> { }
 
-    [Serializable]
+    [System.Serializable]
     public class MatchFoundEvent : UnityEvent<ServerJson> { }
 }

--- a/Assets/Mirror/Cloud/Core/JsonStructs.cs
+++ b/Assets/Mirror/Cloud/Core/JsonStructs.cs
@@ -2,13 +2,13 @@ using System;
 
 namespace Mirror.Cloud
 {
-    [Serializable]
+    [System.Serializable]
     public struct CreatedIdJson : ICanBeJson
     {
         public string id;
     }
 
-    [Serializable]
+    [System.Serializable]
     public struct ErrorJson : ICanBeJson
     {
         public string code;
@@ -17,7 +17,7 @@ namespace Mirror.Cloud
         public int HtmlCode => int.Parse(code);
     }
 
-    [Serializable]
+    [System.Serializable]
     public struct EmptyJson : ICanBeJson
     {
     }

--- a/Assets/Mirror/Cloud/ListServer/ListServerJson.cs
+++ b/Assets/Mirror/Cloud/ListServer/ListServerJson.cs
@@ -4,13 +4,13 @@ using System.Linq;
 
 namespace Mirror.Cloud.ListServerService
 {
-    [Serializable]
+    [System.Serializable]
     public struct ServerCollectionJson : ICanBeJson
     {
         public ServerJson[] servers;
     }
 
-    [Serializable]
+    [System.Serializable]
     public struct ServerJson : ICanBeJson
     {
         public string protocol;
@@ -97,7 +97,7 @@ namespace Mirror.Cloud.ListServerService
         }
     }
 
-    [Serializable]
+    [System.Serializable]
     public struct PartialServerJson : ICanBeJson
     {
         /// <summary>
@@ -174,7 +174,7 @@ namespace Mirror.Cloud.ListServerService
         }
     }
 
-    [Serializable]
+    [System.Serializable]
     public struct KeyValue
     {
         const int MaxKeySize = 32;

--- a/Assets/Mirror/Components/Experimental/NetworkTransformBase.cs
+++ b/Assets/Mirror/Components/Experimental/NetworkTransformBase.cs
@@ -89,7 +89,7 @@ namespace Mirror.Experimental
 
         // client
         // use local position/rotation for VR support
-        [Serializable]
+        [System.Serializable]
         public struct DataPoint
         {
             public float timeStamp;

--- a/Assets/Mirror/Runtime/CustomAttributes.cs
+++ b/Assets/Mirror/Runtime/CustomAttributes.cs
@@ -56,11 +56,18 @@ namespace Mirror
         public bool error = true;
     }
 
+    /// <summary>
+    /// Tell the weaver to generate  reader and writer for a class
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct)]
+    public class SerializableAttribute : Attribute
+    {
+    }
 
     /// <summary>
     /// Exception thrown if a guarded method is invoked incorrectly
     /// </summary>
-    [Serializable]
+    [System.Serializable]
     public class MethodInvocationException : Exception
     {
         /// <summary>

--- a/Assets/Mirror/Runtime/InvalidMessageException.cs
+++ b/Assets/Mirror/Runtime/InvalidMessageException.cs
@@ -4,7 +4,7 @@ using System.Runtime.Serialization;
 namespace Mirror
 {
 
-    [Serializable]
+    [System.Serializable]
     public class InvalidMessageException : Exception
     {
         public InvalidMessageException()

--- a/Assets/Mirror/Runtime/LogSettings.cs
+++ b/Assets/Mirror/Runtime/LogSettings.cs
@@ -8,7 +8,7 @@ namespace Mirror
     [AddComponentMenu("Network/LogSettings")]
     public class LogSettings : MonoBehaviour
     {
-        [Serializable]
+        [System.Serializable]
         public struct Level
         {
             public string Name;

--- a/Assets/Mirror/Runtime/Messages.cs
+++ b/Assets/Mirror/Runtime/Messages.cs
@@ -6,12 +6,16 @@ namespace Mirror
 
     #region Public System Messages
 
+    [Serializable]
     public struct ReadyMessage { }
 
+    [Serializable]
     public struct NotReadyMessage { }
 
+    [Serializable]
     public struct AddPlayerMessage { }
 
+    [Serializable]
     public struct SceneMessage 
     {
         public string scenePath;
@@ -20,6 +24,7 @@ namespace Mirror
         public string[] additiveScenes;
     }
 
+    [Serializable]
     public struct SceneReadyMessage { }
 
     public enum SceneOperation : byte
@@ -32,6 +37,7 @@ namespace Mirror
     #endregion
 
     #region System Messages requried for code gen path
+    [Serializable]
     public struct ServerRpcMessage
     {
         public uint netId;
@@ -46,12 +52,14 @@ namespace Mirror
         public ArraySegment<byte> payload;
     }
 
+    [Serializable]
     public struct ServerRpcReply
     {
         public int replyId;
         public ArraySegment<byte> payload;
     }
 
+    [Serializable]
     public struct RpcMessage
     {
         public uint netId;
@@ -64,6 +72,7 @@ namespace Mirror
     #endregion
 
     #region Internal System Messages
+    [Serializable]
     public struct SpawnMessage
     {
         /// <summary>
@@ -106,16 +115,19 @@ namespace Mirror
         public ArraySegment<byte> payload;
     }
 
+    [Serializable]
     public struct ObjectDestroyMessage
     {
         public uint netId;
     }
 
+    [Serializable]
     public struct ObjectHideMessage
     {
         public uint netId;
     }
 
+    [Serializable]
     public struct UpdateVarsMessage
     {
         public uint netId;
@@ -126,6 +138,7 @@ namespace Mirror
 
     // A client sends this message to the server
     // to calculate RTT and synchronize time
+    [Serializable]
     public struct NetworkPingMessage
     {
         public double clientTime;
@@ -133,6 +146,7 @@ namespace Mirror
 
     // The server responds with this message
     // The client can use this to calculate RTT and sync time
+    [Serializable]
     public struct NetworkPongMessage 
     {
         public double clientTime;

--- a/Assets/Mirror/Runtime/NetworkClient.cs
+++ b/Assets/Mirror/Runtime/NetworkClient.cs
@@ -7,7 +7,7 @@ using UnityEngine.Events;
 
 namespace Mirror
 {
-    [Serializable] public class NetworkConnectionEvent : UnityEvent<INetworkConnection> { }
+    [System.Serializable] public class NetworkConnectionEvent : UnityEvent<INetworkConnection> { }
 
     public enum ConnectState
     {

--- a/Assets/Mirror/Runtime/NetworkSceneManager.cs
+++ b/Assets/Mirror/Runtime/NetworkSceneManager.cs
@@ -19,7 +19,7 @@ namespace Mirror
     {
         static readonly ILogger logger = LogFactory.GetLogger(typeof(NetworkSceneManager));
 
-        [Serializable] public class ClientSceneChangeEvent : UnityEvent<string, SceneOperation> { }
+        [System.Serializable] public class ClientSceneChangeEvent : UnityEvent<string, SceneOperation> { }
 
         [FormerlySerializedAs("client")]
         public NetworkClient Client;

--- a/Assets/Mirror/Weaver/MirrorILPostProcessor.cs
+++ b/Assets/Mirror/Weaver/MirrorILPostProcessor.cs
@@ -39,7 +39,6 @@ namespace Mirror.Weaver
         }
 
         public override bool WillProcess(ICompiledAssembly compiledAssembly) =>
-                compiledAssembly.Name == RuntimeAssemblyName ||
-                compiledAssembly.References.Any(filePath => Path.GetFileNameWithoutExtension(filePath) == RuntimeAssemblyName);
+            compiledAssembly.References.Any(filePath => Path.GetFileNameWithoutExtension(filePath) == RuntimeAssemblyName);
     }
 }

--- a/Assets/Mirror/Weaver/Processors/ReaderWriterProcessor.cs
+++ b/Assets/Mirror/Weaver/Processors/ReaderWriterProcessor.cs
@@ -30,7 +30,8 @@ namespace Mirror.Weaver
             messages.Clear();
 
 
-            LoadBuiltInReadersAndWriters();
+            LoadBuiltinExtensions();
+            LoadBuiltinSerializable();
 
             int writeCount = writers.Count;
             int readCount = readers.Count;
@@ -43,7 +44,7 @@ namespace Mirror.Weaver
         private static bool IsExtension(MethodInfo method) => Attribute.IsDefined(method, typeof(System.Runtime.CompilerServices.ExtensionAttribute));
 
         #region Load MirrorNG built in readers and writers
-        private void LoadBuiltInReadersAndWriters()
+        private void LoadBuiltinExtensions()
         {
             // find all extension methods
             IEnumerable<Type> types = typeof(NetworkReaderExtensions).Module.GetTypes().Where(t => t.IsSealed && t.IsAbstract);
@@ -60,6 +61,17 @@ namespace Mirror.Weaver
                 }
             }
         }
+
+        private void LoadBuiltinSerializable()
+        {
+            IEnumerable<Type> types = typeof(NetworkReaderExtensions).Module.GetTypes().Where(t => t.GetCustomAttribute<SerializableAttribute>() != null);
+            foreach (Type type in types)
+            {
+                writers.GetWriteFunc(module.ImportReference(type), null);
+                readers.GetReadFunc(module.ImportReference(type), null);
+            }
+        }
+
 
         private void RegisterReader(MethodInfo method)
         {

--- a/Assets/Mirror/Weaver/WeaverExceptions.cs
+++ b/Assets/Mirror/Weaver/WeaverExceptions.cs
@@ -3,7 +3,7 @@ using Mono.Cecil;
 
 namespace Mirror.Weaver
 {
-    [Serializable]
+    [System.Serializable]
     public abstract class WeaverException : Exception
     {
         public MemberReference MemberReference { get; }
@@ -16,7 +16,7 @@ namespace Mirror.Weaver
         protected WeaverException(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext) : base(serializationInfo, streamingContext) { }
     }
 
-    [Serializable]
+    [System.Serializable]
     public class GenerateWriterException : WeaverException
     {
         public GenerateWriterException(string message, MemberReference member) : base(message, member) { }


### PR DESCRIPTION
weaving mirror runtime is proving to be problematic.
It requires us to do a reload all every time we change things,
and it does not get weaved proberly with LEGACY_ILPP, which could be
a workaround for rewired compatibility.