### PR TITLE
feat: explicit declaration of network messages

### DIFF
--- a/Assets/Mirror/Weaver/Processors/ReaderWriterProcessor.cs
+++ b/Assets/Mirror/Weaver/Processors/ReaderWriterProcessor.cs
@@ -29,7 +29,6 @@ namespace Mirror.Weaver
         {
             messages.Clear();
 
-
             LoadBuiltinExtensions();
             LoadBuiltinMessages();
 
@@ -117,6 +116,13 @@ namespace Mirror.Weaver
                 {
                     LoadDeclaredWriters(klass);
                     LoadDeclaredReaders(klass);
+                }
+
+                if (klass.GetCustomAttribute<NetworkMessageAttribute>()  != null)
+                {
+                    readers.GetReadFunc(klass, null);
+                    writers.GetWriteFunc(klass, null);
+                    messages.Add(klass);
                 }
             }
 

--- a/Assets/Tests/Weaver/GeneratedReaderWriterTests.cs
+++ b/Assets/Tests/Weaver/GeneratedReaderWriterTests.cs
@@ -17,6 +17,12 @@ namespace Mirror.Weaver
         }
 
         [Test]
+        public void CreateForExplicitNetworkMessage()
+        {
+            IsSuccess();
+        }
+
+        [Test]
         public void CreatesForClass()
         {
             IsSuccess();

--- a/Assets/Tests/Weaver/GeneratedReaderWriterTests~/CreateForExplicitNetworkMessage.cs
+++ b/Assets/Tests/Weaver/GeneratedReaderWriterTests~/CreateForExplicitNetworkMessage.cs
@@ -1,6 +1,6 @@
 using Mirror;
 
-namespace GeneratedReaderWriter.CreateForExplicitNetworkMessage
+namespace GeneratedReaderWriterTests.CreateForExplicitNetworkMessage
 {
     [NetworkMessage]
     public class SomeOtherData

--- a/Assets/Tests/Weaver/GeneratedReaderWriter~/CreateForExplicitNetworkMessage.cs
+++ b/Assets/Tests/Weaver/GeneratedReaderWriter~/CreateForExplicitNetworkMessage.cs
@@ -1,0 +1,10 @@
+using Mirror;
+
+namespace GeneratedReaderWriter.CreateForExplicitNetworkMessage
+{
+    [NetworkMessage]
+    public class SomeOtherData
+    {
+        public int usefulNumber;
+    }
+}


### PR DESCRIPTION
Normally MirrorNG detects what is a message and creates an id for it.
This PR allows you to explicitly declare a class or struct as a network message
This can be useful when you are making a generic class (such as Discovery)

to explicitly mark a class/struct as a network message you can do:
```cs
[NetworkMessage]
public struct MyMessage {
...
}
```