### PR TITLE
refactor: remove SendToObservers from NetworkServer

### DIFF
--- a/Assets/Mirror/Runtime/NetworkBehaviour.cs
+++ b/Assets/Mirror/Runtime/NetworkBehaviour.cs
@@ -312,7 +312,7 @@ namespace Mirror
             // The public facing parameter is excludeOwner in [ClientRpc]
             // so we negate it here to logically align with SendToReady.
             bool includeOwner = !excludeOwner;
-            Server.SendToObservers(NetIdentity, message, includeOwner, channelId);
+            NetIdentity.SendToObservers(message, includeOwner, channelId);
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -1261,9 +1261,9 @@ namespace Mirror
         /// this is used for ObjectDestroy messages.
         /// </summary>
         /// <typeparam name="T">The message type</typeparam>
-        /// <param name="identity"></param>
-        /// <param name="msg"></param>
-        /// <param name="channelId"></param>
+        /// <param name="msg"> the message to deliver to to clients</param>
+        /// <param name="includeOwner">Wether the owner should receive this message too</param>
+        /// <param name="channelId"> the transport channel that should be used to deliver the message</param>
         internal void SendToObservers<T>(T msg, bool includeOwner = true, int channelId = Channel.Reliable)
         {
             if (logger.LogEnabled()) logger.Log("Server.SendToObservers id:" + typeof(T));

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -321,41 +321,6 @@ namespace Mirror
 
         }
 
-        readonly List<INetworkConnection> connectionsExcludeSelf = new List<INetworkConnection>(100);
-
-        /// <summary>
-        /// this is like SendToReady - but it doesn't check the ready flag on the connection.
-        /// this is used for ObjectDestroy messages.
-        /// </summary>
-        /// <typeparam name="T">The message type</typeparam>
-        /// <param name="identity"></param>
-        /// <param name="msg"></param>
-        /// <param name="channelId"></param>
-        internal void SendToObservers<T>(NetworkIdentity identity, T msg, bool includeOwner = true, int channelId = Channel.Reliable)
-        {
-            if (logger.LogEnabled()) logger.Log("Server.SendToObservers id:" + typeof(T));
-
-            if (identity.observers.Count == 0)
-                return;
-
-            if (includeOwner)
-            {
-                NetworkConnection.Send(identity.observers, msg, channelId);
-            }
-            else
-            {
-                connectionsExcludeSelf.Clear();
-                foreach (INetworkConnection conn in identity.observers)
-                {
-                    if (identity.ConnectionToClient != conn)
-                    {
-                        connectionsExcludeSelf.Add(conn);
-                    }
-                }
-                NetworkConnection.Send(connectionsExcludeSelf, msg, channelId);
-            }
-        }
-
         /// <summary>
         /// Send a message to all connected clients.
         /// </summary>

--- a/Assets/Mirror/Runtime/ServerObjectManager.cs
+++ b/Assets/Mirror/Runtime/ServerObjectManager.cs
@@ -598,7 +598,7 @@ namespace Mirror
             Server.Spawned.Remove(identity.NetId);
             identity.ConnectionToClient?.RemoveOwnedObject(identity);
 
-            Server.SendToObservers(identity, new ObjectDestroyMessage { netId = identity.NetId });
+            identity.SendToObservers(new ObjectDestroyMessage { netId = identity.NetId });
 
             identity.ClearObservers();
             if (Server.LocalClientActive)


### PR DESCRIPTION
NetworkServer should be usable without NetworkIdentities or observer lists.
So the SendToObservers method is moved to NetworkIdentity