### PR TITLE
refactor: simplify delay call in kcpconnection.tick

### DIFF
--- a/Assets/Mirror/Runtime/Transport/Kcp/KcpConnection.cs
+++ b/Assets/Mirror/Runtime/Transport/Kcp/KcpConnection.cs
@@ -12,6 +12,8 @@ namespace Mirror.KCP
     public abstract class KcpConnection : IConnection
     {
         static readonly ILogger logger = LogFactory.GetLogger(typeof(KcpConnection));
+        
+        const float MinimumKcpTickInterval = 10f;
 
         protected Socket socket;
         protected EndPoint remoteEndpoint;
@@ -80,7 +82,7 @@ namespace Mirror.KCP
             {
                 Thread.VolatileWrite(ref lastReceived, stopWatch.ElapsedMilliseconds);
 
-                while (open )
+                while (open)
                 {
                     long now = stopWatch.ElapsedMilliseconds;
                     long received = Thread.VolatileRead(ref lastReceived);
@@ -93,9 +95,8 @@ namespace Mirror.KCP
 
                     int delay = (int)(check - now);
 
-                    // todo remove magic number 10, Should it just be UniTask.Yield instead to wait 1 frame
                     if (delay <= 0)
-                        delay = 10;
+                        delay = MinimumKcpTickInterval;
 
                     await UniTask.Delay(delay);
                 }

--- a/Assets/Mirror/Runtime/Transport/Kcp/KcpConnection.cs
+++ b/Assets/Mirror/Runtime/Transport/Kcp/KcpConnection.cs
@@ -91,11 +91,13 @@ namespace Mirror.KCP
 
                     uint check = kcp.Check((uint)now);
 
-                    if (check <= now)
-                        check = (uint)(now + 10);
+                    int delay = (int)(check - now);
 
+                    // todo remove magic number 10, Should it just be UniTask.Yield instead to wait 1 frame
+                    if (delay <= 0)
+                        delay = 10;
 
-                    await UniTask.Delay((int)(check - now));
+                    await UniTask.Delay(delay);
                 }
             }
             catch (SocketException)

--- a/Assets/Mirror/Runtime/Transport/Kcp/KcpConnection.cs
+++ b/Assets/Mirror/Runtime/Transport/Kcp/KcpConnection.cs
@@ -12,8 +12,8 @@ namespace Mirror.KCP
     public abstract class KcpConnection : IConnection
     {
         static readonly ILogger logger = LogFactory.GetLogger(typeof(KcpConnection));
-        
-        const float MinimumKcpTickInterval = 10f;
+
+        const int MinimumKcpTickInterval = 10;
 
         protected Socket socket;
         protected EndPoint remoteEndpoint;


### PR DESCRIPTION
- [x] todo remove magic number 10, Should it just be UniTask.Yield instead to wait 1 frame

ps: not sure what PR title prefix should be