### PR TITLE
fix: increase log level of full server

### DIFF
--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -380,7 +380,7 @@ namespace Mirror
             if (connections.Count >= MaxConnections)
             {
                 conn.Disconnect();
-                if (logger.LogEnabled()) logger.Log("Server full, kicked client:" + conn);
+                if (logger.WarnEnabled()) logger.LogWarning("Server full, kicked client:" + conn);
                 return;
             }
 


### PR DESCRIPTION
- This message should be a warning so that it is logged by default.
- Server being full is something the developer should look into, therefor should be a warning