### PR TITLE
feat: increase flow rate of kcp

### DIFF
--- a/Assets/Mirror/Runtime/Transport/Kcp/KcpTransport.cs
+++ b/Assets/Mirror/Runtime/Transport/Kcp/KcpTransport.cs
@@ -19,7 +19,7 @@ namespace Mirror.KCP
         public int HashCashBits = 18;
 
         [Tooltip("How many messages can be sent simultaneously")]
-        public int SendWindowSize = 32;
+        public int SendWindowSize = 1024;
         [Tooltip("How many messages can be received")]
         public int ReceiveWindowSize = 8192;
 


### PR DESCRIPTION
perf testing was done with Headless Benchmark. This new default value strikes a good balance between flow rate and not choking the network. Works along with: #559