### PR TITLE
refactor: readers no longer depends on NetworkClient and NetworkServer

### DIFF
--- a/Assets/Mirror/Runtime/ClientObjectManager.cs
+++ b/Assets/Mirror/Runtime/ClientObjectManager.cs
@@ -12,7 +12,7 @@ namespace Mirror
 
     [AddComponentMenu("Network/ClientObjectManager")]
     [DisallowMultipleComponent]
-    public class ClientObjectManager : MonoBehaviour
+    public class ClientObjectManager : MonoBehaviour, IObjectLocator
     {
         static readonly ILogger logger = LogFactory.GetLogger(typeof(ClientObjectManager));
 
@@ -551,8 +551,7 @@ namespace Mirror
             {
                 using (PooledNetworkReader networkReader = NetworkReaderPool.GetReader(msg.payload))
                 {
-                    // TODO assign here the COM instead of the client
-                    networkReader.ObjectLocator = Client;
+                    networkReader.ObjectLocator = this;
                     identity.HandleRemoteCall(skeleton, msg.componentIndex, networkReader);
                 }
             }
@@ -589,6 +588,15 @@ namespace Mirror
 
         private readonly Dictionary<int, Action<NetworkReader>> callbacks = new Dictionary<int, Action<NetworkReader>>();
         private int replyId;
+
+        public NetworkIdentity this[uint netId]
+        {
+            get
+            {
+                Client.Spawned.TryGetValue(netId, out NetworkIdentity identity);
+                return identity;
+            }
+        }
 
         /// <summary>
         /// Creates a task that waits for a reply from the server

--- a/Assets/Mirror/Runtime/ClientObjectManager.cs
+++ b/Assets/Mirror/Runtime/ClientObjectManager.cs
@@ -550,7 +550,11 @@ namespace Mirror
             if (Client.Spawned.TryGetValue(msg.netId, out NetworkIdentity identity) && identity != null)
             {
                 using (PooledNetworkReader networkReader = NetworkReaderPool.GetReader(msg.payload))
+                {
+                    // TODO assign here the COM instead of the client
+                    networkReader.ObjectLocator = Client;
                     identity.HandleRemoteCall(skeleton, msg.componentIndex, networkReader);
+                }
             }
         }
 

--- a/Assets/Mirror/Runtime/GameObjectSyncvar.cs
+++ b/Assets/Mirror/Runtime/GameObjectSyncvar.cs
@@ -13,7 +13,7 @@ namespace Mirror
         /// The network client that spawned the parent object
         /// used to lookup the identity if it exists
         /// </summary>
-        internal NetworkClient client;
+        internal IObjectLocator objectLocator;
         internal uint netId;
 
         internal GameObject gameObject;
@@ -27,9 +27,9 @@ namespace Mirror
                 if (gameObject != null)
                     return gameObject;
 
-                if (client != null)
+                if (objectLocator != null)
                 {
-                    client.Spawned.TryGetValue(netId, out NetworkIdentity result);
+                    NetworkIdentity result = objectLocator[netId];
                     if (result != null)
                         return result.gameObject;
                 }
@@ -59,16 +59,12 @@ namespace Mirror
             uint netId = reader.ReadPackedUInt32();
 
             NetworkIdentity identity = null;
-            if (!(reader.Client is null))
-                reader.Client.Spawned.TryGetValue(netId, out identity);
-
-            if (!(reader.Server is null))
-                reader.Server.Spawned.TryGetValue(netId, out identity);
-
+            if (!(reader.ObjectLocator is null))
+                identity = reader.ObjectLocator[netId];
 
             return new GameObjectSyncvar
             {
-                client = reader.Client,
+                objectLocator = reader.ObjectLocator,
                 netId = netId,
                 gameObject = identity != null ? identity.gameObject : null
             };

--- a/Assets/Mirror/Runtime/NetworkBehaviorSyncvar.cs
+++ b/Assets/Mirror/Runtime/NetworkBehaviorSyncvar.cs
@@ -11,7 +11,7 @@
         /// The network client that spawned the parent object
         /// used to lookup the identity if it exists
         /// </summary>
-        internal NetworkClient client;
+        internal IObjectLocator objectLocator;
         internal uint netId;
         internal int componentId;
 
@@ -27,9 +27,9 @@
                 if (component != null)
                     return component;
 
-                if (client != null)
+                if (objectLocator != null)
                 {
-                    client.Spawned.TryGetValue(netId, out NetworkIdentity identity);
+                    NetworkIdentity identity = objectLocator[netId];
                     if (identity != null)
                         return identity.NetworkBehaviours[componentId];
                 }
@@ -64,15 +64,12 @@
             int componentId = reader.ReadPackedInt32();
 
             NetworkIdentity identity = null;
-            if (!(reader.Client is null))
-                reader.Client.Spawned.TryGetValue(netId, out identity);
-
-            if (!(reader.Server is null))
-                reader.Server.Spawned.TryGetValue(netId, out identity);
+            if (!(reader.ObjectLocator is null))
+                identity = reader.ObjectLocator[netId];
 
             return new NetworkBehaviorSyncvar
             {
-                client = reader.Client,
+                objectLocator = reader.ObjectLocator,
                 netId = netId,
                 componentId = componentId,
                 component = identity != null ? identity.NetworkBehaviours[componentId] : null

--- a/Assets/Mirror/Runtime/NetworkClient.cs
+++ b/Assets/Mirror/Runtime/NetworkClient.cs
@@ -16,6 +16,8 @@ namespace Mirror
         Connected,
     }
 
+    // TODO remove the IObjectLocator and move to COM
+
     /// <summary>
     /// This is a network client class used by the networking system. It contains a NetworkConnection that is used to connect to a network server.
     /// <para>The <see cref="NetworkClient">NetworkClient</see> handle connection state, messages handlers, and connection configuration. There can be many <see cref="NetworkClient">NetworkClient</see> instances in a process at a time, but only one that is connected to a game server (<see cref="NetworkServer">NetworkServer</see>) that uses spawned objects.</para>
@@ -23,7 +25,7 @@ namespace Mirror
     /// </summary>
     [AddComponentMenu("Network/NetworkClient")]
     [DisallowMultipleComponent]
-    public class NetworkClient : MonoBehaviour, INetworkClient
+    public class NetworkClient : MonoBehaviour, INetworkClient, IObjectLocator
     {
         static readonly ILogger logger = LogFactory.GetLogger(typeof(NetworkClient));
 
@@ -99,6 +101,17 @@ namespace Mirror
         /// NetworkClient can connect to local server in host mode too
         /// </summary>
         public bool IsLocalClient => hostServer != null;
+
+        // TODO move this to ClientObjectManager
+        public NetworkIdentity this[uint netId]
+        {
+            get
+            {
+                Spawned.TryGetValue(netId, out NetworkIdentity identity);
+                return identity;
+            }
+        }
+
 
         /// <summary>
         /// Connect client to a NetworkServer instance.

--- a/Assets/Mirror/Runtime/NetworkClient.cs
+++ b/Assets/Mirror/Runtime/NetworkClient.cs
@@ -16,8 +16,6 @@ namespace Mirror
         Connected,
     }
 
-    // TODO remove the IObjectLocator and move to COM
-
     /// <summary>
     /// This is a network client class used by the networking system. It contains a NetworkConnection that is used to connect to a network server.
     /// <para>The <see cref="NetworkClient">NetworkClient</see> handle connection state, messages handlers, and connection configuration. There can be many <see cref="NetworkClient">NetworkClient</see> instances in a process at a time, but only one that is connected to a game server (<see cref="NetworkServer">NetworkServer</see>) that uses spawned objects.</para>
@@ -25,7 +23,7 @@ namespace Mirror
     /// </summary>
     [AddComponentMenu("Network/NetworkClient")]
     [DisallowMultipleComponent]
-    public class NetworkClient : MonoBehaviour, INetworkClient, IObjectLocator
+    public class NetworkClient : MonoBehaviour, INetworkClient
     {
         static readonly ILogger logger = LogFactory.GetLogger(typeof(NetworkClient));
 
@@ -101,17 +99,6 @@ namespace Mirror
         /// NetworkClient can connect to local server in host mode too
         /// </summary>
         public bool IsLocalClient => hostServer != null;
-
-        // TODO move this to ClientObjectManager
-        public NetworkIdentity this[uint netId]
-        {
-            get
-            {
-                Spawned.TryGetValue(netId, out NetworkIdentity identity);
-                return identity;
-            }
-        }
-
 
         /// <summary>
         /// Connect client to a NetworkServer instance.

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -871,7 +871,7 @@ namespace Mirror
         internal void OnDeserializeAllSafely(NetworkReader reader, bool initialState)
         {
             // needed so that we can deserialize gameobjects and NI
-            reader.ObjectLocator = Client;
+            reader.ObjectLocator = ClientObjectManager;
             // deserialize all components that were received
             NetworkBehaviour[] components = NetworkBehaviours;
             while (reader.Position < reader.Length)

--- a/Assets/Mirror/Runtime/NetworkIdentity.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentity.cs
@@ -871,7 +871,7 @@ namespace Mirror
         internal void OnDeserializeAllSafely(NetworkReader reader, bool initialState)
         {
             // needed so that we can deserialize gameobjects and NI
-            reader.Client = Client;
+            reader.ObjectLocator = Client;
             // deserialize all components that were received
             NetworkBehaviour[] components = NetworkBehaviours;
             while (reader.Position < reader.Length)
@@ -897,11 +897,6 @@ namespace Mirror
         /// <param name="senderConnection"></param>
         internal void HandleRemoteCall(Skeleton skeleton, int componentIndex, NetworkReader reader, INetworkConnection senderConnection = null, int replyId = 0)
         {
-            // Set the client and server for this remote call.
-            // this can be used by custom deserializers to lookup objects
-            reader.Client = Client;
-            reader.Server = Server;
-
             // find the right component to invoke the function on
             if (componentIndex >= 0 && componentIndex < NetworkBehaviours.Length)
             {

--- a/Assets/Mirror/Runtime/NetworkIdentitySyncvar.cs
+++ b/Assets/Mirror/Runtime/NetworkIdentitySyncvar.cs
@@ -11,7 +11,7 @@
         /// The network client that spawned the parent object
         /// used to lookup the identity if it exists
         /// </summary>
-        internal NetworkClient client;
+        internal IObjectLocator objectLocator;
         internal uint netId;
 
         internal NetworkIdentity identity;
@@ -25,10 +25,9 @@
                 if (identity != null)
                     return identity;
 
-                if (client != null)
+                if (objectLocator != null)
                 {
-                    client.Spawned.TryGetValue(netId, out NetworkIdentity result);
-                    return result;
+                    return objectLocator[netId];
                 }
 
                 return null;
@@ -56,15 +55,12 @@
             uint netId = reader.ReadPackedUInt32();
 
             NetworkIdentity identity = null;
-            if (!(reader.Client is null))
-                reader.Client.Spawned.TryGetValue(netId, out identity);
-
-            if (!(reader.Server is null))
-                reader.Server.Spawned.TryGetValue(netId, out identity);
+            if (!(reader.ObjectLocator is null))
+                identity = reader.ObjectLocator[netId];
 
             return new NetworkIdentitySyncvar
             {
-                client = reader.Client,
+                objectLocator = reader.ObjectLocator,
                 netId = netId,
                 identity = identity
             };

--- a/Assets/Mirror/Runtime/NetworkReader.cs
+++ b/Assets/Mirror/Runtime/NetworkReader.cs
@@ -26,8 +26,17 @@ namespace Mirror
         public static Func<NetworkReader, T> Read { internal get; set; }
     }
 
+    /// <summary>
+    /// An object that implements this interface can find objects by their net id
+    /// This is used by readers when trying to deserialize gameobjects
+    /// </summary>
     public interface IObjectLocator
     {
+        /// <summary>
+        /// Finds a network identity by id
+        /// </summary>
+        /// <param name="netId">the id of the object to find</param>
+        /// <returns>The NetworkIdentity matching the netid or null if none is found</returns>
         NetworkIdentity this[uint netId] { get; }
     }
 

--- a/Assets/Mirror/Runtime/NetworkReaderPool.cs
+++ b/Assets/Mirror/Runtime/NetworkReaderPool.cs
@@ -79,8 +79,7 @@ namespace Mirror
 
             // reset buffer
             SetBuffer(reader, bytes);
-            reader.Client = null;
-            reader.Server = null;
+            reader.ObjectLocator = null;
             return reader;
         }
 
@@ -101,8 +100,7 @@ namespace Mirror
 
             // reset buffer
             SetBuffer(reader, segment);
-            reader.Client = null;
-            reader.Server = null;
+            reader.ObjectLocator = null;
             return reader;
         }
 

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -7,6 +7,7 @@ using UnityEngine.Events;
 
 namespace Mirror
 {
+    // TODO remove IObjectLocator and move to SOM
 
     /// <summary>
     /// The NetworkServer.
@@ -16,7 +17,7 @@ namespace Mirror
     /// </remarks>
     [AddComponentMenu("Network/NetworkServer")]
     [DisallowMultipleComponent]
-    public class NetworkServer : MonoBehaviour, INetworkServer
+    public class NetworkServer : MonoBehaviour, INetworkServer, IObjectLocator
     {
         static readonly ILogger logger = LogFactory.GetLogger(typeof(NetworkServer));
 
@@ -108,6 +109,16 @@ namespace Mirror
         /// <para>This will be true after NetworkServer.Listen() has been called.</para>
         /// </summary>
         public bool Active { get; private set; }
+
+        // TODO move to SOM
+        public NetworkIdentity this[uint netId]
+        {
+            get
+            {
+                Spawned.TryGetValue(netId, out NetworkIdentity identity) ;
+                return identity;
+            }
+        }
 
         public readonly Dictionary<uint, NetworkIdentity> Spawned = new Dictionary<uint, NetworkIdentity>();
 

--- a/Assets/Mirror/Runtime/NetworkServer.cs
+++ b/Assets/Mirror/Runtime/NetworkServer.cs
@@ -7,8 +7,6 @@ using UnityEngine.Events;
 
 namespace Mirror
 {
-    // TODO remove IObjectLocator and move to SOM
-
     /// <summary>
     /// The NetworkServer.
     /// </summary>
@@ -17,7 +15,7 @@ namespace Mirror
     /// </remarks>
     [AddComponentMenu("Network/NetworkServer")]
     [DisallowMultipleComponent]
-    public class NetworkServer : MonoBehaviour, INetworkServer, IObjectLocator
+    public class NetworkServer : MonoBehaviour, INetworkServer
     {
         static readonly ILogger logger = LogFactory.GetLogger(typeof(NetworkServer));
 
@@ -109,16 +107,6 @@ namespace Mirror
         /// <para>This will be true after NetworkServer.Listen() has been called.</para>
         /// </summary>
         public bool Active { get; private set; }
-
-        // TODO move to SOM
-        public NetworkIdentity this[uint netId]
-        {
-            get
-            {
-                Spawned.TryGetValue(netId, out NetworkIdentity identity) ;
-                return identity;
-            }
-        }
 
         public readonly Dictionary<uint, NetworkIdentity> Spawned = new Dictionary<uint, NetworkIdentity>();
 

--- a/Assets/Mirror/Runtime/ServerObjectManager.cs
+++ b/Assets/Mirror/Runtime/ServerObjectManager.cs
@@ -416,7 +416,11 @@ namespace Mirror
             if (logger.LogEnabled()) logger.Log("OnServerRpcMessage for netId=" + msg.netId + " conn=" + conn);
 
             using (PooledNetworkReader networkReader = NetworkReaderPool.GetReader(msg.payload))
+            {
+                // TODO assign the SOM here instead of the Server
+                networkReader.ObjectLocator = Server;
                 identity.HandleRemoteCall(skeleton, msg.componentIndex, networkReader, conn, msg.replyId);
+            }
         }
 
         internal void SpawnObject(GameObject obj, INetworkConnection ownerConnection)

--- a/Assets/Mirror/Runtime/ServerObjectManager.cs
+++ b/Assets/Mirror/Runtime/ServerObjectManager.cs
@@ -19,7 +19,7 @@ namespace Mirror
     /// </remarks>
     [AddComponentMenu("Network/ServerObjectManager")]
     [DisallowMultipleComponent]
-    public class ServerObjectManager : MonoBehaviour, IServerObjectManager
+    public class ServerObjectManager : MonoBehaviour, IServerObjectManager, IObjectLocator
     {
         static readonly ILogger logger = LogFactory.GetLogger(typeof(ServerObjectManager));
 
@@ -48,6 +48,15 @@ namespace Mirror
 
         public readonly HashSet<NetworkIdentity> DirtyObjects = new HashSet<NetworkIdentity>();
         private readonly List<NetworkIdentity> DirtyObjectsTmp = new List<NetworkIdentity>();
+
+        public NetworkIdentity this[uint netId]
+        {
+            get
+            {
+                Server.Spawned.TryGetValue(netId, out NetworkIdentity identity);
+                return identity;
+            }
+        }
 
         public void Start()
         {
@@ -417,8 +426,7 @@ namespace Mirror
 
             using (PooledNetworkReader networkReader = NetworkReaderPool.GetReader(msg.payload))
             {
-                // TODO assign the SOM here instead of the Server
-                networkReader.ObjectLocator = Server;
+                networkReader.ObjectLocator = this;
                 identity.HandleRemoteCall(skeleton, msg.componentIndex, networkReader, conn, msg.replyId);
             }
         }

--- a/Assets/Tests/Runtime/ClientServer/GameObjectSyncvarTest.cs
+++ b/Assets/Tests/Runtime/ClientServer/GameObjectSyncvarTest.cs
@@ -44,7 +44,7 @@ namespace Mirror.Tests.ClientServer
 
             var goSyncvar = new GameObjectSyncvar
             {
-                objectLocator = client,
+                objectLocator = clientObjectManager,
                 netId = serverIdentity.NetId,
                 gameObject = null,
             };

--- a/Assets/Tests/Runtime/ClientServer/GameObjectSyncvarTest.cs
+++ b/Assets/Tests/Runtime/ClientServer/GameObjectSyncvarTest.cs
@@ -44,7 +44,7 @@ namespace Mirror.Tests.ClientServer
 
             var goSyncvar = new GameObjectSyncvar
             {
-                client = client,
+                objectLocator = client,
                 netId = serverIdentity.NetId,
                 gameObject = null,
             };

--- a/Assets/Tests/Runtime/ClientServer/NetworkBehaviorSyncvarTest.cs
+++ b/Assets/Tests/Runtime/ClientServer/NetworkBehaviorSyncvarTest.cs
@@ -43,7 +43,7 @@ namespace Mirror.Tests.ClientServer
 
             var goSyncvar = new NetworkBehaviorSyncvar
             {
-                client = client,
+                objectLocator = client,
                 netId = serverIdentity.NetId,
                 component = null,
             };

--- a/Assets/Tests/Runtime/ClientServer/NetworkBehaviorSyncvarTest.cs
+++ b/Assets/Tests/Runtime/ClientServer/NetworkBehaviorSyncvarTest.cs
@@ -43,7 +43,7 @@ namespace Mirror.Tests.ClientServer
 
             var goSyncvar = new NetworkBehaviorSyncvar
             {
-                objectLocator = client,
+                objectLocator = clientObjectManager,
                 netId = serverIdentity.NetId,
                 component = null,
             };

--- a/Assets/Tests/Runtime/ClientServer/NetworkIdentitySyncvarTest.cs
+++ b/Assets/Tests/Runtime/ClientServer/NetworkIdentitySyncvarTest.cs
@@ -48,7 +48,7 @@ namespace Mirror.Tests.ClientServer
 
             var networkIdentitySyncvar = new NetworkIdentitySyncvar
             {
-                objectLocator = client,
+                objectLocator = clientObjectManager,
                 netId = serverIdentity.NetId,
                 identity = null,
             };

--- a/Assets/Tests/Runtime/ClientServer/NetworkIdentitySyncvarTest.cs
+++ b/Assets/Tests/Runtime/ClientServer/NetworkIdentitySyncvarTest.cs
@@ -48,7 +48,7 @@ namespace Mirror.Tests.ClientServer
 
             var networkIdentitySyncvar = new NetworkIdentitySyncvar
             {
-                client = client,
+                objectLocator = client,
                 netId = serverIdentity.NetId,
                 identity = null,
             };


### PR DESCRIPTION
NetworkReader no longer has a hardcoded dependency on NetworkClient and NetworkServer.
rather the NetworkReader has an IObjectLocator, which can be any class
that can find objects by netid.

BREAKING CHANGE: NetworkReader no longer have .Client and .Server, it has a .ObjectLocator instead