### PR TITLE
refactor: separate player ownership from NetworkServer

### DIFF
--- a/Assets/Mirror/Runtime/INetworkServer.cs
+++ b/Assets/Mirror/Runtime/INetworkServer.cs
@@ -35,7 +35,5 @@ namespace Mirror
         void RemoveConnection(INetworkConnection conn);
 
         void SendToAll<T>(T msg, int channelId = Channel.Reliable);
-
-        void SendToClientOfPlayer<T>(NetworkIdentity identity, T msg, int channelId = Channel.Reliable);
     }
 }

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -1231,7 +1231,7 @@ namespace Mirror
                     {
                         varsMessage.payload = ownerWriter.ToArraySegment();
                         if (ConnectionToClient != null && ConnectionToClient.IsReady)
-                            Server.SendToClientOfPlayer(this, varsMessage);
+                            ConnectionToClient.Send(varsMessage);
                     }
 
                     // send observersWriter to everyone but owner

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -427,23 +427,5 @@ namespace Mirror
 
             Authenticated?.Invoke(conn);
         }
-
-        /// <summary>
-        /// send this message to the player only
-        /// </summary>
-        /// <typeparam name="T">Message type</typeparam>
-        /// <param name="identity"></param>
-        /// <param name="msg"></param>
-        public void SendToClientOfPlayer<T>(NetworkIdentity identity, T msg, int channelId = Channel.Reliable)
-        {
-            if (identity != null)
-            {
-                identity.ConnectionToClient.Send(msg, channelId);
-            }
-            else
-            {
-                throw new InvalidOperationException("SendToClientOfPlayer: player has no NetworkIdentity: " + identity);
-            }
-        }
     }
 }

--- a/Assets/Mirror/Samples~/AdditiveScenes/Scripts/ZoneHandler.cs
+++ b/Assets/Mirror/Samples~/AdditiveScenes/Scripts/ZoneHandler.cs
@@ -21,7 +21,7 @@ namespace Mirror.Examples.Additive
             if (logger.LogEnabled()) logger.LogFormat(LogType.Log, "Loading {0}", subScene);
 
             NetworkIdentity networkIdentity = other.gameObject.GetComponent<NetworkIdentity>();
-            Server.SendToClientOfPlayer(networkIdentity, new SceneMessage { scenePath = subScene, sceneOperation = SceneOperation.LoadAdditive });
+            networkIdentity.ConnectionToClient.Send(new SceneMessage { scenePath = subScene, sceneOperation = SceneOperation.LoadAdditive });
         }
 
         [Server]
@@ -30,7 +30,7 @@ namespace Mirror.Examples.Additive
             if (logger.LogEnabled()) logger.LogFormat(LogType.Log, "Unloading {0}", subScene);
 
             NetworkIdentity networkIdentity = other.gameObject.GetComponent<NetworkIdentity>();
-            Server.SendToClientOfPlayer(networkIdentity, new SceneMessage { scenePath = subScene, sceneOperation = SceneOperation.UnloadAdditive });
+            networkIdentity.ConnectionToClient.Send(new SceneMessage { scenePath = subScene, sceneOperation = SceneOperation.UnloadAdditive });
         }
     }
 }

--- a/Assets/Mirror/Weaver/Processors/ReaderWriterProcessor.cs
+++ b/Assets/Mirror/Weaver/Processors/ReaderWriterProcessor.cs
@@ -185,7 +185,6 @@ namespace Mirror.Weaver
                 method.Is<NetworkClient>(nameof(NetworkClient.Send)) ||
                 method.Is<NetworkClient>(nameof(NetworkClient.SendAsync)) ||
                 method.Is<NetworkServer>(nameof(NetworkServer.SendToAll)) ||
-                method.Is<NetworkServer>(nameof(NetworkServer.SendToClientOfPlayer)) ||
                 method.Is<INetworkServer>(nameof(INetworkServer.SendToAll));
 
             bool generate = isMessage ||

--- a/Assets/Tests/Runtime/ClientServer/NetworkServerTests.cs
+++ b/Assets/Tests/Runtime/ClientServer/NetworkServerTests.cs
@@ -32,15 +32,6 @@ namespace Mirror.Tests.ClientServer
             Assert.That(server.LocalClientActive, Is.False);
         }
 
-        [Test]
-        public void SendToClientOfPlayerExceptionTest()
-        {
-            Assert.Throws<InvalidOperationException>(() =>
-            {
-                server.SendToClientOfPlayer(null, new ServerRpcMessage());
-            });
-        }
-
         [UnityTest]
         public IEnumerator ReadyMessageSetsClientReadyTest() => UniTask.ToCoroutine(async () =>
         {
@@ -73,7 +64,7 @@ namespace Mirror.Tests.ClientServer
 
             connectionToServer.RegisterHandler<WovenTestMessage>(msg => invoked = true) ;
 
-            server.SendToClientOfPlayer(serverIdentity, message);
+            serverIdentity.ConnectionToClient.Send(message);
 
             connectionToServer.ProcessMessagesAsync().Forget();
 


### PR DESCRIPTION
NetworkServer should not have to deal with NetworkIdentities or their
owners.

Remove SendToClientOfPlayer method,  it doesn't add value.

BREAKING CHANGE: SendToClientOfPlayer removed.  Use identity.ConnectionToClient.Send() instead