### PR TITLE
fix: nre issues when trying to reload back in the same instance to a …

### DIFF
--- a/Assets/Mirror/Runtime/ServerObjectManager.cs
+++ b/Assets/Mirror/Runtime/ServerObjectManager.cs
@@ -100,9 +100,11 @@ namespace Mirror
         {
             foreach (NetworkIdentity obj in Server.Spawned.Values.Reverse())
             {
-                if(obj.AssetId != Guid.Empty)
+                if (obj.AssetId != Guid.Empty)
                     DestroyObject(obj, true);
             }
+
+            Server.Spawned.Clear();
         }
 
         void OnServerChangeScene(string scenePath, SceneOperation sceneOperation)

--- a/Assets/Tests/Runtime/Host/ServerObjectManagerTest.cs
+++ b/Assets/Tests/Runtime/Host/ServerObjectManagerTest.cs
@@ -129,8 +129,7 @@ namespace Mirror.Tests.Host
 
             await AsyncUtil.WaitUntilWithTimeout(() => !server.Active);
 
-            //Value will not be 0 as the SceneObject is not destroyed in the stop process.
-            Assert.That(server.Spawned.Count, Is.GreaterThan(0));
+            Assert.That(server.Spawned.Count, Is.Zero);
         });
     }
 }


### PR DESCRIPTION
This fixes issues with spawned list still holding on to old scene objects if user stops hosting or disconnect and reloads to say there main menu to start a new match.