### PR TITLE
fix: client throwing exception when force disconnecting

### DIFF
--- a/Assets/Mirror/Runtime/Transport/Kcp/KcpTransport.cs
+++ b/Assets/Mirror/Runtime/Transport/Kcp/KcpTransport.cs
@@ -68,11 +68,20 @@ namespace Mirror.KCP
         EndPoint newClientEP = new IPEndPoint(IPAddress.IPv6Any, 0);
         public void Update()
         {
-            while (socket != null && socket.Poll(0, SelectMode.SelectRead)) {
-                int msgLength = socket.ReceiveFrom(buffer, 0, buffer.Length, SocketFlags.None, ref newClientEP);
+            try
+            {
+                while (socket != null && socket.Poll(0, SelectMode.SelectRead))
+                {
+                    int msgLength = socket.ReceiveFrom(buffer, 0, buffer.Length, SocketFlags.None, ref newClientEP);
 
-                ReceivedMessageCount++;
-                RawInput(newClientEP, buffer, msgLength);
+                    ReceivedMessageCount++;
+                    RawInput(newClientEP, buffer, msgLength);
+                }
+            }
+            catch (SocketException)
+            {
+                //Client disconnected
+                Disconnect();
             }
         }
 


### PR DESCRIPTION
fixes the 10 seconds of SocketException spam when a client disconnects without a goodby msg. Confirmed as a fix via HeadlessBenchmark testing.