### PR TITLE
style: reorder positions of serializable fields in networkmanager components

### DIFF
--- a/Assets/Mirror/Runtime/ClientObjectManager.cs
+++ b/Assets/Mirror/Runtime/ClientObjectManager.cs
@@ -28,6 +28,7 @@ namespace Mirror
         [System.Serializable]
         public class SpawnEvent : UnityEvent<NetworkIdentity> { }
 
+        [Header("Events")]
         /// <summary>
         /// Raised when the client spawns an object
         /// </summary>
@@ -38,17 +39,18 @@ namespace Mirror
         /// </summary>
         public SpawnEvent UnSpawned = new SpawnEvent();
 
-        /// <summary>
-        /// This is a dictionary of the prefabs that are registered on the client with ClientScene.RegisterPrefab().
-        /// <para>The key to the dictionary is the prefab asset Id.</para>
-        /// </summary>
-        internal readonly Dictionary<Guid, NetworkIdentity> prefabs = new Dictionary<Guid, NetworkIdentity>();
-
+        [Header("Prefabs")]
         /// <summary>
         /// List of prefabs that will be registered with the spawning system.
         /// <para>For each of these prefabs, ClientManager.RegisterPrefab() will be automatically invoke.</para>
         /// </summary>
         public List<NetworkIdentity> spawnPrefabs = new List<NetworkIdentity>();
+
+        /// <summary>
+        /// This is a dictionary of the prefabs that are registered on the client with ClientScene.RegisterPrefab().
+        /// <para>The key to the dictionary is the prefab asset Id.</para>
+        /// </summary>
+        internal readonly Dictionary<Guid, NetworkIdentity> prefabs = new Dictionary<Guid, NetworkIdentity>();
 
         /// <summary>
         /// This is dictionary of the disabled NetworkIdentity objects in the scene that could be spawned by messages from the server.
@@ -72,7 +74,7 @@ namespace Mirror
         {
             RegisterSpawnPrefabs();
 
-            if(Client.IsLocalClient)
+            if (Client.IsLocalClient)
             {
                 RegisterHostHandlers();
             }
@@ -195,10 +197,10 @@ namespace Mirror
         /// <param name="newAssetId">An assetId to be assigned to this prefab. This allows a dynamically created game object to be registered for an already known asset Id.</param>
         public void RegisterPrefab(NetworkIdentity identity, Guid newAssetId)
         {
-                identity.AssetId = newAssetId;
+            identity.AssetId = newAssetId;
 
-                if (logger.LogEnabled()) logger.Log("Registering prefab '" + identity.name + "' as asset:" + identity.AssetId);
-                prefabs[identity.AssetId] = identity;
+            if (logger.LogEnabled()) logger.Log("Registering prefab '" + identity.name + "' as asset:" + identity.AssetId);
+            prefabs[identity.AssetId] = identity;
         }
 
         /// <summary>
@@ -602,8 +604,5 @@ namespace Mirror
             callbacks.Add(newReplyId, Callback);
             return (completionSource.Task, newReplyId);
         }
-
-
     }
 }
-

--- a/Assets/Mirror/Runtime/NetworkClient.cs
+++ b/Assets/Mirror/Runtime/NetworkClient.cs
@@ -27,12 +27,14 @@ namespace Mirror
     {
         static readonly ILogger logger = LogFactory.GetLogger(typeof(NetworkClient));
 
-        [Header("Authentication")]
+        public Transport Transport;
+
         [Tooltip("Authentication component attached to this object")]
         public NetworkAuthenticator authenticator;
 
         internal readonly Dictionary<uint, NetworkIdentity> spawned = new Dictionary<uint, NetworkIdentity>();
 
+        [Header("Events")]
         /// <summary>
         /// Event fires once the Client has connected its Server.
         /// </summary>
@@ -72,8 +74,6 @@ namespace Mirror
         public bool IsConnected => connectState == ConnectState.Connected;
 
         public readonly NetworkTime Time = new NetworkTime();
-
-        public Transport Transport;
 
         /// <summary>
         /// List of all objects spawned in this client

--- a/Assets/Mirror/Runtime/NetworkSceneManager.cs
+++ b/Assets/Mirror/Runtime/NetworkSceneManager.cs
@@ -26,6 +26,7 @@ namespace Mirror
         [FormerlySerializedAs("server")]
         public NetworkServer Server;
 
+        [Header("Events")]
         /// <summary>
         /// Event fires when the Client starts changing scene.
         /// </summary>
@@ -118,7 +119,7 @@ namespace Mirror
             OnClientChangeScene(msg.scenePath, msg.sceneOperation);
 
             //Additive are scenes loaded on server and this client is not a host client
-            if(msg.additiveScenes != null && msg.additiveScenes.Length > 0 && Client && !Client.IsLocalClient)
+            if (msg.additiveScenes != null && msg.additiveScenes.Length > 0 && Client && !Client.IsLocalClient)
             {
                 foreach (string scene in msg.additiveScenes)
                 {
@@ -134,7 +135,7 @@ namespace Mirror
             logger.Log("ClientSceneReadyMessage");
 
             //Server has finished changing scene. Allow the client to finish.
-            if(asyncOperation != null)
+            if (asyncOperation != null)
                 asyncOperation.allowSceneActivation = true;
         }
 
@@ -228,7 +229,7 @@ namespace Mirror
             // Let server prepare for scene change
             OnServerChangeScene(scenePath, sceneOperation);
 
-            if(!Server.LocalClientActive)
+            if (!Server.LocalClientActive)
                 StartCoroutine(ApplySceneOperation(scenePath, sceneOperation));
 
             // notify all clients about the new scene
@@ -285,7 +286,7 @@ namespace Mirror
 
                         yield return asyncOperation;
                     }
-                    
+
                     break;
                 case SceneOperation.LoadAdditive:
                     // Ensure additive scene is not already loaded
@@ -294,7 +295,7 @@ namespace Mirror
                         yield return SceneManager.LoadSceneAsync(scenePath, LoadSceneMode.Additive);
                         additiveSceneList.Add(scenePath);
                         FinishLoadScene(scenePath, sceneOperation);
-                    }   
+                    }
                     else
                     {
                         logger.LogWarning($"Scene {scenePath} is already loaded");

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -31,6 +31,19 @@ namespace Mirror
         public int MaxConnections = 4;
 
         /// <summary>
+        /// <para>If you disable this, the server will not listen for incoming connections on the regular network port.</para>
+        /// <para>This can be used if the game is running in host mode and does not want external players to be able to connect - making it like a single-player game. Also this can be useful when using AddExternalConnection().</para>
+        /// </summary>
+        public bool Listening = true;
+
+        // transport to use to accept connections
+        public Transport Transport;
+
+        [Tooltip("Authentication component attached to this object")]
+        public NetworkAuthenticator authenticator;
+
+        [Header("Events")]
+        /// <summary>
         /// This is invoked when a server is started - including when a host is started.
         /// </summary>
         public UnityEvent Started = new UnityEvent();
@@ -63,10 +76,6 @@ namespace Mirror
         /// </summary>
         public UnityEvent OnStopHost = new UnityEvent();
 
-        [Header("Authentication")]
-        [Tooltip("Authentication component attached to this object")]
-        public NetworkAuthenticator authenticator;
-
         /// <summary>
         /// The connection to the host mode client (if any).
         /// </summary>
@@ -95,12 +104,6 @@ namespace Mirror
         public readonly HashSet<INetworkConnection> connections = new HashSet<INetworkConnection>();
 
         /// <summary>
-        /// <para>If you disable this, the server will not listen for incoming connections on the regular network port.</para>
-        /// <para>This can be used if the game is running in host mode and does not want external players to be able to connect - making it like a single-player game. Also this can be useful when using AddExternalConnection().</para>
-        /// </summary>
-        public bool Listening = true;
-
-        /// <summary>
         /// <para>Checks if the server has been started.</para>
         /// <para>This will be true after NetworkServer.Listen() has been called.</para>
         /// </summary>
@@ -110,9 +113,6 @@ namespace Mirror
 
         // Time kept in this server
         public readonly NetworkTime Time = new NetworkTime();
-
-        // transport to use to accept connections
-        public Transport Transport;
 
         /// <summary>
         /// This shuts down the server and disconnects all clients.

--- a/Assets/Mirror/Runtime/ServerObjectManager.cs
+++ b/Assets/Mirror/Runtime/ServerObjectManager.cs
@@ -31,6 +31,7 @@ namespace Mirror
         [System.Serializable]
         public class SpawnEvent : UnityEvent<NetworkIdentity> { }
 
+        [Header("Events")]
         /// <summary>
         /// Raised when the client spawns an object
         /// </summary>


### PR DESCRIPTION
This PR changes the position of serializable fields in the components that are attached to NetworkManager. For example, the transport field in NetworkServer has been moved above the events. The events take up a lot of space and this prevents the user from having to scroll to the bottom of the component to set a field.